### PR TITLE
Add counters and figure, table and example captions

### DIFF
--- a/lib/asciidoctor.rb
+++ b/lib/asciidoctor.rb
@@ -159,7 +159,8 @@ module Asciidoctor
 
     # attribute reference
     # {foo}
-    :attr_ref         => /(\\?)\{(\w|\w[\w\-]*\w)(\\?)\}/,
+    # {counter:pcount:1}
+    :attr_ref         => /(\\?)\{(\w|\w[\w\-:]*\w)(\\?)\}/,
 
     # The author info line the appears immediately following the document title
     # John Doe <john@anonymous.com>

--- a/lib/asciidoctor/backends/html5.rb
+++ b/lib/asciidoctor/backends/html5.rb
@@ -161,7 +161,7 @@ class BlockDlistTemplate < ::Asciidoctor::BaseTemplate
     @template ||= @eruby.new <<-EOS
 <%#encoding:UTF-8%>
 <div#{id} class="dlist#{style_class}">
-  <% if title %>
+  <% if title? %>
   <div class="title"><%= title %></div>
   <% end %>
   <dl>
@@ -191,7 +191,7 @@ class BlockListingTemplate < ::Asciidoctor::BaseTemplate
     @template ||= @eruby.new <<-EOS
 <%#encoding:UTF-8%>
 <div#{id} class="listingblock#{style_class}">
-  <% if title %>
+  <% if title? %>
   <div class="title"><%= title %></div>
   <% end %>
   <div class="content monospaced">
@@ -211,7 +211,7 @@ class BlockLiteralTemplate < ::Asciidoctor::BaseTemplate
     @template ||= @eruby.new <<-EOS
 <%#encoding:UTF-8%>
 <div#{id} class="literalblock#{style_class}">
-  <% if title %>
+  <% if title? %>
   <div class="title"><%= title %></div>
   <% end %>
   <div class="content monospaced">
@@ -237,7 +237,7 @@ class BlockAdmonitionTemplate < ::Asciidoctor::BaseTemplate
         <% end %>
       </td>
       <td class="content">
-        <% unless title.nil? %>
+        <% if title? %>
         <div class="title"><%= title %></div>
         <% end %>
         <%= content %>
@@ -254,7 +254,7 @@ class BlockParagraphTemplate < ::Asciidoctor::BaseTemplate
     @template ||= @eruby.new <<-EOS
 <%#encoding:UTF-8%>
 <div#{id} class="paragraph#{style_class}">
-  <% unless title.nil? %>
+  <% if title? %>
   <div class="title"><%= title %></div>
   <% end %>
   <p><%= content %></p>
@@ -269,7 +269,7 @@ class BlockSidebarTemplate < ::Asciidoctor::BaseTemplate
 <%#encoding:UTF-8%>
 <div#{id} class="sidebarblock#{style_class}">
   <div class="content">
-    <% unless title.nil? %>
+    <% if title? %>
     <div class="title"><%= title %></div>
     <% end %>
 <%= content %>
@@ -284,10 +284,10 @@ class BlockExampleTemplate < ::Asciidoctor::BaseTemplate
     @template ||= @eruby.new <<-EOS
 <%#encoding:UTF-8%>
 <div#{id} class="exampleblock#{style_class}">
+  <% if title? %>
+  <div class="title"><% unless @caption.nil? %><%= @caption %><% end %><%= title %></div>
+  <% end %>
   <div class="content">
-    <% unless title.nil? %>
-    <div class="title"><%= title %></div>
-    <% end %>
 <%= content %>
   </div>
 </div>
@@ -300,7 +300,7 @@ class BlockOpenTemplate < ::Asciidoctor::BaseTemplate
     @template ||= @eruby.new <<-EOS
 <%#encoding:UTF-8%>
 <div#{id} class="openblock#{style_class}">
-  <% unless title.nil? %>
+  <% if title? %>
   <div class="title"><%= title %></div>
   <% end %>
   <div class="content">
@@ -325,7 +325,7 @@ class BlockQuoteTemplate < ::Asciidoctor::BaseTemplate
     @template ||= @eruby.new <<-EOS
 <%#encoding:UTF-8%>
 <div#{id} class="quoteblock#{style_class}">
