### PR TITLE
Fix toc when doctype is book

### DIFF
--- a/lib/asciidoctor/backends/html5.rb
+++ b/lib/asciidoctor/backends/html5.rb
@@ -24,7 +24,7 @@ class DocumentTemplate < ::Asciidoctor::BaseTemplate
       end
       toc_level << "#{indent}<ol>\n" if nested
       sections.each do |section|
-        toc_level << "#{indent}  <li><a href=\"##{section.id}\">#{section.level > 0 ? section.sectnum('.', ' ') : ''}#{section.title}</a></li>\n"
+        toc_level << "#{indent}  <li><a href=\"##{section.id}\">#{section.level > 0 ? section.sectnum('.', '. ') : ''}#{section.title}</a></li>\n"
         if section.level < to_depth && (child_toc_level = render_outline(section, to_depth))
           if section.document.doctype != 'book' || section.level > 0
             toc_level << "#{indent}  <li>\n#{child_toc_level}\n#{indent}  </li>\n"


### PR DESCRIPTION
Was previously assigning a number to the level-0 section and nesting the toc inside...which is not consistent w/ the toc in asciidoc. The level-0 section should be flat.
