### PR TITLE
Section numbering

### DIFF
--- a/lib/asciidoctor/abstract_block.rb
+++ b/lib/asciidoctor/abstract_block.rb
@@ -15,6 +15,7 @@ class Asciidoctor::AbstractBlock < Asciidoctor::AbstractNode
     @blocks = []
     @id = nil
     @level = (context == :document ? 0 : nil)
+    @next_section_index = 0 
   end
 
   # Public: Determine whether this Block contains block content
@@ -44,6 +45,58 @@ class Asciidoctor::AbstractBlock < Asciidoctor::AbstractNode
   #
   # Returns nothing.
   def <<(block)
+    if block.is_a?(Asciidoctor::Section)
+      assign_index(block)
+    end
     @blocks << block
+  end
+
+  # Public: Get the Array of child Section objects
+  #
+  # Only applies to Document and Section instances
+  #
+  # Examples
+  # 
+  #   section = Section.new(parent)
+  #   section << Block.new(section, :paragraph, 'paragraph 1')
+  #   section << Section.new(parent)
+  #   section << Block.new(section, :paragraph, 'paragraph 2')
+  #   section.sections.size
+  #   # => 1
+  #
+  # returns an Array of Section objects
+  def sections
+    @blocks.inject([]) {|collector, block|
+      collector << block if block.is_a?(Asciidoctor::Section)
+      collector
+    }
+  end
+
+  # Internal: Assign the next index (0-based) to this section
+  #
+  # Assign the next index of this section within the parent
+  # Block (in document order)
+  #
+  # returns nothing
+  def assign_index(section)
+    section.index = @next_section_index
+    @next_section_index += 1
+  end
+
+  # Internal: Reassign the section indexes
+  #
+  # Walk the descendents of the current Document or Section
+  # and reassign the section 0-based index value to each Section
+  # as it appears in document order.
+  # 
+  # returns nothing
+  def reindex_sections
+    @next_section_index = 0
+    @blocks.each {|block|
+      if block.is_a?(Asciidoctor::Section)
+        assign_index(block)
+        block.reindex_sections
+      end
+    }
   end
 end

--- a/lib/asciidoctor/backends/docbook45.rb
+++ b/lib/asciidoctor/backends/docbook45.rb
@@ -63,6 +63,7 @@ class DocumentTemplate < ::Asciidoctor::BaseTemplate
 <%#encoding:UTF-8%>
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE <%= doctype %> PUBLIC "-//OASIS//DTD DocBook XML V4.5//EN" "http://www.oasis-open.org/docbook/xml/4.5/docbookx.dtd">
+<% if attr? :numbered %><?asciidoc-numbered?><% end %>
 <% if doctype == 'book' %>
 <book lang="en">
   <bookinfo>

--- a/lib/asciidoctor/backends/html5.rb
+++ b/lib/asciidoctor/backends/html5.rb
@@ -83,7 +83,7 @@ class SectionTemplate < ::Asciidoctor::BaseTemplate
 <%= content %>
 <% else %>
 <div class="sect<%= level %>#{style_class}">
-  <h<%= level + 1 %>#{id}><%= title %></h<%= level + 1 %>>
+  <h<%= level + 1 %>#{id}><% if attr? :numbered %><%= sectnum %> <% end %><%= title %></h<%= level + 1 %>>
   <% if level == 1 %>
   <div class="sectionbody">
 <%= content %>

--- a/test/headers_test.rb
+++ b/test/headers_test.rb
@@ -126,6 +126,92 @@ context "Headers" do
     end
   end
 
+  context 'Section Numbering' do
+    test 'should create section number with one entry for level 1' do
+      sect1 = Asciidoctor::Section.new(nil)
+      sect1.level = 1
+      assert_equal '1.', sect1.sectnum
+    end
+
+    test 'should create section number with two entries for level 2' do
+      sect1 = Asciidoctor::Section.new(nil)
+      sect1.level = 1
+      sect1_1 = Asciidoctor::Section.new(sect1)
+      sect1 << sect1_1
+      assert_equal '1.1.', sect1_1.sectnum
+    end
+
+    test 'should create section number with three entries for level 3' do
+      sect1 = Asciidoctor::Section.new(nil)
+      sect1.level = 1
+      sect1_1 = Asciidoctor::Section.new(sect1)
+      sect1 << sect1_1
+      sect1_1_1 = Asciidoctor::Section.new(sect1_1)
+      sect1_1 << sect1_1_1
+      assert_equal '1.1.1.', sect1_1_1.sectnum
+    end
+
+    test 'should create section number for second section in level' do
+      sect1 = Asciidoctor::Section.new(nil)
+      sect1.level = 1
+      sect1_1 = Asciidoctor::Section.new(sect1)
+      sect1 << sect1_1
+      sect1_2 = Asciidoctor::Section.new(sect1)
+      sect1 << sect1_2
+      assert_equal '1.2.', sect1_2.sectnum
+    end
+
+    test 'sectnum should use specified delimiter and append string' do
+      sect1 = Asciidoctor::Section.new(nil)
+      sect1.level = 1
+      sect1_1 = Asciidoctor::Section.new(sect1)
+      sect1 << sect1_1
+      sect1_1_1 = Asciidoctor::Section.new(sect1_1)
+      sect1_1 << sect1_1_1
+      assert_equal '1,1,1,', sect1_1_1.sectnum(',')
+      assert_equal '1:1:1', sect1_1_1.sectnum(':', false)
+    end
+
+    test 'should render section numbers when numbered attribute is set' do
+      input = <<-EOS
+= Title
+:numbered:
+
+== Section_1 
+
+text
+
+=== Section_1_1
+
+text
+
+==== Section_1_1_1
+
+text
+
+== Section_2
+
+text
+
+=== Section_2_1
+
+text
+
+=== Section_2_2
+
+text
+      EOS
+    
+      output = render_string input
+      assert_xpath '//h2[@id="_section_1"][starts-with(text(), "1. ")]', output, 1
+      assert_xpath '//h3[@id="_section_1_1"][starts-with(text(), "1.1. ")]', output, 1
+      assert_xpath '//h4[@id="_section_1_1_1"][starts-with(text(), "1.1.1. ")]', output, 1
+      assert_xpath '//h2[@id="_section_2"][starts-with(text(), "2. ")]', output, 1
+      assert_xpath '//h3[@id="_section_2_1"][starts-with(text(), "2.1. ")]', output, 1
+      assert_xpath '//h3[@id="_section_2_2"][starts-with(text(), "2.2. ")]', output, 1
+    end
+  end
+
   context "heading patterns in blocks" do
     test "should not interpret a listing block as a heading" do
       input = <<-EOS


### PR DESCRIPTION
- keep track of the index of each section as it's added to its parent
- create a method for generating a section number
- add section number support to backend templates
- add convenience method to retrieve child sections from a parent block
- tests!

Note that the section number is not applied to the DocBook template because DocBook has it's own mechanism for assigning section numbers.
