### PR TITLE
Fix issue #36, preserve endlines in pre blocks

### DIFF
--- a/lib/asciidoctor/render_templates.rb
+++ b/lib/asciidoctor/render_templates.rb
@@ -1,4 +1,7 @@
 class BaseTemplate
+  BLANK_LINES_PATTERN = /^\s*\n/
+  LINE_FEED_ENTITY = "&#10;" # or &#x0A;
+
   def initialize
   end
 
@@ -14,7 +17,7 @@ class BaseTemplate
   # We're ignoring locals for now. Shut up.
   def render(obj = Object.new, locals = {})
     output = template.result(obj.instance_eval {binding})
-    (self.is_a?(DocumentTemplate) || self.is_a?(EmbeddedTemplate)) ? output.gsub(/^\s*\n/, '') : output
+    (self.is_a?(DocumentTemplate) || self.is_a?(EmbeddedTemplate)) ? output.gsub(BLANK_LINES_PATTERN, '').gsub(LINE_FEED_ENTITY, "\n") : output
   end
 
   def template
@@ -175,7 +178,7 @@ class BlockListingTemplate < BaseTemplate
   <div class='title'><%= title %></div>
   <% end %>
   <div class='content monospaced'>
-    <pre class='highlight#{styleclass(:language)}'><code><%= content %></code></pre>
+    <pre class='highlight#{styleclass(:language)}'><code><%= content.gsub("\n", LINE_FEED_ENTITY) %></code></pre>
   </div>
 </div>
     EOF
@@ -190,7 +193,7 @@ class BlockLiteralTemplate < BaseTemplate
   <div class='title'><%= title %></div>
   <% end %>
   <div class='content monospaced'>
-    <pre><%= content %></pre>
+    <pre><%= content.gsub("\n", LINE_FEED_ENTITY) %></pre>
   </div>
 </div>
     EOF
@@ -313,7 +316,7 @@ class BlockVerseTemplate < BaseTemplate
   <% unless title.nil? %>
   <div class='title'><%= title %></div>
   <% end %>
-  <pre class='content'><%= content %></pre>
+  <pre class='content'><%= content.gsub("\n", LINE_FEED_ENTITY) %></pre>
   <div class='attribution'>
     <% if attr? :citetitle %>
     <em><%= attr :citetitle %></em>

--- a/test/blocks_test.rb
+++ b/test/blocks_test.rb
@@ -55,6 +55,66 @@ How crazy is that?
     end
   end
 
+  context "Preformatted Blocks" do
+    test "should preserve endlines in literal block" do
+      input = <<-EOS
+....
+line one
+
+line two
+
+line three
+....
+EOS
+      output = render_string(input)
+      assert_xpath '//pre', output, 1
+      assert_xpath '//pre/text()', output, 1
+      text = node_from_string(output, '//pre/text()').content
+      lines = text.lines.entries 
+      assert_equal 5, lines.size
+      assert_equal ([] << "line one\n" << "\n" << "line two\n" << "\n" << "line three"), lines
+    end
+
+    test "should preserve endlines in listing block" do
+      input = <<-EOS
+----
+line one
+
+line two
+
+line three
+----
+EOS
+      output = render_string(input)
+      assert_xpath '//pre/code', output, 1
+      assert_xpath '//pre/code/text()', output, 1
+      text = node_from_string(output, '//pre/code/text()').content
+      lines = text.lines.entries 
+      assert_equal 5, lines.size
+      assert_equal ([] << "line one\n" << "\n" << "line two\n" << "\n" << "line three"), lines
+    end
+
+    test "should preserve endlines in verse block" do
+      input = <<-EOS
+[verse]
+____
+line one
+
+line two
+
+line three
+____
+EOS
+      output = render_string(input)
+      assert_xpath '//*[@class="verseblock"]/pre', output, 1
+      assert_xpath '//*[@class="verseblock"]/pre/text()', output, 1
+      text = node_from_string(output, '//*[@class="verseblock"]/pre/text()').content
+      lines = text.lines.entries 
+      assert_equal 5, lines.size
+      assert_equal ([] << "line one\n" << "\n" << "line two\n" << "\n" << "line three"), lines
+    end
+  end
+
   context "Open Blocks" do
     test "can render open block" do
       input = <<-EOS

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -53,6 +53,15 @@ class Test::Unit::TestCase
     end
   end
 
+  def node_from_string(html, xpath = nil)
+    doc = (html =~ /\s*<!DOCTYPE/) ? Nokogiri::HTML::Document.parse(html) : Nokogiri::HTML::DocumentFragment.parse(html)
+    if xpath.nil?
+      doc
+    else
+      doc.xpath("#{xpath.sub('/', './')}").first
+    end
+  end
+
   def assert_xpath(xpath, html, count = nil)
     doc = (html =~ /\s*<!DOCTYPE/) ? Nokogiri::HTML::Document.parse(html) : Nokogiri::HTML::DocumentFragment.parse(html)
     results = doc.xpath("#{xpath.sub('/', './')}")


### PR DESCRIPTION
This fix is an important one. By removing blank lines in the rendered output, Asciidoctor was inadvertently taking away semantic blank lines in literal blocks.

Fortunately, this problem has a nice solution. Simply replace blank lines in preformatted blocks with the line feed entity, then (optionally) restore the visual endlines (instead of leaving the entity).

I still haven't pinned down exactly what our policy will be on handling blank lines and how the user can control the behavior (which I'll raise in a separate issue), but for sure this fix is necessary to make Asciidoctor work properly now.
