### PR TITLE
(Re)implement callouts and callout lists

### DIFF
--- a/asciidoctor.gemspec
+++ b/asciidoctor.gemspec
@@ -71,6 +71,7 @@ Gem::Specification.new do |s|
     lib/asciidoctor/backends/base_template.rb
     lib/asciidoctor/backends/docbook45.rb
     lib/asciidoctor/backends/html5.rb
+    lib/asciidoctor/callouts.rb
     lib/asciidoctor/block.rb
     lib/asciidoctor/debug.rb
     lib/asciidoctor/document.rb

--- a/lib/asciidoctor.rb
+++ b/lib/asciidoctor.rb
@@ -124,10 +124,12 @@ module Asciidoctor
     # callout reference inside literal text
     # <1>
     # special characters will already be replaced, hence their use in the regex
-    :calloutref       => /&lt;(\d+)&gt;/,
+    :callout_render   => /\\?&lt;(\d+)&gt;/,
+    # ...but not while scanning
+    :callout_scan     => /\\?<(\d+)>/,
 
     # <1> Foo
-    :colist           => /^(\<\d+\>)\s*(.*)/,
+    :colist           => /^<?(\d+)> (.*)/,
 
     # ////
     # comment block
@@ -191,7 +193,7 @@ module Asciidoctor
 
     # inline link and some inline link macro
     # FIXME revisit!
