### PR TITLE
Restrict document from enabling icons in SECURE mode

### DIFF
--- a/lib/asciidoctor/document.rb
+++ b/lib/asciidoctor/document.rb
@@ -140,7 +140,7 @@ class Asciidoctor::Document < Asciidoctor::AbstractBlock
     end
 
     if @safe >= SafeMode::SERVER
-      # restrict document from setting source-highlighter or backend
+      # restrict document from setting source-highlighter and backend
       attribute_overrides['source-highlighter'] ||= nil
       attribute_overrides['backend'] ||= DEFAULT_BACKEND
       # restrict document from seeing the docdir and trim docfile to relative path
@@ -148,6 +148,10 @@ class Asciidoctor::Document < Asciidoctor::AbstractBlock
         attribute_overrides['docfile'] = attribute_overrides['docfile'][(attribute_overrides['docdir'].length + 1)..-1]
       end
       attribute_overrides['docdir'] = ''
+      # restrict document from enabling icons
+      if @safe >= SafeMode::SECURE
+        attribute_overrides['icons'] ||= nil
+      end
     end
     
     attribute_overrides.delete_if {|key, val|

--- a/test/blocks_test.rb
+++ b/test/blocks_test.rb
@@ -496,7 +496,7 @@ image::dot.gif[Dot]
 You can use icons for admonitions by setting the 'icons' attribute.
       EOS
 
-      output = render_string input
+      output = render_string input, :safe => Asciidoctor::SafeMode::SERVER
       assert_xpath '//*[@class="admonitionblock"]//*[@class="icon"]/img[@src="images/icons/tip.png"][@alt="Tip"]', output, 1
     end
 
@@ -509,7 +509,7 @@ You can use icons for admonitions by setting the 'icons' attribute.
 You can use icons for admonitions by setting the 'icons' attribute.
       EOS
 
-      output = render_string input
+      output = render_string input, :safe => Asciidoctor::SafeMode::SERVER
       assert_xpath '//*[@class="admonitionblock"]//*[@class="icon"]/img[@src="icons/tip.png"][@alt="Tip"]', output, 1
     end
 
@@ -539,7 +539,7 @@ You can use icons for admonitions by setting the 'icons' attribute.
 You can use icons for admonitions by setting the 'icons' attribute.
       EOS
 
-      output = render_string input
+      output = render_string input, :attributes => {'icons' => ''}
       assert_xpath '//*[@class="admonitionblock"]//*[@class="icon"]/img[@src="fixtures/tip.gif"][@alt="Tip"]', output, 1
     end
 


### PR DESCRIPTION
I think we want to restrict the document from turning on icons (which in SECURE mode are really just `<img>` tags with a relative src). Does this sound like sensible restriction?

Icons can be enabled in the server-side application by the application developer.