-  <% unless title.nil? %>
+  <% if title? %>
   <div class="title"><%= title %></div>
   <% end %>
   <div class="content">
@@ -352,7 +352,7 @@ class BlockVerseTemplate < ::Asciidoctor::BaseTemplate
     @template ||= @eruby.new <<-EOS
 <%#encoding:UTF-8%>
 <div#{id} class="verseblock#{style_class}">
-  <% unless title.nil? %>
+  <% if title? %>
   <div class="title"><%= title %></div>
   <% end %>
   <pre class="content"><%= template.preserve_endlines(content, self) %></pre>
@@ -377,7 +377,7 @@ class BlockUlistTemplate < ::Asciidoctor::BaseTemplate
     @template ||= @eruby.new <<-EOS
 <%#encoding:UTF-8%>
 <div#{id} class="ulist#{attrvalue(:style)}#{style_class}">
-  <% unless title.nil? %>
+  <% if title? %>
   <div class="title"><%= title %></div>
   <% end %>
   <ul>
@@ -400,7 +400,7 @@ class BlockOlistTemplate < ::Asciidoctor::BaseTemplate
     @template ||= @eruby.new <<-EOS
 <%#encoding:UTF-8%>
 <div#{id} class="olist <%= attr :style %>#{style_class}">
-  <% unless title.nil? %>
+  <% if title? %>
   <div class="title"><%= title %></div>
   <% end %>
   <ol class="<%= attr :style %>"#{attribute('start', :start)}>
@@ -423,7 +423,7 @@ class BlockColistTemplate < ::Asciidoctor::BaseTemplate
     @template ||= @eruby.new <<-EOS
 <%#encoding:UTF-8%>
 <div#{id} class="colist <%= attr :style %>#{style_class}">
-  <% unless title.nil? %>
+  <% if title? %>
   <div class="title"><%= title %></div>
   <% end %>
   <ol>
@@ -446,7 +446,7 @@ class BlockTableTemplate < ::Asciidoctor::BaseTemplate
 if !(attr? 'autowidth-option') %>width: <%= attr :tablepcwidth %>%; <% end %><%
 if attr? :float %>float: <%= attr :float %>; <% end %>">
   <% if title? %>
-  <caption class="title"><%= title %></caption>
+  <caption class="title"><% unless @caption.nil? %><%= @caption %><% end %><%= title %></caption>
   <% end %>
   <% if (attr :rowcount) >= 0 %> 
   <colgroup>
@@ -497,8 +497,8 @@ class BlockImageTemplate < ::Asciidoctor::BaseTemplate
     <img src="<%= image_uri(attr :target) %>" alt="<%= attr :alt %>"#{attribute('width', :width)}#{attribute('height', :height)}>
     <% end %>
   </div>
-  <% if title %>
-  <div class="title"><%= title %></div>
+  <% if title? %>
+  <div class="title"><% unless @caption.nil? %><%= @caption %><% end %><%= title %></div>
   <% end %>
 </div>
     EOS

--- a/lib/asciidoctor/document.rb
+++ b/lib/asciidoctor/document.rb
@@ -48,6 +48,9 @@ class Asciidoctor::Document < Asciidoctor::AbstractBlock
   # Public: Get the Hash of document references
   attr_reader :references
 
+  # Public: Get the Hash of document counters
+  attr_reader :counters
+
   # Public: Get the Hash of callouts
   attr_reader :callouts
 
@@ -93,6 +96,7 @@ class Asciidoctor::Document < Asciidoctor::AbstractBlock
       :links => [],
       :images => []
     }
+    @counters = {}
     @callouts = Callouts.new
     @options = options
     @safe = @options.fetch(:safe, SafeMode::SECURE).to_i
@@ -173,6 +177,47 @@ class Asciidoctor::Document < Asciidoctor::AbstractBlock
       }
       msg * "\n"
     }
