### PR TITLE
Resolve issue #69, enable warnings when running tests; fix warnings

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -49,6 +49,7 @@ require 'rake/testtask'
 Rake::TestTask.new(:test) do |test|
   test.libs << 'lib' << 'test'
   test.pattern = 'test/**/*_test.rb'
+  test.warning = true
   test.verbose = true
 end
 

--- a/lib/asciidoctor/cli/invoker.rb
+++ b/lib/asciidoctor/cli/invoker.rb
@@ -50,7 +50,7 @@ module Asciidoctor
           if @options[:verbose]
             puts "Time to read and parse source: #{timings[:parse]}"
             puts "Time to render document: #{timings[:render]}"
-            puts "Total time to read, parse and render: #{timings.reduce(0) {|sum, (k, v)| sum += v}}"
+            puts "Total time to read, parse and render: #{timings.reduce(0) {|sum, (_, v)| sum += v}}"
           end
           if outfile == '/dev/null'
             # output nothing

--- a/lib/asciidoctor/cli/options.rb
+++ b/lib/asciidoctor/cli/options.rb
@@ -32,7 +32,7 @@ module Asciidoctor
       end
 
       def parse!(args)
-        opts = OptionParser.new do |opts|
+        opts_parser = OptionParser.new do |opts|
           opts.banner = <<-EOS
 Usage: asciidoctor [OPTION]... [FILE]
 Translate the AsciiDoc source FILE into the backend output format (e.g., HTML 5, DocBook 4.5, etc.)
@@ -113,7 +113,7 @@ Example: asciidoctor -b html5 source.asciidoc
         end
 
         begin
-          opts.parse!(args)
+          opts_parser.parse!(args)
           if args.size > 1
             $stderr.puts 'asciidoctor: FAILED: too many arguments'
             return 1
@@ -121,7 +121,7 @@ Example: asciidoctor -b html5 source.asciidoc
 
           self[:input_file] = args.first
           if self[:input_file].nil? || self[:input_file].empty?
-            $stdout.puts opts
+            $stdout.puts opts_parser
             return 0
             #exit
           # should we be doing this check in the options parser?
@@ -132,7 +132,7 @@ Example: asciidoctor -b html5 source.asciidoc
           end
         rescue OptionParser::InvalidOption, OptionParser::MissingArgument
           $stderr.puts $!.to_s
-          $stdout.puts opts
+          $stdout.puts opts_parser
           return 1
           #exit
         end

--- a/test/reader_test.rb
+++ b/test/reader_test.rb
@@ -231,7 +231,7 @@ include::include-file.asciidoc[]
   context 'build secure asset path' do
     test 'allows us to specify a path relative to the current dir' do
       doc = Asciidoctor::Document.new
-      reader = Asciidoctor::Reader.new(["foo"], doc)
+      Asciidoctor::Reader.new(["foo"], doc)
       legit_path = Dir.pwd + "/foo"
       assert_equal legit_path, doc.normalize_asset_path(legit_path)
     end
@@ -239,7 +239,7 @@ include::include-file.asciidoc[]
     test "keeps naughty absolute paths from getting outside" do
       naughty_path = "#{disk_root}etc/passwd"
       doc = Asciidoctor::Document.new
-      reader = Asciidoctor::Reader.new(["foo"], doc)
+      Asciidoctor::Reader.new(["foo"], doc)
       secure_path = doc.normalize_asset_path(naughty_path)
       assert naughty_path != secure_path
       assert_match(/^#{doc.base_dir}/, secure_path)
@@ -248,7 +248,7 @@ include::include-file.asciidoc[]
     test "keeps naughty relative paths from getting outside" do
       naughty_path = "safe/ok/../../../../../etc/passwd"
       doc = Asciidoctor::Document.new
-      reader = Asciidoctor::Reader.new(["foo"], doc)
+      Asciidoctor::Reader.new(["foo"], doc)
       secure_path = doc.normalize_asset_path(naughty_path)
       assert naughty_path != secure_path
       assert_match(/^#{doc.base_dir}/, secure_path)

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -158,7 +158,7 @@ class Test::Unit::TestCase
     if buffers
       invoker.redirect_streams(*buffers)
     end
-    invoker.invoke! &block
+    invoker.invoke!(&block)
     invoker
   end
 


### PR DESCRIPTION
I don't see any reason to not have warnings enabled for the test suite. It's especially useful when looking at the Travis CI output. I always find something.
