### PR TITLE
Urgent: fix bad reference to safe-paths, don't clobber value

### DIFF
--- a/lib/asciidoctor/abstract_node.rb
+++ b/lib/asciidoctor/abstract_node.rb
@@ -110,7 +110,7 @@ class Asciidoctor::AbstractNode
 
   # Public: Generate a data URI that can be used to embed an image in the output document
   #
-  # First, and foremost, the target image path is cleaned if the 'safepaths' attribute is
+  # First, and foremost, the target image path is cleaned if the 'safe-paths' attribute is
   # set (on by default) to prevent access to ancestor paths in the filesystem. The
   # image data is then read and converted to Base64. Finally, a data URI is built which
   # can be used in an image tag.
@@ -186,7 +186,7 @@ class Asciidoctor::AbstractNode
       asset_path = asset_path.cleanpath.to_s
     end
 
-    if document.attr('safepaths', true)
+    if document.attr('safe-paths', true)
       relative_asset_dir = Pathname.new(asset_path).relative_path_from(Pathname.new(input_path)).to_s
       if relative_asset_dir.start_with?('..')
         puts 'asciidoctor: WARNING: ' + asset_name + ' has illegal reference to ancestor of docdir'

--- a/lib/asciidoctor/document.rb
+++ b/lib/asciidoctor/document.rb
@@ -63,7 +63,7 @@ class Asciidoctor::Document < Asciidoctor::AbstractBlock
     attribute_overrides = options[:attributes] || {}
 
     # the only way to set the safe-paths attribute is via the document options
-    attribute_overrides['safe-paths'] ||= true
+    attribute_overrides['safe-paths'] = true unless attribute_overrides.has_key?('safe-paths')
     # the only way to set the include-depth attribute is via the document options
     # 10 is the AsciiDoc default, though currently Asciidoctor only supports 1 level
     attribute_overrides['include-depth'] ||= 1

--- a/test/blocks_test.rb
+++ b/test/blocks_test.rb
@@ -359,7 +359,7 @@ image::dot.gif[Dot]
     end
 
     # this test will cause a warning to be printed to the console (until we have a message facility)
-    test 'does not allow access to ancestor directories to read image if safepaths attribute is set' do
+    test 'does not allow access to ancestor directories to read image if safe-paths attribute is set' do
       input = <<-EOS
 :data-uri:
 :imagesdir: ../fixtures
@@ -415,7 +415,7 @@ You can use icons for admonitions by setting the 'icons' attribute.
       assert_xpath '//*[@class="admonitionblock"]//*[@class="icon"]/img[@src="data:image/gif;base64,R0lGODlhAQABAIAAAAUEBAAAACwAAAAAAQABAAACAkQBADs="][@alt="Tip"]', output, 1
     end
 
-    test 'does not allow access to ancestor directories to read icon if safepaths attribute is set' do
+    test 'does not allow access to ancestor directories to read icon if safe-paths attribute is set' do
       input = <<-EOS
 :icons:
 :iconsdir: ../fixtures
@@ -433,7 +433,7 @@ You can use icons for admonitions by setting the 'icons' attribute.
 
   context 'Image paths' do
 
-    test 'restricts access to ancestor directories when safepaths is enabled' do
+    test 'restricts access to ancestor directories when safe-paths is enabled' do
       input = <<-EOS
 image::asciidoctor.png[Asciidoctor]
       EOS
@@ -447,14 +447,14 @@ image::asciidoctor.png[Asciidoctor]
       assert_equal File.join(basedir, 'images'), block.normalize_asset_path('../../images')
     end
 
-    test "doesn't restrict access to ancestor directories when safepaths is disabled" do
+    test "doesn't restrict access to ancestor directories when safe-paths is disabled" do
       input = <<-EOS
 image::asciidoctor.png[Asciidoctor]
       EOS
       basedir = File.dirname(__FILE__)
-      block = block_from_string input, :attributes => {'docdir' => basedir, 'safepaths' => false}
+      block = block_from_string input, :attributes => {'docdir' => basedir, 'safe-paths' => false}
       doc = block.document
-      assert doc.attr('safepaths') == false
+      assert doc.attr('safe-paths') == false
 
       assert_equal File.join(basedir, 'images'), block.normalize_asset_path('images')
       assert_equal '/etc/images', block.normalize_asset_path('/etc/images')


### PR DESCRIPTION
The safe paths feature was broken because it still referenced the key w/o the hypen.
