### PR TITLE
Tweak whitespace in a lot of areas for readability and make style tweaks

### DIFF
--- a/lib/asciidoctor/abstract_node.rb
+++ b/lib/asciidoctor/abstract_node.rb
@@ -18,11 +18,13 @@ class Asciidoctor::AbstractNode
 
   def initialize(parent, context)
     @parent = (context != :document ? parent : nil)
+
     if !parent.nil?
       @document = parent.is_a?(Asciidoctor::Document) ? parent : parent.document
     else
       @document = nil
     end
+    
     @context = context
     @attributes = {}
     @passthroughs = []
@@ -92,15 +94,15 @@ class Asciidoctor::AbstractNode
   # The return value of this method can be safely used in an image tag.
   #
   # target_image - A String path to the target image
-  # assetdir_key - The String attribute key used to lookup the directory where
+  # asset_dir_key - The String attribute key used to lookup the directory where
   #                the image is located (default: 'imagesdir')
   #
   # Returns A String reference or data URI for the target image
-  def image_uri(target_image, assetdir_key = 'imagesdir')
+  def image_uri(target_image, asset_dir_key = 'imagesdir')
     if document.attr? 'data-uri'
-      generate_data_uri(target_image, assetdir_key)
-    elsif assetdir_key && attr?(assetdir_key)
-      File.join(document.attr(assetdir_key), target_image)
+      generate_data_uri(target_image, asset_dir_key)
+    elsif asset_dir_key && attr?(asset_dir_key)
+      File.join(document.attr(asset_dir_key), target_image)
     else
       target_image
     end
@@ -114,19 +116,20 @@ class Asciidoctor::AbstractNode
   # can be used in an image tag.
   #
   # target_image - A String path to the target image
-  # assetdir_key - The String attribute key used to lookup the directory where
+  # asset_dir_key - The String attribute key used to lookup the directory where
   #                the image is located (default: nil)
   #
   # Returns A String data URI containing the content of the target image
-  def generate_data_uri(target_image, assetdir_key = nil)
+  def generate_data_uri(target_image, asset_dir_key = nil)
     require 'base64'
 
     mimetype = 'image/' + File.extname(target_image)[1..-1]
-    if assetdir_key
-      image_path = File.join(normalize_assetpath(document.attr(assetdir_key, '.'), assetdir_key), target_image)
+    if asset_dir_key
+      image_path = File.join(normalize_asset_path(document.attr(asset_dir_key, '.'), asset_dir_key), target_image)
     else
-      image_path = normalize_assetpath(target_image)
+      image_path = normalize_asset_path(target_image)
     end
+
     'data:' + mimetype + ';base64,' + Base64.strict_encode64(IO.read(image_path))
   end
 
@@ -134,9 +137,9 @@ class Asciidoctor::AbstractNode
   #
   # The most important functionality in this method is to prevent the asset directory
   # from resolving to a directory outside of the chroot directory (which defaults to docdir)
-  # if the 'safepaths' attribute is true (the default).
+  # if the 'safe-paths' attribute is true (the default).
   #
-  # assetdir     - The String asset directory as provided in the configuration
+  # asset_dir    - The String asset directory as provided in the configuration
   # asset_name   - The String name of the property being resolved (for use in
   #                the warning message) (default: 'asset directory')
   #
@@ -145,55 +148,58 @@ class Asciidoctor::AbstractNode
   #  # given these fixtures
   #  document.attr('docdir')
   #  # => "/path/to/docdir"
-  #  document.attr('safepaths')
+  #  document.attr('safe-paths')
   #  # => true
   #
   #  # then
-  #  normalize_assetpath('images')
+  #  normalize_asset_path('images')
   #  # => "/path/to/docdir/images"
-  #  normalize_assetpath('/etc/images')
+  #  normalize_asset_path('/etc/images')
   #  # => "/path/to/docdir/images"
-  #  normalize_assetpath('../images')
+  #  normalize_asset_path('../images')
   #  # => "/path/to/docdir/images"
   #
   #  # given these fixtures
   #  document.attr('docdir')
   #  # => "/path/to/docdir"
-  #  document.attr('safepaths')
+  #  document.attr('safe-paths')
   #  # => false
   #
   #  # then
-  #  normalize_assetpath('images')
+  #  normalize_asset_path('images')
   #  # => "/path/to/docdir/images"
