### PR TITLE
Make ruby 1.8.7 about base64 encoding

### DIFF
--- a/lib/asciidoctor/abstract_node.rb
+++ b/lib/asciidoctor/abstract_node.rb
@@ -127,7 +127,7 @@ class Asciidoctor::AbstractNode
     else
       image_path = normalize_assetpath(target_image)
     end
-    'data:' + mimetype + ';base64,' + Base64.strict_encode64(IO.read(image_path))
+    'data:' + mimetype + ';base64,' + Base64.encode64(IO.read(image_path)).delete("\n")
   end
 
   # Public: Normalize the specified asset directory to a concrete directory path


### PR DESCRIPTION
Simple fix. Technically whitespace is permitted in a data-uri, but it seems to be a best practice to remove it. tr does the job lightning fast.
