### PR TITLE
options to disable includes

### DIFF
--- a/lib/asciidoctor.rb
+++ b/lib/asciidoctor.rb
@@ -284,7 +284,7 @@ module Asciidoctor
     :endif_macro      => /^endif::/,
 
     # include::chapter1.ad[]
-    :include_macro    => /^include::([^\[]+)\[\]\s*\n?\z/
+    :include_macro    => /^\\?include::([^\[]+)\[\]\s*\n?\z/
   }
 
   ADMONITION_STYLES = ['NOTE', 'TIP', 'IMPORTANT', 'WARNING', 'CAUTION']

--- a/lib/asciidoctor/document.rb
+++ b/lib/asciidoctor/document.rb
@@ -58,8 +58,11 @@ class Asciidoctor::Document < Asciidoctor::AbstractBlock
 
     attribute_overrides = options[:attributes] || {}
 
-    # the only way to set the safepaths attribute is via the document options
+    # the only way to set the safe-paths attribute is via the document options
     attribute_overrides['safe-paths'] ||= true
+    # the only way to set the include-depth attribute is via the document options
+    # 10 is the AsciiDoc default, though currently Asciidoctor only supports 1 level
+    attribute_overrides['include-depth'] ||= 1
 
     attribute_overrides['docdir'] ||= Dir.pwd
     

--- a/lib/asciidoctor/reader.rb
+++ b/lib/asciidoctor/reader.rb
@@ -260,10 +260,16 @@ class Asciidoctor::Reader
 
     data.each do |line|
       if inc = line.match(REGEXP[:include_macro])
+        # assume that if a block is given, the developer wants
+        # to handle when and how to process the include
         if block_given?
           raw_source.concat yield(inc[1])
-        else
+        elsif inc[0].start_with?('\\')
+          raw_source << line[1..-1]
+        elsif @document.attr('include-depth', 0) > 0
           raw_source.concat File.readlines(build_secure_path(inc[1]))
+        else
+          raw_source << line
         end
       else
         raw_source << line

--- a/test/reader_test.rb
+++ b/test/reader_test.rb
@@ -167,6 +167,46 @@ last line
       }
       assert_equal 'include-file.asciidoc', doc.attributes['file']
     end
+
+    test 'escaped include macro is left unprocessed' do
+      input = <<-EOS
+\\include::include-file.asciidoc[]
+      EOS
+      para = block_from_string input
+      assert_equal 1, para.buffer.size
+      assert_equal 'include::include-file.asciidoc[]', para.buffer.join
+    end
+
+    test 'include macro not at start of line is ignored' do
+      input = <<-EOS
+ include::include-file.asciidoc[]
+      EOS
+      para = block_from_string input
+      assert_equal 1, para.buffer.size
+      # NOTE the space gets stripped because the line is treated as an inline literal
+      assert_equal :literal, para.context
+      assert_equal 'include::include-file.asciidoc[]', para.buffer.join
+    end
+
+    test 'include macro is disabled when include-depth attribute is 0' do
+      input = <<-EOS
+include::include-file.asciidoc[]
+      EOS
+      para = block_from_string input, :attributes => { 'include-depth' => 0 }
+      assert_equal 1, para.buffer.size
+      assert_equal 'include::include-file.asciidoc[]', para.buffer.join
+    end
+
+    test 'include-depth cannot be set by document' do
+      input = <<-EOS
+:include-depth: 1
+
+include::include-file.asciidoc[]
+      EOS
+      para = block_from_string input, :attributes => { 'include-depth' => 0 }
+      assert_equal 1, para.buffer.size
+      assert_equal 'include::include-file.asciidoc[]', para.buffer.join
+    end
   end
 
   context 'build_secure_path' do


### PR DESCRIPTION
Fix for issue #63
- leave escaped include::macro unprocessed (but strip backslash)
- disable includes if include-depth attribute is 0
- include-depth attribute cannot be assigned in the document (it's "immutable")
