### PR TITLE
Implement passthrough block

### DIFF
--- a/lib/asciidoctor.rb
+++ b/lib/asciidoctor.rb
@@ -205,7 +205,7 @@ module Asciidoctor
     :listing          => /^\-{4,}\s*$/,
 
     # ....
-    :lit_blk          => /^\.{4,}\s*$/,
+    :literal          => /^\.{4,}\s*$/,
 
     # <TAB>Foo  or one-or-more-spaces-or-tabs then whatever
     :lit_par          => /^([[:blank:]]+.*)$/,
@@ -220,6 +220,9 @@ module Asciidoctor
     # i. Foo (lowerroman)
     # I. Foo (upperroman)
     :olist            => /^\s*(\d+\.|[a-z]\.|[ivx]+\)|\.{1,5}) +(.*)$/i,
+
+    # ++++
+    :pass             => /^\+{4,}\s*$/,
 
     # inline passthrough macros
     # +++text+++

--- a/lib/asciidoctor/backends/docbook45.rb
+++ b/lib/asciidoctor/backends/docbook45.rb
@@ -341,6 +341,15 @@ class BlockVerseTemplate < ::Asciidoctor::BaseTemplate
   end
 end
 
+class BlockPassTemplate < ::Asciidoctor::BaseTemplate
+  def template
+    @template ||= ERB.new <<-EOS
+<%#encoding:UTF-8%>
+<%= content %>
+    EOS
+  end
+end
+
 class BlockImageTemplate < ::Asciidoctor::BaseTemplate
   def template
     @template ||= ERB.new <<-EOF

--- a/lib/asciidoctor/backends/html5.rb
+++ b/lib/asciidoctor/backends/html5.rb
@@ -366,6 +366,15 @@ class BlockColistTemplate < ::Asciidoctor::BaseTemplate
   end
 end
 
+class BlockPassTemplate < ::Asciidoctor::BaseTemplate
+  def template
+    @template ||= ERB.new <<-EOS
+<%#encoding:UTF-8%>
+<%= content %>
+    EOS
+  end
+end
+
 class BlockImageTemplate < ::Asciidoctor::BaseTemplate
   def template
     @template ||= ERB.new <<-EOS

--- a/lib/asciidoctor/block.rb
+++ b/lib/asciidoctor/block.rb
@@ -111,6 +111,8 @@ class Asciidoctor::Block < Asciidoctor::AbstractBlock
       @buffer
     when :listing, :literal
       apply_literal_subs(@buffer)
+    when :pass
+      apply_passthrough_subs(@buffer)
     when :quote, :verse, :admonition
       if !@buffer.nil?
         apply_normal_subs(@buffer)

--- a/lib/asciidoctor/lexer.rb
+++ b/lib/asciidoctor/lexer.rb
@@ -267,11 +267,12 @@ class Asciidoctor::Lexer
           block = Block.new(parent, quote_context, block_reader.lines)
         end
 
-      elsif this_line.match(REGEXP[:lit_blk])
-        # example is surrounded by '....' (4 or more '.' chars) lines
-        buffer = reader.grab_lines_until {|line| line.match( REGEXP[:lit_blk] ) }
+      elsif blk_ctx = [:literal, :pass].detect{|blk_ctx| this_line.match(REGEXP[blk_ctx])}
+        # literal is surrounded by '....' (4 or more '.' chars) lines
+        # pass is surrounded by '++++' (4 or more '+' chars) lines
+        buffer = reader.grab_lines_until {|line| line.match( REGEXP[blk_ctx] ) }
         buffer.last.chomp! unless buffer.empty?
-        block = Block.new(parent, :literal, buffer)
+        block = Block.new(parent, blk_ctx, buffer)
 
       elsif this_line.match(REGEXP[:lit_par])
         # literal paragraph is contiguous lines starting with

--- a/lib/asciidoctor/reader.rb
+++ b/lib/asciidoctor/reader.rb
@@ -379,8 +379,7 @@ class Asciidoctor::Reader
       m = $~
       subs = []
       if !m[1].empty?
-        sub_options = Asciidoctor::Substituters::COMPOSITE_SUBS.keys + Asciidoctor::Substituters::COMPOSITE_SUBS[:normal]
-        subs = m[1].split(',').map {|sub| sub.to_sym} & sub_options
+        subs = @document.resolve_subs(m[1])
       end
       if !subs.empty?
         @document.apply_subs(m[2], subs)

--- a/test/blocks_test.rb
+++ b/test/blocks_test.rb
@@ -151,6 +151,52 @@ ____
     end
   end
 
+  context 'Passthrough Blocks' do
+    test 'can parse a passthrough block' do
+      input = <<-EOS
+++++
+This is a passthrough block.
+++++
+      EOS
+
+      block = block_from_string input
+      assert !block.nil?
+      assert_equal 1, block.buffer.size
+      assert_equal 'This is a passthrough block.', block.buffer.first
+    end
+
+    test 'performs passthrough subs on a passthrough block' do
+      input = <<-EOS
+:type: passthrough
+
+++++
+This is a '{type}' block.
+http://asciidoc.org
+++++
+      EOS
+
+      expected = %(This is a 'passthrough' block.\n<a href="http://asciidoc.org">http://asciidoc.org</a>\n)
+      output = render_embedded_string input
+      assert_equal expected, output
+    end
+
+    test 'passthrough block honors explicit subs list' do
+      input = <<-EOS
+:type: passthrough
+
+[subs="attributes, quotes"]
+++++
+This is a '{type}' block.
+http://asciidoc.org
+++++
+      EOS
+
+      expected = %(This is a <em>passthrough</em> block.\nhttp://asciidoc.org\n)
+      output = render_embedded_string input
+      assert_equal expected, output
+    end
+  end
+
   context "Images" do
     test "can render block image with alt text" do
       input = <<-EOS

--- a/test/document_test.rb
+++ b/test/document_test.rb
@@ -24,7 +24,7 @@ context 'Document' do
       assert !renderer.nil?
       views = renderer.views
       assert !views.nil?
-      assert_equal 24, views.size
+      assert_equal 25, views.size
       assert views.has_key? 'document'
       assert views['document'].is_a?(Asciidoctor::HTML5::DocumentTemplate)
     end
@@ -39,7 +39,7 @@ context 'Document' do
       assert !renderer.nil?
       views = renderer.views
       assert !views.nil?
-      assert_equal 24, views.size
+      assert_equal 25, views.size
       assert views.has_key? 'document'
       assert views['document'].is_a?(Asciidoctor::DocBook45::DocumentTemplate)
     end


### PR DESCRIPTION
- add passthrough block
- rename regex for lit_blk to literal for dynamic assignment of context
- add resolve_subs() option for resolving subs for user-supplied list
- tests for passthrough block and passthrough substitutions