-  #  normalize_assetpath('/etc/images')
+  #  normalize_asset_path('/etc/images')
   #  # => "/etc/images"
-  #  normalize_assetpath('../images')
+  #  normalize_asset_path('../images')
   #  # => "/path/to/images"
   #
   # Returns The normalized asset directory as a String
-  def normalize_assetpath(assetdir, asset_name = 'asset directory')
+  def normalize_asset_path(asset_dir, asset_name = 'asset directory')
     require 'pathname'
-    inputpath = File.expand_path(document.attr('docdir'))
-    assetpath = Pathname.new(assetdir)
-    if assetpath.relative?
-      assetpath = File.expand_path(File.join(inputpath, assetdir))
+
+    input_path = File.expand_path(document.attr('docdir'))
+    asset_path = Pathname.new(asset_dir)
+    
+    if asset_path.relative?
+      asset_path = File.expand_path(File.join(input_path, asset_dir))
     else
-      assetpath = assetpath.cleanpath.to_s
+      asset_path = asset_path.cleanpath.to_s
     end
 
     if document.attr('safepaths', true)
-      relative_assetdir = Pathname.new(assetpath).relative_path_from(Pathname.new(inputpath)).to_s
-      if relative_assetdir.start_with?('..')
+      relative_asset_dir = Pathname.new(asset_path).relative_path_from(Pathname.new(input_path)).to_s
+      if relative_asset_dir.start_with?('..')
         puts 'asciidoctor: WARNING: ' + asset_name + ' has illegal reference to ancestor of docdir'
-        relative_assetdir.sub!(/^(?:\.\.\/)*/, '')
+        relative_asset_dir.sub!(/^(?:\.\.\/)*/, '')
         # just to be absolutely sure ;)
-        if relative_assetdir[0..0] == '.'
-          raise 'Substitution of parent path references failed for ' + relative_assetdir
+        if relative_asset_dir[0..0] == '.'
+          raise 'Substitution of parent path references failed for ' + relative_asset_dir
         end
-        assetpath = File.expand_path(File.join(inputpath, relative_assetdir))
+        asset_path = File.expand_path(File.join(input_path, relative_asset_dir))
       end
     end
-    assetpath
+
+    asset_path
   end
 
 end

--- a/lib/asciidoctor/attribute_list.rb
+++ b/lib/asciidoctor/attribute_list.rb
@@ -83,8 +83,8 @@ class Asciidoctor::AttributeList
     AttributeList.rekey(@attributes, posattrs)
   end
 
-  def self.rekey(attributes, posattrs)
-    posattrs.each_with_index do |key, index|
+  def self.rekey(attributes, pos_attrs)
+    pos_attrs.each_with_index do |key, index|
       pos = index + 1
       unless (val = attributes[pos]).nil?
         attributes[key] = val
@@ -96,7 +96,7 @@ class Asciidoctor::AttributeList
     attributes
   end
 
-  def parse_attribute(index = 0, posattrs = [])
+  def parse_attribute(index = 0, pos_attrs = [])
     single_quoted_value = false
     skip_blank
     first = @scanner.peek(1)
@@ -155,8 +155,8 @@ class Asciidoctor::AttributeList
 
     if value.nil?
       resolved_name = single_quoted_value && !@block.nil? ? @block.apply_normal_subs(name) : name
-      if !(posname = posattrs[index]).nil?
-        @attributes[posname] = resolved_name
+      if !(pos_name = pos_attrs[index]).nil?
+        @attributes[pos_name] = resolved_name
       else
         #@attributes[index + 1] = resolved_name
       end

--- a/lib/asciidoctor/block.rb
+++ b/lib/asciidoctor/block.rb
@@ -83,6 +83,7 @@ class Asciidoctor::Block < Asciidoctor::AbstractBlock
       block.splain(parent_level) if block.respond_to? :splain
       Asciidoctor.puts_indented(parent_level, "^" * (60 - parent_level*2))
     end
+    
     nil
   end
 

--- a/lib/asciidoctor/callouts.rb
+++ b/lib/asciidoctor/callouts.rb
@@ -28,6 +28,7 @@ class Asciidoctor::Callouts
   def register(li_ordinal)
     current_list << {:ordinal => li_ordinal.to_i, :id => (id = generate_next_callout_id)}
     @co_index += 1
+
     id
   end
 
@@ -41,10 +42,13 @@ class Asciidoctor::Callouts
   def read_next_id
     id = nil
     list = current_list