+  end
+
+  # Public: Get the named counter and take the next number in the sequence.
+  #
+  # name  - the String name of the counter
+  # seed  - the initial value as a String or Integer
+  #
+  # returns the next number in the sequence for the specified counter
+  def counter(name, seed = nil)
+    if !@counters.has_key? name
+      if seed.nil?
+        seed = nextval(@attributes.has_key?(name) ? @attributes[name] : 0)
+      elsif seed.to_i.to_s == seed
+        seed = seed.to_i
+      end
+      @counters[name] = seed
+    else
+      @counters[name] = nextval(@counters[name])
+    end
+
+    (@attributes[name] = @counters[name])
+  end
+
+  # Internal: Get the next value in the sequence.
+  #
+  # Handles both integer and character sequences.
+  #
+  # current - the value to increment as a String or Integer
+  #
+  # returns the next value in the sequence according to the current value's type
+  def nextval(current)
+    if current.is_a?(Integer)
+      current + 1
+    else
+      intval = current.to_i
+      if intval.to_s != current.to_s
+        (current[0].ord + 1).chr
+      else
+        intval + 1 
+      end
+    end
   end
 
   def register(type, value)

--- a/lib/asciidoctor/lexer.rb
+++ b/lib/asciidoctor/lexer.rb
@@ -236,8 +236,6 @@ class Asciidoctor::Lexer
     document = parent.document
     context = parent.is_a?(Block) ? parent.context : nil
     block = nil
-    title = nil
-    caption = nil
 
     while reader.has_lines? && block.nil?
       if parse_metadata && parse_block_metadata_line(reader, document, attributes, options)
@@ -275,6 +273,11 @@ class Asciidoctor::Lexer
           attributes['target'] = target
           document.register(:images, target)
           attributes['alt'] ||= File.basename(target, File.extname(target))
+          # hmmm, this assignment seems like a one-off
+          block.title = attributes['title']
+          if block.title? && attributes['caption'].to_s.empty?
+            attributes['caption'] = "Figure #{document.counter('figure-number')}. "
+          end
         else
           # drop the line if target resolves to nothing
           block = nil
@@ -369,6 +372,11 @@ class Asciidoctor::Lexer
         AttributeList.rekey(attributes, ['style'])
         table_reader = Reader.new reader.grab_lines_until(:terminator => terminator, :skip_line_comments => true)
         block = next_table(table_reader, parent, attributes)
+        # hmmm, this assignment seems like a one-off
+        block.title = attributes['title']
+        if block.title? && attributes['caption'].to_s.empty?
+          attributes['caption'] = "Table #{document.counter('table-number')}. "
+        end
     
       # FIXME violates DRY because it's a duplication of other block parsing
       elsif delimited_blk && (match = this_line.match(REGEXP[:example]))
@@ -381,6 +389,11 @@ class Asciidoctor::Lexer
           attributes['caption'] ||= admonition_style.capitalize
         else
           block = Block.new(parent, :example)
+          # hmmm, this assignment seems like a one-off
+          block.title = attributes['title']
+          if block.title? && attributes['caption'].to_s.empty?
+            attributes['caption'] = "Example #{document.counter('example-number')}. "
+          end
         end
         buffer = Reader.new reader.grab_lines_until(:terminator => terminator)
 
@@ -524,8 +537,8 @@ class Asciidoctor::Lexer
     # so handle accordingly
     if !block.nil?
       block.id        = attributes['id'] if attributes.has_key?('id')
-      block.title   ||= (attributes['title'] || title)
-      block.caption ||= caption unless block.is_a?(Section)
+      block.title     = attributes['title'] unless block.title?
+      block.caption ||= attributes['caption'] unless block.is_a?(Section)
       # AsciiDoc always use [id] as the reftext in HTML output,
       # but I'd like to do better in Asciidoctor
       if block.id && block.title? && !attributes.has_key?('reftext')

