### PR TITLE
Add floating title and tests, plus minor tweaks

### DIFF
--- a/lib/asciidoctor.rb
+++ b/lib/asciidoctor.rb
@@ -328,8 +328,8 @@ module Asciidoctor
     #
     # match[1] is the delimiter, whose length determines the level
     # match[2] is the title itself
-    # match[3] is an optional repeat of the delimiter, which is dropped
-    :section_title     => /^(={1,5})\s+(\S.*?)\s*(?:\[\[([^\[]+)\]\]\s*)?(\s\1)?$/,
+    # match[3] is an inline anchor, which becomes the section id
+    :section_title     => /^(={1,5})\s+(\S.*?)\s*(?:\[\[([^\[]+)\]\]\s*)?(?:\s\1)?$/,
 
     # does not begin with a dot and has at least one alphanumeric character
     :section_name      => /^((?=.*\w+.*)[^\.].*?)\s*$/,

--- a/lib/asciidoctor/backends/docbook45.rb
+++ b/lib/asciidoctor/backends/docbook45.rb
@@ -113,13 +113,22 @@ class SectionTemplate < ::Asciidoctor::BaseTemplate
   def template
     @template ||= @eruby.new <<-EOF
 <%#encoding:UTF-8%>
-<<%= document.doctype == 'book' && level <= 1 ? 'chapter' : 'section' %>#{id}#{role}#{xreflabel}>
+<<%= document.doctype == 'book' && @level <= 1 ? 'chapter' : 'section' %>#{id}#{role}#{xreflabel}>
   #{title}
 <%= content %>
-</<%= document.doctype == 'book' && level <= 1 ? 'chapter' : 'section' %>>
+</<%= document.doctype == 'book' && @level <= 1 ? 'chapter' : 'section' %>>
     EOF
   end
 end
+
+class BlockFloatingTitleTemplate < ::Asciidoctor::BaseTemplate
+  def template
+    @template ||= @eruby.new <<-EOS
+<bridgehead#{id}#{role}#{xreflabel} renderas="sect<%= @level %>"><%= title %></bridgehead>
+    EOS
+  end
+end
+
 
 class BlockParagraphTemplate < ::Asciidoctor::BaseTemplate
   def template

--- a/lib/asciidoctor/backends/html5.rb
+++ b/lib/asciidoctor/backends/html5.rb
@@ -137,7 +137,7 @@ class SectionTemplate < ::Asciidoctor::BaseTemplate
   def template
     @template ||= @eruby.new <<-EOS
 <%#encoding:UTF-8%>
-<% if level == 0 %>
+<% if @level == 0 %>
 <h1#{id}><%= title %></h1>
 <%= content %>
 <% else %>
@@ -152,6 +152,14 @@ class SectionTemplate < ::Asciidoctor::BaseTemplate
   <% end %>
 </div>
 <% end %>
+    EOS
+  end
+end
+
+class BlockFloatingTitleTemplate < ::Asciidoctor::BaseTemplate
+  def template
+    @template ||= @eruby.new <<-EOS
+<h<%= @level + 1 %>#{id} class="#{attrvalue :style, false}#{style_class}"><%= title %></h<%= @level + 1 %>>
     EOS
   end
 end

--- a/lib/asciidoctor/document.rb
+++ b/lib/asciidoctor/document.rb
@@ -150,11 +150,12 @@ class Asciidoctor::Document < Asciidoctor::AbstractBlock
     now = Time.new
     @attributes['localdate'] ||= now.strftime('%Y-%m-%d')
     @attributes['localtime'] ||= now.strftime('%H:%m:%S %Z')
-    @attributes['localdatetime'] ||= [@attributes['localdate'], @attributes['localtime']].join(' ')
+    @attributes['localdatetime'] ||= [@attributes['localdate'], @attributes['localtime']] * ' '
     
-    # docdate and doctime should default to localdate and localtime if not otherwise set
+    # docdate and doctime default to localdate and localtime if not otherwise set
     @attributes['docdate'] ||= @attributes['localdate']
     @attributes['doctime'] ||= @attributes['localtime']
+    @attributes['docdatetime'] ||= [@attributes['localdate'], @attributes['localtime']] * ' '
     
     @attributes['iconsdir'] ||= File.join(@attributes.fetch('imagesdir', 'images'), 'icons')
 

--- a/lib/asciidoctor/section.rb
+++ b/lib/asciidoctor/section.rb
@@ -58,7 +58,7 @@ class Asciidoctor::Section < Asciidoctor::AbstractBlock
   #   another_section.generate_id
   #   => "_foo_1"
   def generate_id
-    if @document.attr?('sectids')
+    if @document.attr? 'sectids'
       base_id = @document.attr('idprefix', '_') + title.downcase.gsub(/&#[0-9]+;/, '_').
           gsub(/\W+/, '_').tr_s('_', '_').gsub(/^_?(.*?)_?$/, '\1')
       gen_id = base_id
@@ -67,7 +67,7 @@ class Asciidoctor::Section < Asciidoctor::AbstractBlock
         gen_id = "#{base_id}_#{cnt}" 
         cnt += 1
       end 
-      @document.references[:ids][gen_id] = title
+      @document.register(:ids, [gen_id, title])
       gen_id
     else
       nil

--- a/test/document_test.rb
+++ b/test/document_test.rb
@@ -45,7 +45,7 @@ context 'Document' do
       assert !renderer.nil?
       views = renderer.views
       assert !views.nil?
-      assert_equal 26, views.size
+      assert_equal 27, views.size
       assert views.has_key? 'document'
       assert views['document'].is_a?(Asciidoctor::HTML5::DocumentTemplate)
       assert_equal 'ERB', views['document'].eruby.to_s
@@ -61,7 +61,7 @@ context 'Document' do
       assert !renderer.nil?
       views = renderer.views
       assert !views.nil?
-      assert_equal 26, views.size
+      assert_equal 27, views.size
       assert views.has_key? 'document'
       assert views['document'].is_a?(Asciidoctor::DocBook45::DocumentTemplate)
       assert_equal 'ERB', views['document'].eruby.to_s


### PR DESCRIPTION
Add support for floating titles. Floating titles are basically just regular heading tags that don't appear in the table of contents.

AsciiDoc reserves the style name 'float' to mark a floating title, but I think a more accurate (and less confusing) name for this style is 'discrete', so I included it as an alternative.
