### PR TITLE
Fix merge errors, clean outfile, return absolute path from fixture_path

### DIFF
--- a/lib/asciidoctor.rb
+++ b/lib/asciidoctor.rb
@@ -569,7 +569,7 @@ module Asciidoctor
     if in_place && input.is_a?(File)
       to_file = File.join(File.dirname(input.path), "#{doc.attributes['docname']}#{doc.attributes['outfilesuffix']}")
     elsif to_file
-      to_file = File.absolute_path(to_file, doc.base_dir) 
+      to_file = doc.normalize_asset_path(to_file)
       if !File.directory?(File.dirname(to_file))
         to_file = nil
       end

--- a/lib/asciidoctor/document.rb
+++ b/lib/asciidoctor/document.rb
@@ -130,8 +130,6 @@ class Asciidoctor::Document < Asciidoctor::AbstractBlock
       @base_dir = attribute_overrides['docdir'] = File.expand_path(options[:base_dir])
     end
 
-    # restrict document from setting source-highlighter or backend in SECURE
-    # safe mode; can only be set via the constructor
     if @safe >= SafeMode::SECURE
       # restrict document from setting source-highlighter or backend
       attribute_overrides['source-highlighter'] ||= nil
@@ -165,8 +163,6 @@ class Asciidoctor::Document < Asciidoctor::AbstractBlock
     end
 
     # dynamic intrinstic attribute values
-    @attributes['doctype'] ||= DEFAULT_DOCTYPE
-
     now = Time.new
     @attributes['localdate'] ||= now.strftime('%Y-%m-%d')
     @attributes['localtime'] ||= now.strftime('%H:%M:%S %Z')

--- a/test/blocks_test.rb
+++ b/test/blocks_test.rb
@@ -549,7 +549,7 @@ You can use icons for admonitions by setting the 'icons' attribute.
       input = <<-EOS
 image::asciidoctor.png[Asciidoctor]
       EOS
-      basedir = File.dirname(Pathname.new(__FILE__).realpath)
+      basedir = File.expand_path File.dirname(__FILE__)
       block = block_from_string input, :attributes => {'docdir' => basedir}
       doc = block.document
       assert doc.safe >= Asciidoctor::SafeMode::SAFE
@@ -563,7 +563,7 @@ image::asciidoctor.png[Asciidoctor]
       input = <<-EOS
 image::asciidoctor.png[Asciidoctor]
       EOS
-      basedir = File.dirname(Pathname.new(__FILE__).realpath)
+      basedir = File.expand_path File.dirname(__FILE__)
       block = block_from_string input, :safe => Asciidoctor::SafeMode::UNSAFE, :attributes => {'docdir' => basedir}
       doc = block.document
       assert doc.safe == Asciidoctor::SafeMode::UNSAFE

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -30,7 +30,7 @@ class Test::Unit::TestCase
   end
 
   def fixture_path(name)
-    File.join(File.dirname(__FILE__), 'fixtures', name)
+    File.join(File.expand_path(File.dirname(__FILE__)), 'fixtures', name)
   end
 
   def example_document(name)


### PR DESCRIPTION
This patch corrects the failing test in Ruby 1.8.7, among other things.