+
     if @co_index <= list.size
       id = list[@co_index - 1][:id]
     end
+
     @co_index += 1
+
     id
   end
 
@@ -73,10 +77,13 @@ class Asciidoctor::Callouts
   # Returns nothing
   def next_list
     @list_index += 1
+
     if @lists.size < @list_index
       @lists << []
     end
+
     @co_index = 1
+
     nil
   end
 
@@ -87,6 +94,7 @@ class Asciidoctor::Callouts
   def rewind
     @list_index = 1
     @co_index = 1
+    
     nil
   end
 

--- a/lib/asciidoctor/debug.rb
+++ b/lib/asciidoctor/debug.rb
@@ -14,9 +14,10 @@ module Asciidoctor
   end
 
   def self.puts_indented(level, *args)
-    thing = " "*level*2
+    indentation = " " * level * 2
+
     args.each do |arg|
-      self.debug "#{thing}#{arg}"
+      self.debug "#{indentation}#{arg}"
     end
   end
 end

--- a/lib/asciidoctor/inline.rb
+++ b/lib/asciidoctor/inline.rb
@@ -11,10 +11,12 @@ class Asciidoctor::Inline < Asciidoctor::AbstractNode
 
   def initialize(parent, context, text = nil, opts = {})
     super(parent, context)
+
     @text = text 
     @id = opts[:id] if opts.has_key?(:id)
     @type = opts[:type] if opts.has_key?(:type)
     @target = opts[:target] if opts.has_key?(:target)
+    
     if opts.has_key?(:attributes) && (attributes = opts[:attributes]).is_a?(Hash)
       update_attributes(opts[:attributes]) unless attributes.empty?
     end

--- a/lib/asciidoctor/lexer.rb
+++ b/lib/asciidoctor/lexer.rb
@@ -54,6 +54,7 @@ class Asciidoctor::Lexer
     Asciidoctor.debug "/"*64
     Asciidoctor.debug "#{File.basename(__FILE__)}:#{__LINE__} -> #{__method__} - First two lines are:"
     Asciidoctor.debug reader.peek_line
+
     tmp_line = reader.get_line
     Asciidoctor.debug reader.peek_line
     reader.unshift tmp_line
@@ -82,6 +83,7 @@ class Asciidoctor::Lexer
           attributes['reftext'] = reftext
           parent.document.references[id] = reftext
         end
+
         reader.skip_blank
 
       elsif this_line.match(REGEXP[:comment_blk])
@@ -1059,6 +1061,7 @@ class Asciidoctor::Lexer
     value = value.downcase
     digits = { 'i' => 1, 'v' => 5, 'x' => 10 }
     result = 0
+    
     (0..value.length - 1).each {|i|
       digit = digits[value[i..i]]
       if i + 1 < value.length && digits[value[i+1..i+1]] > digit
@@ -1067,6 +1070,7 @@ class Asciidoctor::Lexer
         result += digit
       end
     }
+
     result
   end
 end

--- a/lib/asciidoctor/reader.rb
+++ b/lib/asciidoctor/reader.rb
@@ -197,6 +197,7 @@ class Asciidoctor::Reader
 
       buffer << this_line
     end
+
     buffer
   end
 
@@ -222,7 +223,6 @@ class Asciidoctor::Reader
 
   # Private: Process raw input, used for the outermost reader.
   def process(data, &block)
-
     raw_source = []
 
     data.each do |line|
@@ -241,6 +241,7 @@ class Asciidoctor::Reader
     continuing_value = nil
     continuing_key = nil
     @lines = []
+
     raw_source.each do |line|
       if skip_to
         skip_to = nil if line.match(skip_to)
@@ -375,7 +376,7 @@ class Asciidoctor::Reader
     # hurt anything. For paths that aren't, they'll get shoved down into the
     # current directory to keep them from nosing about where they shouldn't
     # in the filesystem.
