### PR TITLE
allow block in list continuation to have block attributes

### DIFF
--- a/lib/asciidoctor/reader.rb
+++ b/lib/asciidoctor/reader.rb
@@ -301,7 +301,7 @@ class Asciidoctor::Reader
 
     raw_source.each do |line|
       # normalize line ending to LF (purging occurrences of CRLF)
-      line = "#{line.chomp}\n"
+      line = "#{line.rstrip}\n"
       if skip_to
         skip_to = nil if line.match(skip_to)
       elsif continuing_value

--- a/test/lists_test.rb
+++ b/test/lists_test.rb
@@ -808,6 +808,66 @@ Item one, literal block
       assert_xpath '(//ul/li[1]/p/following-sibling::*)[1][@class = "literalblock"]', output, 1
     end
 
+    test "adjacent list continuation line attaches following block with block attributes" do
+      input = <<-EOS
+Lists
+=====
+
+* Item one, paragraph one
++
+[[beck]]
+.Read the following aloud to yourself
+[source, ruby]
+----
+5.times { print "Odelay!" }
+----
+ 
+* Item two
+      EOS
+      output = render_string input
+      assert_xpath '//ul', output, 1
+      assert_xpath '//ul/li', output, 2
+      assert_xpath '//ul/li[1]/p', output, 1
+      assert_xpath '(//ul/li[1]/p/following-sibling::*)[1][@id="beck"][@class = "listingblock"]', output, 1
+      assert_xpath '(//ul/li[1]/p/following-sibling::*)[1][@id="beck"]/div[@class="title"][starts-with(text(),"Read")]', output, 1
+      assert_xpath '(//ul/li[1]/p/following-sibling::*)[1][@id="beck"]//code[@class="ruby"][starts-with(text(),"5.times")]', output, 1
+    end
+
+    test 'trailing block attribute line attached by continuation should not create block' do
+      input = <<-EOS
+Lists
+=====
+
+* Item one, paragraph one
++
+[source]
+ 
+* Item two
+      EOS
+      output = render_string input
+      assert_xpath '//ul', output, 1
+      assert_xpath '//ul/li', output, 2
+      assert_xpath '//ul/li[1]/*', output, 1
+      assert_xpath '//ul/li//*[@class="listingblock"]', output, 0
+    end
+
+    test 'trailing block title line attached by continuation should not create block' do
+      input = <<-EOS
+Lists
+=====
+
+* Item one, paragraph one
++
+.Disappears into the ether
+ 
+* Item two
+      EOS
+      output = render_string input
+      assert_xpath '//ul', output, 1
+      assert_xpath '//ul/li', output, 2
+      assert_xpath '//ul/li[1]/*', output, 1
+    end
+
     test "consecutive blocks in list continuation attach to list item" do
       input = <<-EOS
 Lists

--- a/test/substitutions_test.rb
+++ b/test/substitutions_test.rb
@@ -610,19 +610,21 @@ context 'Substitutions' do
       assert_equal [:specialcharacters, :quotes], para.passthroughs.first[:subs]
     end
 
+    # NOTE placeholder is surrounded by text to prevent reader from stripping trailing boundary char (unique to test scenario)
     test 'restore inline passthroughs without subs' do
-      para = block_from_string("\x0" + '0' + "\x0")
+      para = block_from_string("some \x0" + '0' + "\x0 to study")
       para.passthroughs << {:text => '<code>inline code</code>', :subs => []}
       result = para.restore_passthroughs(para.buffer.join)
-      assert_equal '<code>inline code</code>', result
+      assert_equal "some <code>inline code</code> to study", result
     end
 
+    # NOTE placeholder is surrounded by text to prevent reader from stripping trailing boundary char (unique to test scenario)
     # TODO add two entries to ensure index lookup is working correctly (0 indx could be ambiguous)
     test 'restore inline passthroughs with subs' do
-      para = block_from_string("\x0" + '0' + "\x0")
+      para = block_from_string("some \x0" + '0' + "\x0 to study")
       para.passthroughs << {:text => '<code>{code}</code>', :subs => [:specialcharacters]}
       result = para.restore_passthroughs(para.buffer.join)
-      assert_equal '&lt;code&gt;{code}&lt;/code&gt;', result
+      assert_equal 'some &lt;code&gt;{code}&lt;/code&gt; to study', result
     end
   end
 


### PR DESCRIPTION
also:
- strip whitespace from end of lines
- strip endlines from end of list item