-    :link_inline      => %r{(^|link:|\s|>)(\\?https?://[^\[ ]*[^\. \[])(?:\[((?:\\\]|[^\]])*?)\])?},
+    :link_inline      => %r{(^|link:|\s|>|&lt;)(\\?https?://[^\[ ]*[^\. \[])(?:\[((?:\\\]|[^\]])*?)\])?},
 
     # inline link macro
     # link:path[label]
@@ -408,6 +410,7 @@ module Asciidoctor
   require 'asciidoctor/attribute_list'
   require 'asciidoctor/backends/base_template'
   require 'asciidoctor/block'
+  require 'asciidoctor/callouts'
   require 'asciidoctor/debug'
   require 'asciidoctor/document'
   require 'asciidoctor/errors'

--- a/lib/asciidoctor/backends/docbook45.rb
+++ b/lib/asciidoctor/backends/docbook45.rb
@@ -189,6 +189,25 @@ class BlockOlistTemplate < ::Asciidoctor::BaseTemplate
   end
 end
 
+class BlockColistTemplate < ::Asciidoctor::BaseTemplate
+  def template
+    @template ||= ERB.new <<-EOF
+<%#encoding:UTF-8%>
+<calloutlist#{id}#{role}#{xreflabel}>
+  #{title}
+  <% content.each do |li| %>
+    <callout arearefs="<%= li.attr :coids %>">
+      <para><%= li.text %></para>
+      <% if li.has_section_body? %>
+<%= li.content %>
+      <% end %>
+    </callout>
+  <% end %>
+</calloutlist>
+    EOF
+  end
+end
+
 class BlockDlistTemplate < ::Asciidoctor::BaseTemplate
   def template
     @template ||= ERB.new <<-EOF
@@ -229,7 +248,7 @@ class BlockListingTemplate < ::Asciidoctor::BaseTemplate
     @template ||= ERB.new <<-EOF
 <%#encoding:UTF-8%>
 <% if title.nil? %>
-<programlisting#{id}#{role}#{xreflabel} language="<%= attr :language %>" linenumbering="<%= (attr? :linenums) ? 'numbered' : 'unnumbered' %>"><%= content.gsub("\n", LINE_FEED_ENTITY) %></programlisting>
+<programlisting#{id}#{role}#{xreflabel}#{attribute('language', :language)} linenumbering="<%= (attr? :linenums) ? 'numbered' : 'unnumbered' %>"><%= content.gsub("\n", LINE_FEED_ENTITY) %></programlisting>
 <% else %>
 <formalpara#{id}#{role}#{xreflabel}>
   <title><%= title %></title>

--- a/lib/asciidoctor/backends/html5.rb
+++ b/lib/asciidoctor/backends/html5.rb
@@ -344,6 +344,26 @@ class BlockOlistTemplate < ::Asciidoctor::BaseTemplate
   end
 end
 
+class BlockColistTemplate < ::Asciidoctor::BaseTemplate
+  def template
+    @template ||= ERB.new <<-EOS
+<%#encoding:UTF-8%>
+<div#{id} class="colist <%= attr :style %>#{style_class}">
+  <% unless title.nil? %>
+  <div class="title"><%= title %></div>
+  <% end %>
+  <ol>
+  <% content.each do |li| %>
+    <li>
+      <p><%= li.text %></p>
+    </li>
+  <% end %>
+  </ol>
+</div>
+    EOS
+  end
+end
+
 class BlockImageTemplate < ::Asciidoctor::BaseTemplate
   def template
     @template ||= ERB.new <<-EOS

--- a/lib/asciidoctor/block.rb
+++ b/lib/asciidoctor/block.rb
@@ -39,7 +39,9 @@ class Asciidoctor::Block < Asciidoctor::AbstractBlock
     Asciidoctor.debug "Now attempting to render for #{context} my own bad #{self}"
     Asciidoctor.debug "Parent is #{@parent}"
     Asciidoctor.debug "Renderer is #{renderer}"
-    renderer.render("block_#{context}", self)
+    out = renderer.render("block_#{context}", self)
+    @document.callouts.next_list if context == :colist
+    out
   end
 
   def splain(parent_level = 0)
@@ -102,13 +104,9 @@ class Asciidoctor::Block < Asciidoctor::AbstractBlock
     case @context
     when :preamble, :open, :example, :sidebar
       blocks.map{|block| block.render}.join
-    when :colist
-      @buffer.map do |li|
-        htmlify(li.text) + li.blocks.map{|block| block.render}.join
-      end
     # lists get iterated in the template (for now)
     # list items recurse into this block when their text and content methods are called
-    when :ulist, :olist, :dlist
+    when :ulist, :olist, :dlist, :colist
       @buffer
     when :listing, :literal
       apply_literal_subs(@buffer)

--- a/lib/asciidoctor/callouts.rb
+++ b/lib/asciidoctor/callouts.rb
@@ -1,0 +1,109 @@
+# Public: Maintains a catalog of callouts and their associations.
+class Asciidoctor::Callouts
+  def initialize
+    @lists = []
+    @list_index = 0
+    next_list
+  end
+
+  # Public: Register a new callout for the given list item ordinal.
+  #
+  # Generates a unique id for this callout based on the index of the next callout
+  # list in the document and the index of this callout since the end of the last
+  # callout list.
+  #
+  # li_ordinal - the Integer ordinal (1-based) of the list item to which this
+  #              callout is to be associated
+  #
+  # Examples
+  #
+  #  callouts = Asciidoctor::Callouts.new
+  #  callouts.register(1)
+  #  # => "CO1-1"
+  #  callouts.next_list
+  #  callouts.register(2)
+  #  # => "CO2-1"
+  #
+  # Returns The unique String id of this callout
+  def register(li_ordinal)
+    current_list << {:ordinal => li_ordinal.to_i, :id => (id = generate_next_callout_id)}
+    @co_index += 1
+    id
+  end
+
+  # Public: Get the next callout index in the document
+  #
+  # Reads the next callout index in the document and advances the pointer.
+  # This method is used during rendering to retrieve the unique id of the
+  # callout that was generated during lexing.
+  #
+  # Returns The unique String id of the next callout in the document
+  def read_next_id
+    id = nil
+    list = current_list
+    if @co_index <= list.size
+      id = list[@co_index - 1][:id]
+    end
+    @co_index += 1
+    id
+  end
+
+  # Public: Get a space-separated list of callout ids for the specified list item
+  #
+  # li_ordinal - the Integer ordinal (1-based) of the list item for which to
+  #              retrieve the callouts
+  #
+  # Returns A space-separated String of callout ids associated with the specified list item
+  def callout_ids(li_ordinal)
+    current_list.inject([]) {|collector, element|
+      collector << element[:id] if element[:ordinal] == li_ordinal
+      collector
+    } * ' '
+  end
+
+  # Public: The current list for which callouts are being collected
+  #
+  # Returns The Array of callouts at the position of the list index pointer
+  def current_list
+    @lists[@list_index - 1]
+  end
+
+  # Public: Advance to the next callout list in the document
+  #
+  # Returns nothing
+  def next_list
+    @list_index += 1
+    if @lists.size < @list_index
+      @lists << []
+    end
+    @co_index = 1
+    nil
+  end
+
+  # Public: Rewind the list index pointer, intended to be used when switching
+  # from the parsing to rendering phase.
+  #
+  # Returns nothing
+  def rewind
+    @list_index = 1
+    @co_index = 1
+    nil
+  end
+
+  # Internal: Generate a unique id for the callout based on the internal indexes
+  #
+  # Returns A unique String id for this callout
+  def generate_next_callout_id
+    generate_callout_id(@list_index, @co_index)
+  end
+
+  # Internal: Generate a unique id for the callout at the specified position
+  #
+  # list_index - The 1-based Integer index of the callout list within the document
+  # co_index   - The 1-based Integer index of the callout since the end of the last callout list
+  #
+  # Returns A unique String id for a callout
+  def generate_callout_id(list_index, co_index)
+    "CO#{list_index}-#{co_index}"
+  end
+end

--- a/lib/asciidoctor/document.rb
+++ b/lib/asciidoctor/document.rb
@@ -22,6 +22,9 @@ class Asciidoctor::Document < Asciidoctor::AbstractBlock
   # Public: Get the Hash of document references
   attr_reader :references
 
+  # Public: Get the Hash of callouts
+  attr_reader :callouts
+
   # The section level 0 block
   attr_reader :header
 
@@ -44,6 +47,7 @@ class Asciidoctor::Document < Asciidoctor::AbstractBlock
   def initialize(data = [], options = {}, &block)
     super(self, :document)
     @references = {}
+    @callouts = Callouts.new
     @renderer = nil
     @options = options
     @options[:header_footer] = @options.fetch(:header_footer, true)
@@ -88,6 +92,8 @@ class Asciidoctor::Document < Asciidoctor::AbstractBlock
         self << block unless block.nil?
       end
     end
+
+    @callouts.rewind
 
     Asciidoctor.debug "Found #{@blocks.size} blocks in this document:"
     @blocks.each do |el|

--- a/lib/asciidoctor/inline.rb
+++ b/lib/asciidoctor/inline.rb
@@ -12,8 +12,9 @@ class Asciidoctor::Inline < Asciidoctor::AbstractNode
   def initialize(parent, context, text = nil, opts = {})
     super(parent, context)
     @text = text 
-    @type = opts[:type]
-    @target = opts[:target]
+    @id = opts[:id] if opts.has_key?(:id)
+    @type = opts[:type] if opts.has_key?(:type)
+    @target = opts[:target] if opts.has_key?(:target)
     if opts.has_key?(:attributes) && (attributes = opts[:attributes]).is_a?(Hash)
       update_attributes(opts[:attributes]) unless attributes.empty?
     end

--- a/lib/asciidoctor/lexer.rb
+++ b/lib/asciidoctor/lexer.rb
@@ -159,31 +159,32 @@ class Asciidoctor::Lexer
           block.blocks << new_block unless new_block.nil?
         end
 
-      elsif list_type = [:colist].detect{|l| this_line.match( REGEXP[l] )}
+      elsif match = this_line.match(REGEXP[:colist])
+        Asciidoctor.debug "Creating block of type: :colist"
+        block = Block.new(parent, :colist)
+        attributes['style'] = 'arabic'
         items = []
-        Asciidoctor.debug "Creating block of type: #{list_type}"
-        block = Block.new(parent, list_type)
-        attributes['style'] ||= 'arabic'
-        while !this_line.nil? && match = this_line.match(REGEXP[list_type])
-          item = ListItem.new(block)
-
-          # Store first line as the text of the list item
-          item.text = match[2]
-          list_item_reader = Reader.new grab_lines_for_list_item(reader, list_type)
-          while item_reader.has_lines?
-            new_block = next_block(list_item_reader, block)
-            item.blocks << new_block unless new_block.nil?
-          end
-
-          items << item
-
-          reader.skip_blank
-
-          this_line = reader.get_line
-        end
-        reader.unshift(this_line) unless this_line.nil?
-
         block.buffer = items
+        reader.unshift this_line
+        expected_index = 1
+        begin
+          if match[1].to_i != expected_index
+            puts "asciidoctor: WARNING: callout list item index: expected #{expected_index} got #{match[1]}"
+          end
+          list_item = next_list_item(reader, block, match)
+          expected_index += 1
+          if !list_item.nil?
+            items << list_item
+            coids = parent.document.callouts.callout_ids(items.size)
+            if !coids.empty?
+              list_item.attributes['coids'] = coids
+            else
+              puts 'asciidoctor: WARNING: no callouts refer to list item ' + items.size.to_s
+            end
+          end
+        end while reader.has_lines? && match = reader.peek_line.match(REGEXP[:colist])
+
+        block.document.callouts.next_list
 
       elsif match = this_line.match(REGEXP[:ulist])
         AttributeList.rekey(attributes, ['style'])
@@ -321,6 +322,7 @@ class Asciidoctor::Lexer
           (context == :dlist && line.match(REGEXP[:dlist])) ||
           line.match(REGEXP[:open_blk]) ||
           # total hack job, we need to rethink this in a more generic way
+          # what about :colist?
           (context == :olist && [:ulist, :dlist].detect {|c| line.match(REGEXP[c])}) ||
           (context == :ulist && [:olist, :dlist].detect {|c| line.match(REGEXP[c])}) ||
           line.match(REGEXP[:attr_line])
@@ -355,6 +357,10 @@ class Asciidoctor::Lexer
         block.document.references[block.id] = block.title
       end
       block.update_attributes(attributes)
+
+      if block.context == :listing || block.context == :literal
+        catalog_callouts(block.buffer.join, block.document)
+      end
     # if the block ended with unrooted attributes, then give them
     # to the next block; this seems like a hack, but it really
     # is the simplest solution to this problem
@@ -430,9 +436,25 @@ class Asciidoctor::Lexer
     list_block
   end
 
+  # Internal: Catalog any callouts found in the text, but don't process them
+  #
+  # text     - The String of text in which to look for callouts
+  # document - The current document on which the callouts are stored
+  #
+  # Returns nothing
+  def self.catalog_callouts(text, document)
+    text.scan(REGEXP[:callout_scan]) {
+      # alias match for Ruby 1.8.7 compat
+      m = $~
+      next if m[0].start_with? '\\'
+      document.callouts.register(m[1])
+    }
+  end
+
   # Internal: Catalog any inline anchors found in the text, but don't process them
   #
-  # text - The String text in which to look for inline anchors
+  # text     - The String text in which to look for inline anchors
+  # document - The current document on which the references are stored
   #
   # Returns nothing
   def self.catalog_inline_anchors(text, document)
@@ -489,7 +511,8 @@ class Asciidoctor::Lexer
     block
   end
 
-  # Internal: Parse and construct the next ListItem for the current bulleted (unordered or ordered) list Block.
+  # Internal: Parse and construct the next ListItem for the current bulleted
+  # (unordered or ordered) list Block, callout lists included.
   #
   # First collect and process all the lines that constitute the next list item
   # for the parent list (according to its type). Next, parse those lines into
@@ -530,7 +553,7 @@ class Asciidoctor::Lexer
   # Internal: Collect the lines belonging to the current list item.
   #
   # Definition lists (:dlist) are handled slightly differently than regular
-  # lists (:olist or :ulist):
+  # lists (:olist, :colist or :ulist):
   #
   # Regular lists - grab lines until another list item is found, or the
   # block is broken by a terminator (such as a line comment or a blank line).
@@ -540,7 +563,7 @@ class Asciidoctor::Lexer
   # are more lenient about allowing blank lines.
   #
   # reader          - The Reader from which to retrieve the lines.
-  # list_type       - The context Symbol of the list (:ulist, :olist or :dlist)
+  # list_type       - The context Symbol of the list (:ulist, :olist, :colist or :dlist)
   # sibling_pattern - A Regexp that matches a sibling of this list item (default: nil)
   # phase           - The Symbol representing the parsing phase (:collect or :process) (default: :process)
   #
@@ -612,7 +635,7 @@ class Asciidoctor::Lexer
         else
           buffer << this_line
         end
-      # :olist & :ulist
+      # :ulist, :olist & :colist
       else
         if continuation == :active && !this_line.strip.empty?
           # swallow the continuation into a blank line in the process phase
@@ -903,12 +926,12 @@ class Asciidoctor::Lexer
         end while (match = this_line.match(REGEXP[:dlist]))
         reader.unshift this_line unless this_line.nil?
 
-      elsif (list_type = [:ulist, :olist].detect {|t| this_line.match(REGEXP[t])})
+      elsif (list_type = [:ulist, :olist, :colist].detect {|t| this_line.match(REGEXP[t])})
         begin
           section_lines << this_line
           section_lines.concat grab_lines_for_list_item(reader, list_type, nil, :collect)
           this_line = reader.get_line
-        end while !this_line.nil? && (list_type = [:ulist, :olist].detect {|t| this_line.match(REGEXP[t])})
+        end while !this_line.nil? && (list_type = [:ulist, :olist, :colist].detect {|t| this_line.match(REGEXP[t])})
         reader.unshift this_line unless this_line.nil?
 
       elsif is_section_heading? this_line, next_line

--- a/test/document_test.rb
+++ b/test/document_test.rb
@@ -24,7 +24,7 @@ context 'Document' do
       assert !renderer.nil?
       views = renderer.views
       assert !views.nil?
-      assert_equal 23, views.size
+      assert_equal 24, views.size
       assert views.has_key? 'document'
       assert views['document'].is_a?(Asciidoctor::HTML5::DocumentTemplate)
     end
@@ -39,7 +39,7 @@ context 'Document' do
       assert !renderer.nil?
       views = renderer.views
       assert !views.nil?
-      assert_equal 23, views.size
+      assert_equal 24, views.size
       assert views.has_key? 'document'
       assert views['document'].is_a?(Asciidoctor::DocBook45::DocumentTemplate)
     end

--- a/test/links_test.rb
+++ b/test/links_test.rb
@@ -22,6 +22,10 @@ context 'Links' do
     assert_xpath %{//a[@href='http://asciidoc.org'][text() = 'AsciiDoc\nmarkup']}, render_string("We're parsing link:http://asciidoc.org[AsciiDoc\nmarkup]")
   end
 
+  test 'qualified url surrounded by angled brackets' do
+    assert_xpath '//a[@href="http://asciidoc.org"][text()="http://asciidoc.org"]', render_string('<http://asciidoc.org> is the project page for AsciiDoc.'), 1
+  end
+
   test 'qualified url using invalid link macro should not create link' do
     assert_xpath '//a', render_string('link:http://asciidoc.org is the project page for AsciiDoc.'), 0
   end


### PR DESCRIPTION
Restore (and enhance) support for callout lists (now with tests ;))

This pull request is based on the previous two. Please advise if you need me to rebase.

p.s. It's interesting that we are starting to go a step beyond AsciiDoc by having some information available in the document structure prior to any rendering. In this case, we know about the callout references before we've started to render, whereas AsciiDoc does it all together.
