### PR TITLE
Source highlighting (two forms)

### DIFF
--- a/asciidoctor.gemspec
+++ b/asciidoctor.gemspec
@@ -46,6 +46,7 @@ Gem::Specification.new do |s|
 
   ## List your development dependencies here. Development dependencies are
   ## those that are only needed during development
+  s.add_development_dependency('coderay')
   s.add_development_dependency('erubis')
   s.add_development_dependency('htmlentities')
   s.add_development_dependency('mocha')

--- a/lib/asciidoctor/document.rb
+++ b/lib/asciidoctor/document.rb
@@ -83,6 +83,8 @@ class Asciidoctor::Document < Asciidoctor::AbstractBlock
       # should we dup here?
       options[:attributes] = @parent_document.attributes
       @renderer = @parent_document.renderer
+    else
+      @parent_document = nil
     end
 
     @header = nil
@@ -114,6 +116,12 @@ class Asciidoctor::Document < Asciidoctor::AbstractBlock
     else
       attribute_overrides['docdir'] ||= Dir.pwd
       @base_dir = attribute_overrides['docdir']
+    end
+
+    # restrict document from setting source-highlighter in SECURE safe mode
+    # it can only be set via the constructor
+    if @safe >= SafeMode::SECURE
+      attribute_overrides['source-highlighter'] ||= nil
     end
     
     attribute_overrides.each {|key, val|

--- a/test/blocks_test.rb
+++ b/test/blocks_test.rb
@@ -505,4 +505,64 @@ image::asciidoctor.png[Asciidoctor]
 
   end
 
+  context 'Source code' do
+    test 'should highlight source if source-highlighter attribute is coderay' do
+      input = <<-EOS
+:source-highlighter: coderay
+
+[source, ruby]
+----
+require 'coderay'
+
+html = CodeRay.scan("puts 'Hello, world!'", :ruby).div(:line_numbers => :table)
+----
+      EOS
+      output = render_string input, :safe => Asciidoctor::SafeMode::SAFE
+      assert_xpath '//pre[@class="highlight CodeRay"]/code[@class="ruby"]//span[@class = "constant"][text() = "CodeRay"]', output, 1
+      assert_match(/\.CodeRay \{/, output)
+    end
+
+    test 'should highlight source inline if source-highlighter attribute is coderay and coderay-css is style' do
+      input = <<-EOS
+:source-highlighter: coderay
+:coderay-css: style
+
+[source, ruby]
+----
+require 'coderay'
+
+html = CodeRay.scan("puts 'Hello, world!'", :ruby).div(:line_numbers => :table)
+----
+      EOS
+      output = render_string input, :safe => Asciidoctor::SafeMode::SAFE
+      assert_xpath '//pre[@class="highlight CodeRay"]/code[@class="ruby"]//span[@style = "color:#036;font-weight:bold"][text() = "CodeRay"]', output, 1
+      assert_no_match(/\.CodeRay \{/, output)
+    end
+
+    test 'should include remote highlight.js assets if source-highlighter attribute is highlightjs' do
+      input = <<-EOS
+:source-highlighter: highlightjs
+
+[source, javascript]
+----
+<link rel="stylesheet" href="styles/default.css">
+<script src="highlight.pack.js"></script>
+<script>hljs.initHighlightingOnLoad();</script>
+----
+      EOS
+      output = render_string input, :safe => Asciidoctor::SafeMode::SAFE
+      assert_match(/<link .*highlight\.js/, output)
+      assert_match(/<script .*highlight\.js/, output)
+      assert_match(/hljs.initHighlightingOnLoad/, output)
+    end
+
+    test 'document cannot turn on source highlighting if safe mode is at least SECURE' do
+      input = <<-EOS
+:source-highlighter: coderay
+      EOS
+      doc = document_from_string input
+      assert doc.attributes['source-highlighter'].nil?
+    end
+  end
+
 end

--- a/test/paragraphs_test.rb
+++ b/test/paragraphs_test.rb
@@ -39,11 +39,11 @@ You're good to go!
     end
 
     test "listing paragraph" do
-      assert_xpath "//pre[@class='highlight']", render_string("[source]\n----\nblah blah blah\n----")
+      assert_xpath "//pre[@class='highlight']/code", render_string("[source]\n----\nblah blah blah\n----")
     end
 
     test "source code paragraph" do
-      assert_xpath "//pre[@class='highlight perl']", render_string("[source, perl]\ndie 'zomg perl sucks';")
+      assert_xpath "//pre[@class='highlight']/code[@class='perl']", render_string("[source, perl]\ndie 'zomg perl sucks';")
     end
   end
 


### PR DESCRIPTION
- Embedded via CodeRay
- Client-side via highlight.js

Both are optional, activated by the source-highlighter attribute
- use coderay for embedded source highlighting
- load coderay lazily
- add coderay as development dependency (for tests)
- use highlight.js for javascript source highlighting
- tests
- set asciidoctor attribute for creating asciidoctor-specific blocks

Right now highlight.js is being loaded by default from a CDN. By setting the highlightjsdir attribute, the user can change this to a relative reference (all paths handled by browser).

There is definitely just a first step. There's certainly more that can be done with this feature. Let's see what the users have to say.