-    relative_path = File.expand_path(path).sub(/^#{@document.basedir}/, '')
-    File.join(@document.basedir, relative_path)
+    relative_path = File.expand_path(path).sub(/^#{@document.base_dir}/, '')
+    File.join(@document.base_dir, relative_path)
   end
 end

--- a/lib/asciidoctor/renderer.rb
+++ b/lib/asciidoctor/renderer.rb
@@ -28,17 +28,20 @@ class Asciidoctor::Renderer
     # If user passed in a template dir, let them override our base templates
     if template_dir = options.delete(:template_dir)
       require 'tilt'
+
       Asciidoctor.debug "Views going in are like so:"
       @views.each_pair do |k, v|
         Asciidoctor.debug "#{k}: #{v}"
       end
       Asciidoctor.debug "="*60
+      
       # Grab the files in the top level of the directory (we're not traversing)
       files = Dir.glob(File.join(template_dir, '*')).select{|f| File.stat(f).file?}
       files.inject(@views) do |view_hash, view|
         name = File.basename(view).split('.').first
         view_hash.merge!(name => Tilt.new(view, nil, :trim => '<>'))
       end
+      
       Asciidoctor.debug "Views are now like so:"
       @views.each_pair do |k, v|
         Asciidoctor.debug "#{k}: #{v}"
@@ -56,11 +59,13 @@ class Asciidoctor::Renderer
   # locals - the optional Hash of locals to be passed to Tilt (default {}) (also ignored, really)
   def render(view, object, locals = {})
     @render_stack.push([view, object])
+
     if !@views.has_key? view
       raise "Couldn't find a view in @views for #{view}"
     else
       Asciidoctor.debug "View for #{view} is #{@views[view]}, object is #{object}"
     end
+    
     ret = @views[view].render(object, locals)
 
     if @debug

--- a/lib/asciidoctor/section.rb
+++ b/lib/asciidoctor/section.rb
@@ -96,9 +96,9 @@ class Asciidoctor::Section < Asciidoctor::AbstractBlock
   def content
     @blocks.map do |block|
       Asciidoctor.debug "Begin rendering block #{block.is_a?(Asciidoctor::Section) ? block.title : 'n/a'} #{block} (context: #{block.is_a?(Asciidoctor::Block) ? block.context : 'n/a' })"
-      poo = block.render
+      block_content = block.render
       Asciidoctor.debug "===> Done rendering block #{block.is_a?(Asciidoctor::Section) ? block.title : 'n/a'} #{block} (context: #{block.is_a?(Asciidoctor::Block) ? block.context : 'n/a' })"
-      poo
+      block_content
     end.join
   end
 

--- a/lib/asciidoctor/substituters.rb
+++ b/lib/asciidoctor/substituters.rb
@@ -37,8 +37,10 @@ module Asciidoctor
 
       multiline = lines.is_a?(Array)
       text = multiline ? lines.join : lines
+
       passthroughs = subs.include?(:macros)
       text = extract_passthroughs(text) if passthroughs
+      
       subs.each {|type|
         case type
         when :specialcharacters
@@ -124,6 +126,7 @@ module Asciidoctor
         if m[0].start_with? '\\'
           next m[0][1..-1]
         end
+
         # TODO warn if we don't recognize the sub
         if m[1] == '$$'
           subs = [:specialcharacters]
@@ -132,6 +135,7 @@ module Asciidoctor
         else
           subs = []
         end
+
         @passthroughs << {:text => m[2] || m[4].gsub('\]', ']'), :subs => subs}
         "\x0" + (@passthroughs.size - 1).to_s + "\x0"
       } unless !(result.include?('+++') || result.include?('$$') || result.include?('pass:'))
@@ -139,10 +143,12 @@ module Asciidoctor
       result.gsub!(REGEXP[:pass_lit]) {
         # alias match for Ruby 1.8.7 compat
         m = $~
+
         # honor the escape
         if m[2].start_with? '\\'
           next m[1] + m[2][1..-1]
         end
+        
         @passthroughs << {:text => m[3], :subs => [:specialcharacters], :literal => true}
         m[1] + "\x0" + (@passthroughs.size - 1).to_s + "\x0"
       } unless !result.include?('`')
@@ -157,6 +163,7 @@ module Asciidoctor
     # returns The String text with the passthrough text restored
     def restore_passthroughs(text)
       return text if @passthroughs.nil? || @passthroughs.empty? || !text.include?("\x0")
+      
       text.gsub(REGEXP[:pass_placeholder]) {
         pass = @passthroughs[$1.to_i];
         text = apply_subs(pass[:text], pass.fetch(:subs, []))
@@ -185,9 +192,11 @@ module Asciidoctor
     # returns The String text with quoted text rendered using the backend templates
     def sub_quotes(text)
       result = text.dup
+
       QUOTE_SUBS.each {|type, scope, pattern|
         result.gsub!(pattern) { transform_quoted_text($~, type, scope) }
       }
+      
       result
     end
 
@@ -198,9 +207,11 @@ module Asciidoctor
     # returns The String text with the replacement characters substituted
     def sub_replacements(text)
       result = text.dup
+
       REPLACEMENTS.each {|pattern, replacement|
         result.gsub!(pattern, replacement)
       }
+      
       result
     end
 
@@ -219,6 +230,7 @@ module Asciidoctor
     # so that a missing key doesn't wipe out the whole block of data
     def sub_attributes(data)
       return data if data.nil? || data.empty?
+
       # normalizes data type to an array (string becomes single-element array)
       lines = Array(data)
 
@@ -400,6 +412,7 @@ module Asciidoctor
     def parse_attributes(attrline, posattrs = ['role'])
       return nil if attrline.nil?
       return {} if attrline.empty?
+      
       AttributeList.new(attrline, self).parse(posattrs)
     end
   end

--- a/test/blocks_test.rb
+++ b/test/blocks_test.rb
@@ -319,11 +319,11 @@ image::asciidoctor.png[Asciidoctor]
       basedir = File.dirname(__FILE__)
       block = block_from_string input, :attributes => {'docdir' => basedir}
       doc = block.document
-      assert doc.attr('safepaths') == true
+      assert doc.attr('safe-paths') == true
 
-      assert_equal File.join(basedir, 'images'), block.normalize_assetpath('images')
-      assert_equal File.join(basedir, 'etc/images'), block.normalize_assetpath('/etc/images')
-      assert_equal File.join(basedir, 'images'), block.normalize_assetpath('../../images')
+      assert_equal File.join(basedir, 'images'), block.normalize_asset_path('images')
+      assert_equal File.join(basedir, 'etc/images'), block.normalize_asset_path('/etc/images')
+      assert_equal File.join(basedir, 'images'), block.normalize_asset_path('../../images')
     end
 
     test "doesn't restrict access to ancestor directories when safepaths is disabled" do
@@ -335,9 +335,9 @@ image::asciidoctor.png[Asciidoctor]
       doc = block.document
       assert doc.attr('safepaths') == false
 
-      assert_equal File.join(basedir, 'images'), block.normalize_assetpath('images')
-      assert_equal '/etc/images', block.normalize_assetpath('/etc/images')
-      assert_equal File.expand_path(File.join(basedir, '../../images')), block.normalize_assetpath('../../images')
+      assert_equal File.join(basedir, 'images'), block.normalize_asset_path('images')
+      assert_equal '/etc/images', block.normalize_asset_path('/etc/images')
+      assert_equal File.expand_path(File.join(basedir, '../../images')), block.normalize_asset_path('../../images')
     end
 
   end

--- a/test/reader_test.rb
+++ b/test/reader_test.rb
@@ -183,7 +183,7 @@ last line
       reader = Asciidoctor::Reader.new(["foo"], doc)
       secure_path = reader.build_secure_path(naughty_path)
       assert naughty_path != secure_path
-      assert_match(/^#{doc.basedir}/, secure_path)
+      assert_match(/^#{doc.base_dir}/, secure_path)
     end
 
     test "keeps naughty relative paths from getting outside" do
@@ -192,7 +192,7 @@ last line
       reader = Asciidoctor::Reader.new(["foo"], doc)
       secure_path = reader.build_secure_path(naughty_path)
       assert naughty_path != secure_path
-      assert_match(/^#{doc.basedir}/, secure_path)
+      assert_match(/^#{doc.base_dir}/, secure_path)
     end
   end
 


### PR DESCRIPTION
This PR just tweaks whitespace all over and changes a few variable names to make more sense or fit Ruby style a bit better.  I'm not sold on using dashes on the attributes keys on `Document`, but I don't know if that's a Python/Asciidoc established precedent or not so I just followed it. :)

Feel free to revert any of these you think are necessary names for some reason; I didn't know if you intentionally left things like `assetdir` rather than `asset_dir` or if it's just a style thing.

As for whitespace, I was finding parts of the code hard to read, so I dropped some whitespace in to make it easier for these old eyes to process. ;)  I also tried to put the return value on its own line if it's a bare return (i.e., just returning the last value used in a method).  That's just a style thing I've picked up, so if you hate it, feel free to revert that, too, but I feel like it's much easier to discern what's going on with it like that.
