### PR TITLE
Resolve issue #119, add hardbreaks option

### DIFF
--- a/lib/asciidoctor.rb
+++ b/lib/asciidoctor.rb
@@ -139,7 +139,7 @@ module Asciidoctor
   # Pattern:
   # (?:\[((?:\\\]|[^\]])*?)\])
   # Matches:
-  # [enclosed text here] or [enclosed text here]
+  # [enclosed text here] or [enclosed [text\] here]
   REGEXP = {
     # [[Foo]]
     :anchor           => /^\[\[([^\[\]]+)\]\]\s*$/,

--- a/lib/asciidoctor/substituters.rb
+++ b/lib/asciidoctor/substituters.rb
@@ -487,7 +487,14 @@ module Asciidoctor
     #
     # returns The String with the post replacements rendered using the backend templates
     def sub_post_replacements(text)
-      text.gsub(REGEXP[:line_break]) { Inline.new(self, :break, $1, :type => :line).render }
+      if @document.attr? 'hardbreaks'
+        lines = text.lines.entries
+        return text if lines.size == 1
+        last = lines.pop
+        "#{lines.map {|line| Inline.new(self, :break, line.rstrip.chomp(' +'), :type => :line).render } * "\n"}\n#{last}"
+      else
+        text.gsub(REGEXP[:line_break]) { Inline.new(self, :break, $1, :type => :line).render }
+      end
     end
 
     # Internal: Transform (render) a quoted text region

--- a/test/substitutions_test.rb
+++ b/test/substitutions_test.rb
@@ -413,7 +413,7 @@ context 'Substitutions' do
       end
     end
 
-    test 'a single-line primary index term macro with primary and secondary terms should be registered as an index reference' do
+    test 'a single-line index term macro with primary and secondary terms should be registered as an index reference' do
       sentence = "The tiger (Panthera tigris) is the largest cat species.\n"
       macros = ['indexterm:[Big cats, Tigers]', '(((Big cats, Tigers)))']
       macros.each do |macro|
@@ -425,7 +425,7 @@ context 'Substitutions' do
       end
     end
 
-    test 'a single-line primary index term macro with primary, secondary and tertiary terms should be registered as an index reference' do
+    test 'a single-line index term macro with primary, secondary and tertiary terms should be registered as an index reference' do
       sentence = "The tiger (Panthera tigris) is the largest cat species.\n"
       macros = ['indexterm:[Big cats,Tigers , Panthera tigris]', '(((Big cats,Tigers , Panthera tigris)))']
       macros.each do |macro|
@@ -619,10 +619,28 @@ context 'Substitutions' do
   end
 
   context 'Post replacements' do
-    test 'line break' do
+    test 'line break inserted after line with line break character' do
       para = block_from_string("First line +\nSecond line")
       result = para.apply_subs(para.buffer, :post_replacements)
       assert_equal "First line<br>\n", result.first
+    end
+
+    test 'line break inserted after line wrap with hardbreaks enabled' do
+      para = block_from_string("First line\nSecond line", :attributes => {'hardbreaks' => ''})
+      result = para.apply_subs(para.buffer, :post_replacements)
+      assert_equal "First line<br>\n", result.first
+    end
+
+    test 'line break character stripped from end of line with hardbreaks enabled' do
+      para = block_from_string("First line +\nSecond line", :attributes => {'hardbreaks' => ''})
+      result = para.apply_subs(para.buffer, :post_replacements)
+      assert_equal "First line<br>\n", result.first
+    end
+
+    test 'line break not inserted for single line with hardbreaks enabled' do
+      para = block_from_string("First line", :attributes => {'hardbreaks' => ''})
+      result = para.apply_subs(para.buffer, :post_replacements)
+      assert_equal "First line", result.first
     end
   end
 end


### PR DESCRIPTION
Turns out this was a really easy feature to implement, so I went ahead and did it.

I call this the "make the GFM crowd happy" feature :wink: 

I applied the replacement where line break characters are normally substituted. If we find that it's putting line breaks in too many places, we can always scale it back.

...note that this does slow down processing a pinch...0.05s on the AsciiDoc User Guide. But that's also because the User Guide hard wraps just about every single line of paragraph text.
