### PR TITLE
Add Gemfile to enable `bundle install` for setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 pkg/
+/Gemfile.lock

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,2 @@
+source :rubygems
+gemspec


### PR DESCRIPTION
- the Gemfile simply redirects bundler to the information in the gemspec
- to bootstrap, you just run: git clone {repo}, bundle install, rake