--- a/lib/asciidoctor/substituters.rb
+++ b/lib/asciidoctor/substituters.rb
@@ -250,14 +250,24 @@ module Asciidoctor
         reject = false
         subject = line.dup
         subject.gsub!(REGEXP[:attr_ref]) {
+          # alias match for Ruby 1.8.7 compat
+          m = $~
+          # escaped attribute
           if !$1.empty? || !$3.empty?
             "{#$2}"
-          elsif document.attributes.has_key? $2
-            document.attributes[$2]
-          elsif INTRINSICS.has_key? $2
-            INTRINSICS[$2]
+          elsif m[2].start_with?('counter:')
+            args = m[2].split(':')
+            @document.counter(args[1], args[2]) 
+          elsif m[2].start_with?('counter2:')
+            args = m[2].split(':')
+            @document.counter(args[1], args[2]) 
+            ''
+          elsif document.attributes.has_key? m[2]
+            @document.attributes[m[2]]
+          elsif INTRINSICS.has_key? m[2]
+            INTRINSICS[m[2]]
           else
-            Asciidoctor.debug { "Missing attribute: #$2, line marked for removal" }
+            Asciidoctor.debug { "Missing attribute: #{m[2]}, line marked for removal" }
             reject = true
             break '{undefined}'
           end

--- a/test/attributes_test.rb
+++ b/test/attributes_test.rb
@@ -241,6 +241,78 @@ of the attribute named foo in your document.
       html = render_string('<node>&</node>')
       assert_match(/&lt;node&gt;&amp;&lt;\/node&gt;/, html)
     end
+
+    test 'creates counter' do
+      input = <<-EOS
+{counter:mycounter}
+      EOS
+
+      doc = document_from_string input
+      output = doc.render
+      assert_equal 1, doc.attributes['mycounter']
+      assert_xpath '//p[text()="1"]', output, 1
+    end
+
+    test 'creates counter silently' do
+      input = <<-EOS
+{counter2:mycounter}
+      EOS
+
+      doc = document_from_string input
+      output = doc.render
+      assert_equal 1, doc.attributes['mycounter']
+      assert_xpath '//p[text()="1"]', output, 0
+    end
+
+    test 'creates counter with numeric seed value' do
+      input = <<-EOS
+{counter2:mycounter:10}
+      EOS
+
+      doc = document_from_string input
+      doc.render
+      assert_equal 10, doc.attributes['mycounter']
+    end
+
+    test 'creates counter with character seed value' do
+      input = <<-EOS
+{counter2:mycounter:A}
+      EOS
+
+      doc = document_from_string input
+      doc.render
+      assert_equal 'A', doc.attributes['mycounter']
+    end
+
+    test 'increments counter with numeric value' do
+      input = <<-EOS
+:mycounter: 1
+
+{counter:mycounter}
+
+{mycounter}
+      EOS
+
+      doc = document_from_string input
+      output = doc.render
+      assert_equal 2, doc.attributes['mycounter']
+      assert_xpath '//p[text()="2"]', output, 2
+    end
+
+    test 'increments counter with character value' do
+      input = <<-EOS
+:mycounter: @
+
+{counter:mycounter}
+
+{mycounter}
+      EOS
+
+      doc = document_from_string input
+      output = doc.render
+      assert_equal 'A', doc.attributes['mycounter']
+      assert_xpath '//p[text()="A"]', output, 2
+    end
     
   end
 

--- a/test/tables_test.rb
+++ b/test/tables_test.rb
@@ -39,7 +39,7 @@ context 'Tables' do
 |=======
       EOS
       output = render_embedded_string input
-      assert_xpath '/table/caption[@class="title"][text()="Simple psv table"]', output, 1
+      assert_xpath '/table/caption[@class="title"][text()="Table 1. Simple psv table"]', output, 1
       assert_xpath '/table/caption/following-sibling::colgroup', output, 1
     end
 
@@ -217,7 +217,7 @@ I am getting in shape!
       output = render_embedded_string input
       assert_css 'table', output, 1
       assert_css 'table[style~="width: 80%;"]', output, 1
-      assert_xpath '/table/caption[@class="title"][text()="Horizontal and vertical source data"]', output, 1
+      assert_xpath '/table/caption[@class="title"][text()="Table 1. Horizontal and vertical source data"]', output, 1
       assert_css 'table > colgroup > col', output, 4
       assert_css 'table > colgroup > col:nth-child(1)[@style~="width: 17%;"]', output, 1
       assert_css 'table > colgroup > col:nth-child(2)[@style~="width: 11%;"]', output, 1


### PR DESCRIPTION
- add a counter facility
- use counter to create synthetic captions for block images, tables and example blocks
- support creating, incrementing and reading counters from attributes
- tests and TomDoc
- optimize the checks for block title in the HTML5 templates
