### PR TITLE
Cleanup templates, reoptimize macro subs, fixes & tests

### DIFF
--- a/lib/asciidoctor.rb
+++ b/lib/asciidoctor.rb
@@ -253,7 +253,7 @@ module Asciidoctor
     # image::filename.png[Caption]
     :image_blk        => /^image::(\S+?)\[(.*?)\]\s*$/,
 
-    # image:filename.png[Alt]
+    # image:filename.png[Alt Text]
     :image_macro      => /\\?image:([^\[]+)(?:\[([^\]]*)\])/,
 
     # indexterm:[Tigers,Big cats]
@@ -278,7 +278,7 @@ module Asciidoctor
 
     # inline link and some inline link macro
     # FIXME revisit!
-    :link_inline      => %r{(^|link:|\s|>|&lt;|[\(\)\]])(\\?https?://[^\[ ]*[^\. \)\[])(?:\[((?:\\\]|[^\]])*?)\])?},
+    :link_inline      => %r{(^|link:|\s|>|&lt;|[\(\)\[\]])(\\?https?://[^\[ ]*[^\. \)\[])(?:\[((?:\\\]|[^\]])*?)\])?},
 
     # inline link macro
     # link:path[label]
@@ -528,7 +528,7 @@ module Asciidoctor
     # and so on...
     
     # restore entities; TODO needs cleanup
-    [/&amp;(#[a-z0-9]+;)/i, '&\1']
+    [/(^|[^\\])&amp;(#[a-z0-9]+;)/i, '\1&\2']
   ]
 
   # Public: Parse the AsciiDoc source input into an Asciidoctor::Document

--- a/lib/asciidoctor/attribute_list.rb
+++ b/lib/asciidoctor/attribute_list.rb
@@ -179,6 +179,12 @@ class Asciidoctor::AttributeList
   end
 
   def parse_attribute_value(quote)
+    # empty quoted value
+    if @scanner.peek(1) == quote
+      @scanner.get_byte 
+      return ''
+    end
+
     value = scan_to_quote quote
     if value.nil?
       quote + scan_to_delimiter

--- a/lib/asciidoctor/backends/base_template.rb
+++ b/lib/asciidoctor/backends/base_template.rb
@@ -75,13 +75,12 @@ class Asciidoctor::BaseTemplate
   # create template matter to insert an attribute if the variable has a value
   def attribute(name, key)
     type = key.is_a?(Symbol) ? :attr : :var
-    key = key.to_s
     if type == :attr
       # example: <% if attr? 'foo' %> bar="<%= attr 'foo' %>"<% end %>
-      '<% if attr? \'' + key + '\' %> ' + name + '="<%= attr \'' + key.to_s + '\' %>"<% end %>'
+      %(<% if attr? '#{key}' %> #{name}="<%= attr '#{key}' %>"<% end %>)
     else
       # example: <% if foo %> bar="<%= foo %>"<% end %>
-      '<% if ' + key + ' %> ' + name + '="<%= ' + key + ' %>"<% end %>'
+      %(<% if #{key} %> #{name}="<%= #{key} %>"<% end %>)
     end
   end
 
@@ -89,7 +88,7 @@ class Asciidoctor::BaseTemplate
   def attrvalue(key, sibling = true)
     delimiter = sibling ? ' ' : ''
     # example: <% if attr? 'foo' %><%= attr 'foo' %><% end %>
-    '<% if attr? \'' + key.to_s + '\' %>' + delimiter + '<%= attr \'' + key.to_s + '\' %><% end %>'
+    %(<% if attr? '#{key}' %>#{delimiter}<%= attr '#{key}' %><% end %>)
   end
 
   # create template matter to insert an id if one is specified for the block

--- a/lib/asciidoctor/backends/docbook45.rb
+++ b/lib/asciidoctor/backends/docbook45.rb
@@ -16,10 +16,10 @@ class Asciidoctor::BaseTemplate
     key = key.to_s
     if type == :attr
       # example: <% if attr? 'foo' %><bar><%= attr 'foo' %></bar><% end %>
-      '<% if attr? \'' + key + '\' %><' + name + '><%= attr \'' + key + '\' %></' + name + '><% end %>'
+      %(<% if attr? '#{key}' %><#{name}><%= attr '#{key}' %></#{name}><% end %>)
     else
       # example: <% unless foo.to_s.empty? %><bar><%= foo %></bar><% end %>
-      '<% unless ' + key + '.to_s.empty? %><' + name + '><%= ' + key + ' %></' + name + '><% end %>'
+      %(<% unless #{key}.to_s.empty? %><#{name}><%= #{key} %></#{name}><% end %>)
     end
   end
 end

--- a/lib/asciidoctor/backends/html5.rb
+++ b/lib/asciidoctor/backends/html5.rb
@@ -9,6 +9,10 @@ class Asciidoctor::BaseTemplate
   def style_class(sibling = true)
     attrvalue(:style, sibling)
   end
+
+  def title_div(opts = {})
+    %(<% if title? %><div class="title">#{opts.has_key?(:caption) ? '<% unless @caption.nil? %><%= @caption %><% end %>' : ''}<%= title %></div><% end %>)
+  end
 end
 
 module Asciidoctor::HTML5
@@ -196,9 +200,7 @@ class BlockDlistTemplate < ::Asciidoctor::BaseTemplate
 <%#encoding:UTF-8%>
 <% if (attr :style) == 'qanda' %>
 <div#{id} class="qlist#{style_class}#{role_class}">
-  <% if title? %>
-  <div class="title"><%= title %></div>
-  <% end %>
+  #{title_div}
   <ol>
   <% content.each do |dt, dd| %>
     <li>
@@ -217,9 +219,7 @@ class BlockDlistTemplate < ::Asciidoctor::BaseTemplate
 </div>
 <% else %>
 <div#{id} class="dlist#{style_class}#{role_class}">
-  <% if title? %>
-  <div class="title"><%= title %></div>
-  <% end %>
+  #{title_div}
   <dl>
     <% content.each do |dt, dd| %>
     <dt<% if !(attr? :style) %> class="hdlist1"<% end %>>
@@ -248,9 +248,7 @@ class BlockListingTemplate < ::Asciidoctor::BaseTemplate
     @template ||= @eruby.new <<-EOS
 <%#encoding:UTF-8%>
 <div#{id} class="listingblock#{role_class}">
-  <% if title? %>
-  <div class="title"><%= title %></div>
-  <% end %>
+  #{title_div}
   <div class="content monospaced">
     <% if (attr :style) == 'source' %>
     <pre class="highlight<% if attr('source-highlighter') == 'coderay' %> CodeRay<% end %>"><code#{attribute('class', :language)}><%= template.preserve_endlines(content, self) %></code></pre>
@@ -268,9 +266,7 @@ class BlockLiteralTemplate < ::Asciidoctor::BaseTemplate
     @template ||= @eruby.new <<-EOS
 <%#encoding:UTF-8%>
 <div#{id} class="literalblock#{role_class}">
-  <% if title? %>
-  <div class="title"><%= title %></div>
-  <% end %>
+  #{title_div}
   <div class="content monospaced">
     <pre><%= template.preserve_endlines(content, self) %></pre>
   </div>
@@ -294,9 +290,7 @@ class BlockAdmonitionTemplate < ::Asciidoctor::BaseTemplate
         <% end %>
       </td>
       <td class="content">
-        <% if title? %>
-        <div class="title"><%= title %></div>
-        <% end %>
+        #{title_div}
         <%= content %>
       </td>
     </tr>
@@ -311,9 +305,7 @@ class BlockParagraphTemplate < ::Asciidoctor::BaseTemplate
     @template ||= @eruby.new <<-EOS
 <%#encoding:UTF-8%>
 <div#{id} class="paragraph#{role_class}">
-  <% if title? %>
-  <div class="title"><%= title %></div>
-  <% end %>
+  #{title_div}
   <p><%= content %></p>
 </div>
     EOS
@@ -326,9 +318,7 @@ class BlockSidebarTemplate < ::Asciidoctor::BaseTemplate
 <%#encoding:UTF-8%>
 <div#{id} class="sidebarblock#{role_class}">
   <div class="content">
-    <% if title? %>
-    <div class="title"><%= title %></div>
-    <% end %>
+    #{title_div}
 <%= content %>
   </div>
 </div>
@@ -341,9 +331,7 @@ class BlockExampleTemplate < ::Asciidoctor::BaseTemplate
     @template ||= @eruby.new <<-EOS
 <%#encoding:UTF-8%>
 <div#{id} class="exampleblock#{role_class}">
-  <% if title? %>
-  <div class="title"><% unless @caption.nil? %><%= @caption %><% end %><%= title %></div>
-  <% end %>
+  #{title_div :caption => true}
   <div class="content">
 <%= content %>
   </div>
@@ -357,9 +345,7 @@ class BlockOpenTemplate < ::Asciidoctor::BaseTemplate
     @template ||= @eruby.new <<-EOS
 <%#encoding:UTF-8%>
 <div#{id} class="openblock#{role_class}">
-  <% if title? %>
-  <div class="title"><%= title %></div>
-  <% end %>
+  #{title_div}
   <div class="content">
 <%= content %>
   </div>
@@ -382,9 +368,7 @@ class BlockQuoteTemplate < ::Asciidoctor::BaseTemplate
     @template ||= @eruby.new <<-EOS
 <%#encoding:UTF-8%>
 <div#{id} class="quoteblock#{role_class}">
-  <% if title? %>
-  <div class="title"><%= title %></div>
-  <% end %>
+  #{title_div}
   <blockquote>
 <%= content %>
   </blockquote>
@@ -409,9 +393,7 @@ class BlockVerseTemplate < ::Asciidoctor::BaseTemplate
     @template ||= @eruby.new <<-EOS
 <%#encoding:UTF-8%>
 <div#{id} class="verseblock#{role_class}">
-  <% if title? %>
-  <div class="title"><%= title %></div>
-  <% end %>
+  #{title_div}
   <pre class="content"><%= template.preserve_endlines(content, self) %></pre>
   <div class="attribution">
     <% if attr? :citetitle %>
@@ -434,9 +416,7 @@ class BlockUlistTemplate < ::Asciidoctor::BaseTemplate
     @template ||= @eruby.new <<-EOS
 <%#encoding:UTF-8%>
 <div#{id} class="ulist#{style_class}#{role_class}">
-  <% if title? %>
-  <div class="title"><%= title %></div>
-  <% end %>
+  #{title_div}
   <ul>
   <% content.each do |li| %>
     <li>
@@ -457,9 +437,7 @@ class BlockOlistTemplate < ::Asciidoctor::BaseTemplate
     @template ||= @eruby.new <<-EOS
 <%#encoding:UTF-8%>
 <div#{id} class="olist#{style_class}#{role_class}">
-  <% if title? %>
-  <div class="title"><%= title %></div>
-  <% end %>
+  #{title_div}
   <ol class="<%= attr :style %>"#{attribute('start', :start)}>
   <% content.each do |li| %>
     <li>
@@ -480,9 +458,7 @@ class BlockColistTemplate < ::Asciidoctor::BaseTemplate
     @template ||= @eruby.new <<-EOS
 <%#encoding:UTF-8%>
 <div#{id} class="colist#{style_class}#{role_class}">
-  <% if title? %>
-  <div class="title"><%= title %></div>
-  <% end %>
+  #{title_div}
   <% if attr? :icons %>
   <table>
     <% content.each_with_index do |li, i| %>
@@ -565,9 +541,7 @@ class BlockImageTemplate < ::Asciidoctor::BaseTemplate
     <img src="<%= image_uri(attr :target) %>" alt="<%= attr :alt %>"#{attribute('width', :width)}#{attribute('height', :height)}>
     <% end %>
   </div>
-  <% if title? %>
-  <div class="title"><% unless @caption.nil? %><%= @caption %><% end %><%= title %></div>
-  <% end %>
+  #{title_div :caption => true}
 </div>
     EOS
   end

--- a/lib/asciidoctor/lexer.rb
+++ b/lib/asciidoctor/lexer.rb
@@ -276,7 +276,7 @@ class Asciidoctor::Lexer
           attributes['alt'] ||= File.basename(target, File.extname(target))
           # hmmm, this assignment seems like a one-off
           block.title = attributes['title']
-          if block.title? && attributes['caption'].to_s.empty?
+          if block.title? && attributes['caption'].nil?
             attributes['caption'] = "Figure #{document.counter('figure-number')}. "
           end
         else
@@ -376,7 +376,7 @@ class Asciidoctor::Lexer
         block = next_table(table_reader, parent, attributes)
         # hmmm, this assignment seems like a one-off
         block.title = attributes['title']
-        if block.title? && attributes['caption'].to_s.empty?
+        if block.title? && attributes['caption'].nil?
           attributes['caption'] = "Table #{document.counter('table-number')}. "
         end
     
@@ -393,7 +393,7 @@ class Asciidoctor::Lexer
           block = Block.new(parent, :example)
           # hmmm, this assignment seems like a one-off
           block.title = attributes['title']
-          if block.title? && attributes['caption'].to_s.empty?
+          if block.title? && attributes['caption'].nil?
             attributes['caption'] = "Example #{document.counter('example-number')}. "
           end
         end
@@ -993,7 +993,7 @@ class Asciidoctor::Lexer
       section.sectname = attributes[1]
       section.special = true
       if section.sectname == 'appendix'
-        attributes['caption'] = "Appendix #{parent.document.counter('appendix-number', 'A')}: "
+        attributes['caption'] ||= "Appendix #{parent.document.counter('appendix-number', 'A')}: "
       end
     else
       section.sectname = "sect#{section.level}"

--- a/lib/asciidoctor/reader.rb
+++ b/lib/asciidoctor/reader.rb
@@ -359,7 +359,7 @@ class Asciidoctor::Reader
       elsif !line.match(REGEXP[:endif_macro])
         while line.match(REGEXP[:attr_conditional])
           value = @document.attributes.has_key?($1) ? $2 : ''
-          line.sub!(conditional_regexp, value)
+          line.sub!(REGEXP[:attr_conditional], value)
         end
         # NOTE leave line comments in as they play a role in flow (such as a list divider)
         @lines << line

--- a/lib/asciidoctor/section.rb
+++ b/lib/asciidoctor/section.rb
@@ -70,12 +70,13 @@ class Asciidoctor::Section < Asciidoctor::AbstractBlock
   #   => "_foo_1"
   def generate_id
     if @document.attr? 'sectids'
-      base_id = @document.attr('idprefix', '_') + title.downcase.gsub(/&#[0-9]+;/, '_').
-          gsub(/\W+/, '_').tr_s('_', '_').gsub(/^_?(.*?)_?$/, '\1')
+      separator = @document.attr('idseparator', '_')
+      base_id = @document.attr('idprefix', '_') + title.downcase.gsub(/&#[0-9]+;/, separator).
+          gsub(/\W+/, separator).tr_s(separator, separator).chomp(separator)
       gen_id = base_id
       cnt = 2
       while @document.references[:ids].has_key? gen_id 
-        gen_id = "#{base_id}_#{cnt}" 
+        gen_id = "#{base_id}#{separator}#{cnt}" 
         cnt += 1
       end 
       @document.register(:ids, [gen_id, title])

--- a/lib/asciidoctor/table.rb
+++ b/lib/asciidoctor/table.rb
@@ -19,6 +19,7 @@ module Asciidoctor
     # Public: A Hash mapping styles abbreviations to styles that can be applied
     # to a table column or cell
     TEXT_STYLES = {
+      'd' => :none,
       's' => :strong,
       'e' => :emphasis,
       'm' => :monospaced,
@@ -407,8 +408,14 @@ module Asciidoctor
       @buffer = ''
       if format == 'psv'
         cell_spec = take_cell_spec
-        repeat = cell_spec.fetch('repeatcol', 1)
-        cell_spec.delete('repeatcol')
+        if cell_spec.nil?
+          puts 'asciidoctor: ERROR: table missing leading separator, recovering automatically'
+          cell_spec = {}
+          repeat = 1
+        else
+          repeat = cell_spec.fetch('repeatcol', 1)
+          cell_spec.delete('repeatcol')
+        end
       else
         cell_spec = nil
         repeat = 1

--- a/test/lexer_test.rb
+++ b/test/lexer_test.rb
@@ -23,6 +23,14 @@ context "Lexer" do
     assert_equal expected, attributes
   end
 
+  test "collect empty unnamed attribute double-quoted" do
+    attributes = {}
+    line = '""'
+    expected = {1 => ''}
+    Asciidoctor::AttributeList.new(line).parse_into(attributes)
+    assert_equal expected, attributes
+  end
+
   test "collect unnamed attribute double-quoted containing escaped quote" do
     attributes = {}
     line = '"ba\"zaar"'
@@ -35,6 +43,14 @@ context "Lexer" do
     attributes = {}
     line = '\'quote\''
     expected = {1 => 'quote'}
+    Asciidoctor::AttributeList.new(line).parse_into(attributes)
+    assert_equal expected, attributes
+  end
+
+  test "collect empty unnamed attribute single-quoted" do
+    attributes = {}
+    line = '\'\''
+    expected = {1 => ''}
     Asciidoctor::AttributeList.new(line).parse_into(attributes)
     assert_equal expected, attributes
   end
@@ -79,12 +95,28 @@ context "Lexer" do
     assert_equal expected, attributes
   end
 
+  test 'collect named attribute with double-quoted empty value' do
+    attributes = {}
+    line = 'height=100,caption="",link="images/octocat.png"'
+    expected = {'height' => '100', 'caption' => '', 'link' => 'images/octocat.png'}
+    Asciidoctor::AttributeList.new(line).parse_into(attributes)
+    assert_equal expected, attributes 
+  end
+
   test "collect named attribute single-quoted" do
     attributes = {}
     line = 'foo=\'bar\''
     expected = {'foo' => 'bar'}
     Asciidoctor::AttributeList.new(line).parse_into(attributes)
     assert_equal expected, attributes
+  end
+
+  test 'collect named attribute with single-quoted empty value' do
+    attributes = {}
+    line = "height=100,caption='',link='images/octocat.png'"
+    expected = {'height' => '100', 'caption' => '', 'link' => 'images/octocat.png'}
+    Asciidoctor::AttributeList.new(line).parse_into(attributes)
+    assert_equal expected, attributes 
   end
 
   test "collect named attributes unquoted" do

--- a/test/links_test.rb
+++ b/test/links_test.rb
@@ -132,6 +132,24 @@ context 'Links' do
     assert_xpath '//a[@href="#tigers"][text() = "[tigers]"]', doc.render, 1
   end
 
+  test 'xref shows label from title of target for forward and backward references in html backend' do
+    input = <<-EOS
+== Section A
+
+<\<_section_b>>
+
+== Section B
+
+<\<_section_a>>
+    EOS
+    
+    output = render_embedded_string input
+    assert_xpath '//h2[@id="_section_a"][text()="Section A"]', output, 1
+    assert_xpath '//a[@href="#_section_a"][text()="Section A"]', output, 1
+    assert_xpath '//h2[@id="_section_b"][text()="Section B"]', output, 1
+    assert_xpath '//a[@href="#_section_b"][text()="Section B"]', output, 1
+  end
+
   test 'anchor creates reference' do
     doc = document_from_string "[[tigers]]Tigers roam here."
     assert_equal({'tigers' => '[tigers]'}, doc.references[:ids])

--- a/test/sections_test.rb
+++ b/test/sections_test.rb
@@ -28,6 +28,16 @@ context 'Sections' do
       assert_equal 'section_one', sec.id
     end
 
+    test 'synthetic id separator can be customized' do
+      sec = block_from_string(":idseparator: -\n\n== Section One")
+      assert_equal '_section-one', sec.id
+    end
+
+    test 'synthetic id separator can be set to blank' do
+      sec = block_from_string(":idseparator:\n\n== Section One")
+      assert_equal '_sectionone', sec.id
+    end
+
     test 'synthetic ids can be disabled' do
       sec = block_from_string(":sectids!:\n\n== Section One\n")
       assert sec.id.nil?

--- a/test/substitutions_test.rb
+++ b/test/substitutions_test.rb
@@ -357,6 +357,14 @@ context 'Substitutions' do
       assert_equal %(Sentence text<span class="footnote">[<a id="_footnoteref_1" href="#_footnote_1" title="View footnote." class="footnote">1</a>]</span>.), para.sub_macros(para.buffer.join)
     end
 
+    test 'a footnote macro may contain a macro' do
+      para = block_from_string('Share your code. footnote:[http://github.com[GitHub]]')
+      assert_equal %(Share your code. <span class="footnote">[<a id="_footnoteref_1" href="#_footnote_1" title="View footnote." class="footnote">1</a>]</span>), para.sub_macros(para.buffer.join)
+      assert_equal 1, para.document.references[:footnotes].size
+      footnote1 = para.document.references[:footnotes][0]
+      assert_equal '<a href="http://github.com">GitHub</a>', footnote1.text
+    end
+
     test 'should increment index of subsequent footnote macros' do
       para = block_from_string("Sentence text footnote:[An example footnote.]. Sentence text footnote:[Another footnote.].")
       assert_equal %(Sentence text <span class="footnote">[<a id="_footnoteref_1" href="#_footnote_1" title="View footnote." class="footnote">1</a>]</span>. Sentence text <span class="footnote">[<a id="_footnoteref_2" href="#_footnote_2" title="View footnote." class="footnote">2</a>]</span>.), para.sub_macros(para.buffer.join)
@@ -364,7 +372,7 @@ context 'Substitutions' do
       footnote1 = para.document.references[:footnotes][0]
       assert_equal 1, footnote1.index
       assert footnote1.id.nil?
-      assert "An example footnote.", footnote1.text
+      assert_equal "An example footnote.", footnote1.text
       footnote2 = para.document.references[:footnotes][1]
       assert_equal 2, footnote2.index
       assert footnote2.id.nil?

--- a/test/tables_test.rb
+++ b/test/tables_test.rb
@@ -58,6 +58,23 @@ context 'Tables' do
       assert_xpath '/table/tbody/tr/td[2]/p[text()="a | there"]', output, 1
     end
 
+    test 'should auto recover with warning if missing leading separator on first cell' do
+      input = <<-EOS
+|===
+A | here| a | there
+|===
+      EOS
+      output = render_embedded_string input
+      assert_css 'table', output, 1
+      assert_css 'table > colgroup > col', output, 4
+      assert_css 'table > tbody > tr', output, 1
+      assert_css 'table > tbody > tr > td', output, 4
+      assert_xpath '/table/tbody/tr/td[1]/p[text()="A"]', output, 1
+      assert_xpath '/table/tbody/tr/td[2]/p[text()="here"]', output, 1
+      assert_xpath '/table/tbody/tr/td[3]/p[text()="a"]', output, 1
+      assert_xpath '/table/tbody/tr/td[4]/p[text()="there"]', output, 1
+    end
+
     test 'performs normal substitutions on cell content' do
       input = <<-EOS
 :show_title: Cool new show
@@ -242,7 +259,7 @@ I am getting in shape!
 |1 >s|2 |3 |4
 ^|5 2.2+^.^|6 .3+<.>m|7
 ^|8
-|9 2+>|10
+d|9 2+>|10
 |===
       EOS
       output = render_embedded_string input
@@ -267,7 +284,8 @@ I am getting in shape!
 
       assert_css 'table tr:nth-child(3) > td:nth-child(1).halign-center.valign-top p em', output, 1
 
-      assert_css 'table tr:nth-child(4) > td:nth-child(1).halign-left.valign-top p em', output, 1
+      assert_css 'table tr:nth-child(4) > td:nth-child(1).halign-left.valign-top p', output, 1
+      assert_css 'table tr:nth-child(4) > td:nth-child(1).halign-left.valign-top p em', output, 0
       assert_css 'table tr:nth-child(4) > td:nth-child(2).halign-right.valign-top[colspan="2"] p tt', output, 1
     end
 


### PR DESCRIPTION
Particularly important in this pull request is a fix to prevent Asciidoctor from crashing on bad table markup. The additional tests help with peace of mind :)
- use function for inserting title div in html5 templates
- use string interpolation instead of concat in template functions
- clean up macro substitution optimizations
- fix link macro embedded in footnote
- allow entities to be escaped
- fix invalid attribute parsing if value is quoted value is empty
- don't override caption if set to empty string
- fix invalid reference to regex constant
- add idseparator to customize separator used to generate section ids
- recover if separator is missing from first cell of psv table
- add support for 'd' cell style (for default, or normal)
- add tests for forward and backward xref references
