### PR TITLE
Make Rakefile work with older versions of rake

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -66,7 +66,7 @@ begin
   RDoc::Task.new do |rdoc|
     rdoc.rdoc_dir = 'rdoc'
     rdoc.title = "#{name} #{version}"
-    rdoc.markup = 'tomdoc'
+    rdoc.markup = 'tomdoc' if rdoc.respond_to?(:markup)
     rdoc.rdoc_files.include('README*')
     rdoc.rdoc_files.include('lib/**/*.rb')
   end


### PR DESCRIPTION
It finally dawned on me how to make the Rakefile compliant with other versions of rake, when I remembered that the Rakefile is Ruby code :)

Use Ruby's respond_to? method to check that the markup method exists on RDoc before attempting to invoke it.
