### PR TITLE
Resolve #83 and #143, refactor Reader

### DIFF
--- a/lib/asciidoctor/abstract_node.rb
+++ b/lib/asciidoctor/abstract_node.rb
@@ -240,7 +240,7 @@ class Asciidoctor::AbstractNode
       relative_asset_path = Pathname.new(asset_path).relative_path_from(Pathname.new(input_path)).to_s
       if relative_asset_path.start_with?('..')
         if autocorrect
-          puts 'asciidoctor: WARNING: ' + asset_name + ' has illegal reference to ancestor of base directory'
+          puts "asciidoctor: WARNING: #{asset_name} has illegal reference to ancestor of base directory"
         else
           raise SecurityError, "#{asset_name} has reference to path outside of base directory, disallowed in safe mode: #{asset_path}"
         end

--- a/lib/asciidoctor/backends/html5.rb
+++ b/lib/asciidoctor/backends/html5.rb
@@ -94,7 +94,7 @@ pre code { background-color: #F8F8F8; padding: 0; }
     <script>hljs.initHighlightingOnLoad();</script>
     <% end %>
   </head>
-  <body#{attribute('id', :'css-signature')} class="<%= doctype %>"<% if attr? 'max-width' %> style="max-width: <%= attr 'max-width' %>;"<% end %>>
+  <body#{id} class="<%= doctype %>"<% if attr? 'max-width' %> style="max-width: <%= attr 'max-width' %>;"<% end %>>
     <% unless noheader %>
     <div id="header">
       <% if has_header? %>
@@ -109,7 +109,7 @@ pre code { background-color: #F8F8F8; padding: 0; }
       <% end %>
       <% if attr? :toc %>
       <div id="toc">
-        <div id="toctitle"><%= attr 'toc-title', 'Table of Contents' %></div>
+        <div id="toctitle"><%= attr 'toc-title' %></div>
 <%= template.render_outline(self, (attr :toclevels, 2).to_i) %>
       </div>
       <% end %>
@@ -266,7 +266,7 @@ class BlockListingTemplate < ::Asciidoctor::BaseTemplate
   def template
     @template ||= @eruby.new <<-EOS
 <%#encoding:UTF-8%><div#{id} class="listingblock#{role_class}">
-  #{title_div}
+  #{title_div :caption => true}
   <div class="content monospaced">
     <% if (attr :style) == 'source' %>
     <pre class="highlight<% if attr('source-highlighter') == 'coderay' %> CodeRay<% end %>"><code#{attribute('class', :language)}><%= template.preserve_endlines(content, self) %></code></pre>

--- a/lib/asciidoctor/block.rb
+++ b/lib/asciidoctor/block.rb
@@ -33,6 +33,7 @@ class Asciidoctor::Block < Asciidoctor::AbstractBlock
   # parent block's template.
   def render
     Asciidoctor.debug { "Now rendering #{@context} block for #{self}" }
+    @document.playback_attributes @attributes
     out = renderer.render("block_#{@context}", self)
     @document.callouts.next_list if @context == :colist
     out

--- a/lib/asciidoctor/document.rb
+++ b/lib/asciidoctor/document.rb
@@ -20,6 +20,16 @@ class Asciidoctor::Document < Asciidoctor::AbstractBlock
   include Asciidoctor
 
   Footnote = Struct.new(:index, :id, :text)
+  AttributeEntry = Struct.new(:name, :value, :negate) do
+    def initialize(name, value, negate = nil)
+      super(name, value, negate.nil? ? value.nil? : false)
+    end
+
+    def save_to(block_attributes)
+      block_attributes[:attribute_entries] ||= []
+      block_attributes[:attribute_entries] << self
+    end
+  end
 
   # Public A read-only integer value indicating the level of security that
   # should be enforced while processing this document. The value must be
@@ -123,42 +133,55 @@ class Asciidoctor::Document < Asciidoctor::AbstractBlock
     @attributes['sectids'] = ''
     @attributes['encoding'] = 'UTF-8'
 
-    attribute_overrides = options[:attributes] || {}
+    # language strings
+    # TODO load these based on language settings
+    @attributes['caution-caption'] = 'Caution'
+    @attributes['important-caption'] = 'Important'
+    @attributes['note-caption'] = 'Note'
+    @attributes['tip-caption'] = 'Tip'
+    @attributes['warning-caption'] = 'Warning'
+    @attributes['appendix-caption'] = 'Appendix'
+    @attributes['example-caption'] = 'Example'
+    @attributes['figure-caption'] = 'Figure'
+    @attributes['table-caption'] = 'Table'
+    @attributes['toc-title'] = 'Table of Contents'
+
+    @attribute_overrides = options[:attributes] || {}
 
     # the only way to set the include-depth attribute is via the document options
     # 10 is the AsciiDoc default, though currently Asciidoctor only supports 1 level
-    attribute_overrides['include-depth'] ||= 10
+    @attribute_overrides['include-depth'] ||= 10
 
     # if the base_dir option is specified, it overrides docdir as the root for relative paths
     # otherwise, the base_dir is the directory of the source file (docdir) or the current
     # directory of the input is a string
     if options[:base_dir].nil?
-      if attribute_overrides['docdir']
-        @base_dir = attribute_overrides['docdir'] = File.expand_path(attribute_overrides['docdir'])
+      if @attribute_overrides['docdir']
+        @base_dir = @attribute_overrides['docdir'] = File.expand_path(@attribute_overrides['docdir'])
       else
         # perhaps issue a warning here?
-        @base_dir = attribute_overrides['docdir'] = Dir.pwd
+        @base_dir = @attribute_overrides['docdir'] = Dir.pwd
       end
     else
-      @base_dir = attribute_overrides['docdir'] = File.expand_path(options[:base_dir])
+      @base_dir = @attribute_overrides['docdir'] = File.expand_path(options[:base_dir])
     end
 
     if @safe >= SafeMode::SERVER
       # restrict document from setting source-highlighter and backend
-      attribute_overrides['source-highlighter'] ||= nil
-      attribute_overrides['backend'] ||= DEFAULT_BACKEND
+      @attribute_overrides['source-highlighter'] ||= nil
+      @attribute_overrides['backend'] ||= DEFAULT_BACKEND
       # restrict document from seeing the docdir and trim docfile to relative path
-      if attribute_overrides.has_key?('docfile') && @parent_document.nil?
-        attribute_overrides['docfile'] = attribute_overrides['docfile'][(attribute_overrides['docdir'].length + 1)..-1]
+      if @attribute_overrides.has_key?('docfile') && @parent_document.nil?
+        @attribute_overrides['docfile'] = @attribute_overrides['docfile'][(@attribute_overrides['docdir'].length + 1)..-1]
       end
-      attribute_overrides['docdir'] = ''
+      @attribute_overrides['docdir'] = ''
       # restrict document from enabling icons
       if @safe >= SafeMode::SECURE
-        attribute_overrides['icons'] ||= nil
+        @attribute_overrides['icons'] ||= nil
       end
     end
     
-    attribute_overrides.delete_if {|key, val|
+    @attribute_overrides.delete_if {|key, val|
       verdict = false
       # a nil or negative key undefines the attribute 
       if val.nil? || key[-1..-1] == '!'
@@ -184,7 +207,7 @@ class Asciidoctor::Document < Asciidoctor::AbstractBlock
       # don't need to do the extra processing within our own document
       @reader = Reader.new(data)
     else
-      @reader = Reader.new(data, self, attribute_overrides, &block)
+      @reader = Reader.new(data, self, true, &block)
     end
 
     # dynamic intrinstic attribute values
@@ -202,9 +225,7 @@ class Asciidoctor::Document < Asciidoctor::AbstractBlock
     @attributes['iconsdir'] ||= File.join(@attributes.fetch('imagesdir', 'images'), 'icons')
 
     # Now parse the lines in the reader into blocks
-    Lexer.parse(@reader, self) 
-    # or we could make it...
-    #self << *Lexer.parse(@reader, self)
+    Lexer.parse(@reader, self, :header_only => @options.fetch(:parse_header_only, false)) 
 
     @callouts.rewind
 
@@ -282,7 +303,7 @@ class Asciidoctor::Document < Asciidoctor::AbstractBlock
 
   # Make the raw source for the Document available.
   def source
-    @reader.source if @reader
+    @reader.source.join if @reader
   end
 
   def doctype
@@ -311,6 +332,20 @@ class Asciidoctor::Document < Asciidoctor::AbstractBlock
   end
   alias :name :doctitle
 
+  # Public: Convenience method to retrieve the document attribute 'author'
+  #
+  # returns the full name of the author as a String
+  def author
+    @attributes['author']
+  end
+
+  # Public: Convenience method to retrieve the document attribute 'revdate'
+  #
+  # returns the date of last revision for the document as a String
+  def revdate
+    @attributes['revdate']
+  end
+
   def notitle
     @attributes.has_key? 'notitle'
   end
@@ -326,6 +361,114 @@ class Asciidoctor::Document < Asciidoctor::AbstractBlock
 
   def has_header?
     !@header.nil?
+  end
+ 
+  # Internal: Branch the attributes so that the original state can be restored
+  # at a future time.
+  def save_attributes
+    # css-signature cannot be updated after header attributes are processed
+    if @id.nil? && @attributes.has_key?('css-signature')
+      @id = @attributes['css-signature']
+    end
+    @original_attributes = @attributes.dup
+  end
+
+  # Internal: Restore the attributes to the previously saved state
+  def restore_attributes
+    @attributes = @original_attributes
+  end
+
+  # Internal: Delete any attributes stored for playback
+  def clear_playback_attributes(attributes)
+    attributes.delete(:attribute_entries)
+  end
+
+  # Internal: Replay attribute assignments at the block level
+  def playback_attributes(block_attributes)
+    if block_attributes.has_key? :attribute_entries
+      block_attributes[:attribute_entries].each do |entry|
+        if entry.negate
+          @attributes.delete(entry.name)
+        else
+          @attributes[entry.name] = entry.value
+        end
+      end
+    end
+  end
+
+  # Public: Set the specified attribute on the document if the name is not locked
+  #
+  # If the attribute is locked, false is returned. Otherwise, the value is
+  # assigned to the attribute name after first performing attribute
+  # substitutions on the value. If the attribute name is 'backend', then the
+  # value of backend-related attributes are updated.
+  #
+  # name  - the String attribute name
+  # value - the String attribute value
+  #
+  # returns true if the attribute was set, false if it was not set because it's locked
+  def set_attribute(name, value)
+    if attribute_locked?(name)
+      false
+    else
+      @attributes[name] = apply_attribute_value_subs(value)
+      if name == 'backend'
+        update_backend_attributes()
+      end
+      true
+    end
+  end
+
+  # Public: Delete the specified attribute from the document if the name is not locked
+  #
+  # If the attribute is locked, false is returned. Otherwise, the attribute is deleted.
+  #
+  # name  - the String attribute name
+  #
+  # returns true if the attribute was deleted, false if it was not because it's locked
+  def delete_attribute(name)
+    if attribute_locked?(name)
+      false
+    else
+      @attributes.delete(name)
+      true
+    end
+  end
+
+  # Public: Determine if the attribute has been locked by being assigned in document options
+  #
+  # key - The attribute key to check
+  #
+  # Returns true if the attribute is locked, false otherwise
+  def attribute_locked?(name)
+    @attribute_overrides.has_key?(name) || @attribute_overrides.has_key?("#{name}!")
+  end
+
+  # Internal: Apply substitutions to the attribute value
+  #
+  # If the value is an inline passthrough macro (e.g., pass:[text]), then
+  # apply the substitutions defined on the macro to the text. Otherwise,
+  # apply the verbatim substitutions to the value.
+  #
+  # value - The String attribute value on which to perform substitutions
+  #
+  # Returns The String value with substitutions performed.
+  def apply_attribute_value_subs(value)
+    if value.match(REGEXP[:pass_macro_basic])
+      # copy match for Ruby 1.8.7 compat
+      m = $~
+      subs = []
+      if !m[1].empty?
+        subs = resolve_subs(m[1])
+      end
+      if !subs.empty?
+        apply_subs(m[2], subs)
+      else
+        m[2]
+      end
+    else
+      apply_header_subs(value)
+    end
   end
 
   # Public: Update the backend attributes to reflect a change in the selected backend
@@ -400,6 +543,7 @@ class Asciidoctor::Document < Asciidoctor::AbstractBlock
   # or a template is missing, the renderer will fall back to
   # using the appropriate built-in template.
   def render(opts = {})
+    restore_attributes
     r = renderer(opts)
     @options.merge(opts)[:header_footer] ? r.render('document', self).strip : r.render('embedded', self)
   end

--- a/lib/asciidoctor/reader.rb
+++ b/lib/asciidoctor/reader.rb
@@ -1,23 +1,24 @@
-# Public: Methods for retrieving lines from Asciidoc documents
+# Public: Methods for retrieving lines from AsciiDoc source files
 class Asciidoctor::Reader
 
   include Asciidoctor
 
-  # Public: Get the String document source.
+  # Public: Get the document source as a String Array of lines.
   attr_reader :source
 
-  # Public: Get the String Array of lines parsed from the source
-  attr_reader :lines
+  # Public: Get the 1-based offset of the current line.
+  attr_reader :lineno
 
   # Public: Initialize the Reader object.
   #
   # data       - The Array of Strings holding the Asciidoc source document. The
-  #              original instance of this Array is not modified
+  #              original instance of this Array is not modified (default: nil)
   # document   - The document with which this reader is associated. Used to access
-  #              document attributes
-  # overrides  - A Hash of attributes that were passed to the Document and should
-  #              prevent attribute assignments or removals of matching keys found in
-  #              the document
+  #              document attributes (default: nil)
+  # preprocess - A flag indicating whether to run the preprocessor on these lines.
+  #              Only enable for the outer-most Reader. If this argument is true,
+  #              a Document object must also be supplied.
+  #              (default: false)
   # block      - A block that can be used to retrieve external Asciidoc
   #              data to include in this document.
   #
@@ -25,33 +26,63 @@ class Asciidoctor::Reader
   #
   #   data   = File.readlines(filename)
   #   reader = Asciidoctor::Reader.new data
-  def initialize(data = [], document = nil, overrides = nil, &block)
-    # if document is nil, we assume this is a preprocessed string
-    if document.nil?
+  def initialize(data = nil, document = nil, preprocess = false, &block)
+    data = [] if data.nil?
+    # TODO use Struct to track file/lineno info; track as file changes; offset for sub-readers
+    @lineno = 0
+    if !preprocess
       @lines = data.is_a?(String) ? data.lines.entries : data.dup
+      @preprocess_source = false
     elsif !data.empty?
-      @overrides = overrides || {}
+      # NOTE we assume document is not nil!
       @document = document
-      process(data.is_a?(String) ? data.lines.entries : data, &block)
+      @preprocess_source = true
+      @include_block = block_given? ? block : nil
+      normalize_data(data.is_a?(String) ? data.lines.entries : data)
     else
       @lines = []
+      @preprocess_source = false
     end
 
-    @source = @lines.join
+    @source = @lines.dup
+
+    @next_line_preprocessed = false
+    @unescape_next_line = false
+
+    @conditionals_stack = []
+    @skipping = false
+    @eof = false
+  end
+
+  # Public: Get a copy of the remaining Array of String lines parsed from the source
+  def lines
+    @lines.nil? ? nil : @lines.dup
   end
 
   # Public: Check whether there are any lines left to read.
   #
-  # Returns true if !@lines.empty? is true, or false otherwise.
-  def has_lines?
-    !@lines.empty?
+  # If preprocessing is enabled for this Reader, and there are lines remaining,
+  # the next line is preprocessed before checking whether there are more lines. 
+  #
+  # Returns true if @lines is empty, or false otherwise.
+  def has_more_lines?
+    if @eof || (@eof = @lines.empty?)
+      false
+    elsif @preprocess_source && !@next_line_preprocessed
+      preprocess_next_line.nil? ? false : !@lines.empty?
+    else
+      true
+    end
   end
 
   # Public: Check whether this reader is empty (contains no lines)
   #
-  # Returns true if @lines.empty? is true, otherwise false.
+  # If preprocessing is enabled for this Reader, and there are lines remaining,
+  # the next line is preprocessed before checking whether there are more lines. 
+  #
+  # Returns true if @lines is empty, otherwise false.
   def empty?
-    @lines.empty?
+    !has_more_lines?
   end
 
   # Private: Strip off leading blank lines in the Array of lines.
@@ -61,25 +92,27 @@ class Asciidoctor::Reader
   #   @lines
   #   => ["\n", "\t\n", "Foo\n", "Bar\n", "\n"]
   #
-  #   skip_blank
+  #   skip_blank_lines
   #   => 2
   #
   #   @lines
   #   => ["Foo\n", "Bar\n"]
   #
   # Returns an Integer of the number of lines skipped
-  def skip_blank
+  def skip_blank_lines
     skipped = 0
-    while has_lines? && @lines.first.strip.empty?
-      @lines.shift
-      skipped += 1
-    end
+    # optimized code for shortest execution path
+    while !(next_line = get_line).nil?
+      if next_line.chomp.empty?
+        skipped += 1
+      else
+        unshift_line next_line
+        break
+      end
+    end 
 
     skipped
   end
-  # Create alias of skip_blank named skip_blank_lines for readability
-  # TODO likely want to drop the original method name
-  alias :skip_blank_lines :skip_blank
 
   # Public: Consume consecutive lines containing line- or block-level comments.
   #
@@ -94,25 +127,27 @@ class Asciidoctor::Reader
   #
   #   @lines
   #   => ["actual text\n"]
-  def consume_comments(opts = {})
+  def consume_comments(options = {})
     comment_lines = []
-    while !@lines.empty?
-      next_line = peek_line
-      if opts[:include_blanks] && next_line.strip.empty?
-        comment_lines << get_line
-      elsif match = next_line.match(REGEXP[:comment_blk])
-        comment_lines << get_line
-        comment_lines.push(*(grab_lines_until(:terminator => match[0], :preserve_last_line => true)))
-        comment_lines << get_line
-      elsif next_line.match(REGEXP[:comment])
-        comment_lines << get_line
+    preprocess = options.fetch(:preprocess, true)
+    while !(next_line = get_line(preprocess)).nil?
+      if options[:include_blank_lines] && next_line.chomp.empty?
+        comment_lines << next_line
+      elsif (commentish = next_line.start_with?('//')) && (match = next_line.match(REGEXP[:comment_blk]))
+        comment_lines << next_line
+        comment_lines.push(*(grab_lines_until(:terminator => match[0], :grab_last_line => true, :preprocess => false)))
+      elsif commentish && next_line.match(REGEXP[:comment])
+        comment_lines << next_line
       else
+        # throw it back
+        unshift_line next_line
         break
       end
     end
 
     comment_lines
   end
+  alias :skip_comment_lines :consume_comments
 
   # Public: Consume consecutive lines containing line comments.
   #
@@ -129,10 +164,12 @@ class Asciidoctor::Reader
   #   => ["bar\n"]
   def consume_line_comments
     comment_lines = []
-    while !@lines.empty?
-      if peek_line.match(REGEXP[:comment])
-        comment_lines << get_line
+    # optimized code for shortest execution path
+    while !(next_line = get_line).nil?
+      if next_line.match(REGEXP[:comment])
+        comment_lines << next_line
       else
+        unshift_line next_line
         break
       end
     end
@@ -140,41 +177,302 @@ class Asciidoctor::Reader
     comment_lines
   end
 
-  # Skip the next line if it's a list continuation character
-  # 
-  # Returns nil
-  def skip_list_continuation
-    if has_lines? && @lines.first.chomp == '+'
-      @lines.shift
-    end
-
-    nil
-  end
-
   # Public: Get the next line of source data. Consumes the line returned.
+  #
+  # preprocess - A Boolean flag indicating whether to evaluate preprocessing
+  #              directives (macros) before reading line (default: true)
   #
   # Returns the String of the next line of the source data if data is present.
   # Returns nil if there is no more data.
-  def get_line
-    @lines.shift
+  def get_line(preprocess = true)
+    if @eof || (@eof = @lines.empty?)
+      @next_line_preprocessed = true
+      nil
+    elsif preprocess && @preprocess_source &&
+        !@next_line_preprocessed && preprocess_next_line.nil?
+      @next_line_preprocessed = true
+      nil
+    else
+      @lineno += 1
+      @next_line_preprocessed = false
+      if @unescape_next_line
+        @unescape_next_line = false
+        @lines.shift[1..-1]
+      else
+        @lines.shift
+      end
+    end
   end
-  # QUESTION what about advance?
-  # Create an alias of get_line named next_line for readability
-  alias :next_line :get_line
+
+  # Public: Advance to the next line by discarding the line at the front of the stack
+  #
+  # Removes the line at the front of the stack without any processing.
+  #
+  # returns a boolean indicating whether there was a line to discard
+  def advance
+    @next_line_preprocessed = false
+    # we assume that we're advancing over a line of known content
+    if @eof || (@eof = @lines.empty?)
+      false
+    else
+      @lineno += 1
+      @lines.shift
+      true
+    end
+  end
 
   # Public: Get the next line of source data. Does not consume the line returned.
   #
+  # preprocess - A Boolean flag indicating whether to evaluate preprocessing
+  #              directives (macros) before reading line (default: true)
+  #
   # Returns a String dup of the next line of the source data if data is present.
   # Returns nil if there is no more data.
-  def peek_line
-    @lines.first.dup if @lines.first
+  def peek_line(preprocess = true)
+    if !preprocess
+      # QUESTION do we need to dup?
+      @eof || (@eof = @lines.empty?) ? nil : @lines.first.dup
+    elsif has_more_lines?
+      # QUESTION do we need to dup?
+      @lines.first.dup
+    else
+      nil
+    end
   end
 
-  # Public: Push Array of string `lines` onto queue of source data lines, unless `lines` has no non-nil values.
+  # TODO document & test me!
+  def peek_lines(number = 1)
+    lines = []
+    idx = 0
+    (1..number).each do
+      if @preprocess_source && !@next_line_preprocessed
+        advanced = preprocess_next_line
+        break if advanced.nil? || @eof || (@eof = @lines.empty?)
+        idx = 0 if advanced
+      end
+      break if idx >= @lines.size
+      # QUESTION do we need to dup?
+      lines << @lines[idx].dup
+      idx += 1
+    end
+    lines
+  end
+
+  # Internal: Preprocess the next line until the cursor is at a line of content
+  #
+  # Evaluate preprocessor macros on the next line, continuing to do so until
+  # the cursor arrives at a line of included content. That line is marked as
+  # preprocessed so that preprocessing is not performed multiple times.
+  #
+  # returns a Boolean indicating whether the cursor advanced, or nil if there
+  # are no more lines available.
+  def preprocess_next_line
+    # this return could be happening from a recursive call
+    return nil if @eof || (next_line = @lines.first).nil?
+    if next_line.include?('if') && (match = next_line.match(REGEXP[:ifdef_macro]))
+      if next_line.start_with? '\\'
+        @next_line_preprocessed = true
+        @unescape_next_line = true
+        false
+      else
+        preprocess_conditional_inclusion(*match.captures)
+      end
+    elsif @skipping
+      advance
+      # skip over comment blocks, we don't want to process directives in them
+      skip_comment_lines :include_blank_lines => true, :preprocess => false
+      preprocess_next_line.nil? ? nil : true
+    elsif next_line.include?('include::') && match = next_line.match(REGEXP[:include_macro])
+      if next_line.start_with? '\\'
+        @next_line_preprocessed = true
+        @unescape_next_line = true
+        false
+      else
+        preprocess_include(match[1])
+      end
+    else
+      @next_line_preprocessed = true
+      false
+    end
+  end
+
+  # Internal: Preprocess the directive (macro) to conditionally include content.
+  #
+  # Preprocess the conditional inclusion directive (ifdef, ifndef, ifeval,
+  # endif) under the cursor. If the Reader is currently skipping content, then
+  # simply track the open and close delimiters of any nested conditional
+  # blocks. If the Reader is not skipping, mark whether the condition is
+  # satisfied and continue preprocessing recursively until the next line of
+  # available content is found.
+  #
+  # directive  - The conditional inclusion directive (ifdef, ifndef, ifeval, endif)
+  # target     - The target, which is the name of one or more attributes that are
+  #              used in the condition (blank in the case of the ifeval directive)
+  # delimiter  - The conditional delimiter for multiple attributes ('+' means all
+  #              attributes must be defined or undefined, ',' means any of the attributes
+  #              can be defined or undefined.
+  # text       - The text associated with this directive (occurring between the square brackets)
+  #              Used for a single-line conditional block in the case of the ifdef or
+  #              ifndef directives, and for the conditional expression for the ifeval directive.
+  #
+  # returns a Boolean indicating whether the cursor advanced, or nil if there
+  # are no more lines available.
+  def preprocess_conditional_inclusion(directive, target, delimiter, text)
+    # must have a target before brackets if ifdef or ifndef
+    # must not have text between brackets if endif
+    # don't honor match if it doesn't meet this criteria
+    if ((directive == 'ifdef' || directive == 'ifndef') && target.empty?) ||
+        (directive == 'endif' && !text.nil?)
+      @next_line_preprocessed = true
+      return false
+    end
+
+    if directive == 'endif'
+      stack_size = @conditionals_stack.size
+      if stack_size > 0
+        pair = @conditionals_stack.last
+        if target.empty? || target == pair[:target]
+          @conditionals_stack.pop
+          @skipping = @conditionals_stack.empty? ? false : @conditionals_stack.last[:skipping]
+        else
+          puts "asciidoctor: ERROR: line #{@lineno + 1}: mismatched macro: endif::#{target}[], expected endif::#{pair[:target]}[]"
+        end
+      else
+        puts "asciidoctor: ERROR: line #{@lineno + 1}: unmatched macro: endif::#{target}[]"
+      end
+      advance
+      return preprocess_next_line.nil? ? nil : true
+    end
+
+    skip = nil
+    if !@skipping
+      case directive
+      when 'ifdef'
+        case delimiter
+        when nil
+          # if the attribute is undefined, then skip
+          skip = !@document.attributes.has_key?(target)
+        when ','
+          # if any attribute is defined, then don't skip
+          skip = !target.split(',').detect {|name| @document.attributes.has_key? name }
+        when '+'
+          # if any attribute is undefined, then skip
+          skip = target.split('+').detect {|name| !@document.attributes.has_key? name }
+        end
+      when 'ifndef'
+        case delimiter
+        when nil
+          # if the attribute is defined, then skip
+          skip = @document.attributes.has_key?(target)
+        when ','
+          # if any attribute is undefined, then don't skip
+          skip = !target.split(',').detect {|name| !@document.attributes.has_key? name }
+        when '+'
+          # if any attribute is defined, then skip
+          skip = target.split('+').detect {|name| @document.attributes.has_key? name }
+        end
+      when 'ifeval'
+        # the text in brackets must match an expression
+        # don't honor match if it doesn't meet this criteria
+        if !target.empty? || !(expr_match = text.strip.match(REGEXP[:eval_expr]))
+          @next_line_preprocessed = true
+          return false
+        end
+
+        lhs = resolve_expr_val(expr_match[1])
+        op = expr_match[2]
+        rhs = resolve_expr_val(expr_match[3])
+
+        skip = !lhs.send(op.to_sym, rhs)
+      end
+      @skipping = skip
+    end
+    advance
+    # single line conditional inclusion
+    if directive != 'ifeval' && !text.nil?
+      if !@skipping
+        unshift_line "#{text.rstrip}\n"
+        return true
+      end
+    # conditional inclusion block
+    else
+      @conditionals_stack << {:target => target, :skip => skip, :skipping => @skipping}
+    end
+    return preprocess_next_line.nil? ? nil : true
+  end
+
+  # Internal: Preprocess the directive (macro) to include the target document.
+  #
+  # Preprocess the directive to include the target document. The scenarios
+  # are as follows:
+  #
+  # If SafeMode is SECURE or greater, the directive is ignore and the include
+  # directive line is emitted verbatim.
+  #
+  # Otherwise, if an include handler is specified (currently controlled by a
+  # closure block), pass the target to that block and expect an Array of String
+  # lines in return.
+  #
+  # Otherwise, if the include-depth attribute is greater than 0, normalize the
+  # target path and read the lines onto the beginning of the Array of source
+  # data.
+  #
+  # If none of the above apply, emit the include directive line verbatim.
+  #
+  # target - The name of the source document to include as specified in the
+  #          target slot of the include::[] macro
+  #
+  # returns a Boolean indicating whether the line under the cursor has changed.
+  def preprocess_include(target)
+    # if running in SafeMode::SECURE or greater, don't process this directive
+    if @document.safe >= SafeMode::SECURE
+      @next_line_preprocessed = true
+      false
+    # assume that if a block is given, the developer wants
+    # to handle when and how to process the include, even
+    # if the include-depth attribute is 0
+    elsif @include_block
+      advance
+      # FIXME this borks line numbers
+      @lines.unshift(*@include_block.call(target).map {|l| "#{l.rstrip}\n"})
+    # FIXME currently we're not checking the upper bound of the include depth
+    elsif @document.attributes.fetch('include-depth', 0).to_i > 0
+      advance
+      # FIXME this borks line numbers
+      @lines.unshift(*File.readlines(@document.normalize_asset_path(target, 'include file')).map {|l| "#{l.rstrip}\n"})
+      true
+    else
+      @next_line_preprocessed = true
+      false
+    end
+  end
+
+  # Public: Push the String line onto the beginning of the Array of source data.
+  #
+  # Since this line was (assumed to be) previously retrieved through the
+  # reader, it is marked as preprocessed.
+  #
+  # returns nil
+  def unshift_line(line)
+    @lines.unshift line
+    @next_line_preprocessed = true
+    @eof = false
+    @lineno -= 1
+    nil
+  end
+
+  # Public: Push Array of lines onto the front of the Array of source data, unless `lines` has no non-nil values.
   #
   # Returns nil
   def unshift(*new_lines)
-    @lines.unshift(*new_lines) if !new_lines.empty?
+    size = new_lines.size
+    if size > 0
+      @lines.unshift(*new_lines)
+      # assume that what we are putting back on is already processed for directives
+      @next_line_preprocessed = true
+      @eof = false
+      @lineno -= size
+    end
     nil
   end
 
@@ -184,7 +482,7 @@ class Asciidoctor::Reader
   #
   # Returns nil
   def chomp_last!
-    @lines.last.chomp! unless @lines.empty?
+    @lines.last.chomp! unless @eof || (@eof = @lines.empty?)
     nil
   end
 
@@ -218,27 +516,27 @@ class Asciidoctor::Reader
     buffer = []
 
     finis = false
-    get_line if options[:skip_first_line]
+    advance if options[:skip_first_line]
     # save options to locals for minor optimization
     terminator = options[:terminator]
     terminator.chomp! if terminator
     break_on_blank_lines = options[:break_on_blank_lines]
     break_on_list_continuation = options[:break_on_list_continuation]
-    while (this_line = self.get_line)
+    skip_line_comments = options[:skip_line_comments]
+    preprocess = options.fetch(:preprocess, true)
+    while !(this_line = get_line(preprocess)).nil?
       Asciidoctor.debug { "Reader processing line: '#{this_line}'" }
       finis = true if terminator && this_line.chomp == terminator
       finis = true if !finis && break_on_blank_lines && this_line.strip.empty?
       finis = true if !finis && break_on_list_continuation && this_line.chomp == LIST_CONTINUATION
       finis = true if !finis && block && yield(this_line)
       if finis
-        self.unshift(this_line) if options[:preserve_last_line]
         buffer << this_line if options[:grab_last_line]
+        unshift_line(this_line) if options[:preserve_last_line]
         break
       end
 
-      if options[:skip_line_comments] && this_line.match(REGEXP[:comment])
-        # skip it
-      else
+      unless skip_line_comments && this_line.match(REGEXP[:comment])
         buffer << this_line
       end
     end
@@ -263,108 +561,62 @@ class Asciidoctor::Reader
   #   sanitize_attribute_name('Foo 3 #-Billy')
   #   => 'foo3-billy'
   def sanitize_attribute_name(name)
-    name.gsub(/[^\w\-]/, '').downcase
+    Asciidoctor::Lexer.sanitize_attribute_name(name)
   end
 
-  # Private: Process raw input, used for the outermost reader.
-  def process(data, &block)
-    raw_source = []
-    include_depth = @document.attr('include-depth', 0).to_i
+  # Private: Resolve the value of one side of the expression
+  def resolve_expr_val(str)
+    val = str
+    type = nil
 
-    data.each do |line|
-      if inc = line.match(REGEXP[:include_macro])
-        if inc[0].start_with? '\\'
-          raw_source << line[1..-1]
-        # if running in SafeMode::SECURE or greater, don't process
-        # this directive (or should we swallow it?)
-        elsif @document.safe >= SafeMode::SECURE
-          raw_source << line
-        # assume that if a block is given, the developer wants
-        # to handle when and how to process the include, even
-        # if the include-depth attribute is 0
-        elsif block_given?
-          raw_source.concat yield(inc[1])
-        elsif include_depth > 0
-          raw_source.concat File.readlines(@document.normalize_asset_path(inc[1], 'include file'))
-        else
-          raw_source << line
-        end
+    if val.start_with?('"') && val.end_with?('"') ||
+        val.start_with?('\'') && val.end_with?('\'')
+      type = :s
+      val = val[1..-2]
+    end
+
+    if val.include? '{'
+      val = @document.sub_attributes(val)
+    end
+
+    if type != :s
+      if val.empty?
+        val = nil
+      elsif val == 'true'
+        val = true
+      elsif val == 'false'
+        val = false
+      elsif val.include?('.')
+        val = val.to_f
       else
-        raw_source << line
+        val = val.to_i
       end
     end
 
-    skip_to = nil
-    continuing_value = nil
-    continuing_key = nil
-    @lines = []
+    val
+  end
 
-    raw_source.each do |line|
-      # normalize line ending to LF (purging occurrences of CRLF)
-      line = "#{line.rstrip}\n"
-      if skip_to
-        skip_to = nil if line.match(skip_to)
-      elsif continuing_value
-        close_continue = false
-        # Lines that start with whitespace and end with a '+' are
-        # a continuation, so gobble them up into `value`
-        if line.match(REGEXP[:attr_continue])
-          continuing_value += ' ' + $1.rstrip
-        # An empty line ends a continuation
-        elsif line.strip.empty?
-          raw_source.unshift(line)
-          close_continue = true
-        else
-          # If this continued line isn't empty and doesn't end with a +, then
-          # this is the end of the continuation, no matter what the next line
-          # does.
-          continuing_value += ' ' + line.strip
-          close_continue = true
-        end
-        if close_continue
-          unless attribute_overridden? continuing_key
-            @document.attributes[continuing_key] = apply_attribute_value_subs(continuing_value)
-          end
-          continuing_key = nil
-          continuing_value = nil
-        end
-      elsif line.match(REGEXP[:ifdef_macro])
-        attr = $2
-        skip = case $1
-               when 'ifdef';  !@document.attributes.has_key?(attr)
-               when 'ifndef'; @document.attributes.has_key?(attr)
-               end
-        skip_to = /^endif::#{attr}\[\]\s*\n/ if skip
-      elsif line.match(REGEXP[:attr_assign])
-        key = sanitize_attribute_name($1)
-        value = $2
-        if value.match(REGEXP[:attr_continue])
-          # attribute value continuation line; grab lines until we run out
-          # of continuation lines
-          continuing_key = key
-          continuing_value = $1.rstrip  # strip off the spaces and +
-        else
-          unless attribute_overridden? key
-            @document.attributes[key] = apply_attribute_value_subs(value)
-            if key == 'backend'
-              @document.update_backend_attributes()
-            end
-          end
-        end
-      elsif line.match(REGEXP[:attr_delete])
-        key = sanitize_attribute_name($1)
-        unless attribute_overridden? key
-          @document.attributes.delete(key)
-        end
-      elsif !line.match(REGEXP[:endif_macro])
-        while line.match(REGEXP[:attr_conditional])
-          value = @document.attributes.has_key?($1) ? $2 : ''
-          line.sub!(REGEXP[:attr_conditional], value)
-        end
-        # NOTE leave line comments in as they play a role in flow (such as a list divider)
-        @lines << line
-      end
-    end
+  # Private: Normalize raw input, used for the outermost Reader.
+  #
+  # This method strips whitespace from the end of every line of
+  # the source data and appends a LF (i.e., Unix endline). This
+  # whitespace substitution is very important to how Asciidoctor
+  # works.
+  #
+  # Any leading or trailing blank lines are also removed.
+  #
+  # The normalized lines are assigned to the @lines instance variable.
+  #
+  # data - A String Array of input data to be normalized
+  #
+  # returns nothing
+  def normalize_data(data)
+    # normalize line ending to LF (purging occurrences of CRLF)
+    # this rstrip is *very* important to how Asciidoctor works
+    @lines = data.map {|line| "#{line.rstrip}\n" }
+
+    @lines.shift && @lineno += 1 while !@lines.first.nil? && @lines.first.chomp.empty?
+    @lines.pop while !@lines.last.nil? && @lines.last.chomp.empty?
 
     # Process bibliography references, so they're available when text
     # before the reference is being rendered.
@@ -375,41 +627,6 @@ class Asciidoctor::Reader
     #    @document.register(:ids, biblio[1])
     #  end
     #end
-  end
-
-  # Internal: Determine if the attribute has been overridden in the document options
-  #
-  # key - The attribute key to check
-  #
-  # Returns true if the attribute has been overridden, false otherwise
-  def attribute_overridden?(key)
-    @overrides.has_key?(key) || @overrides.has_key?(key + '!')
-  end
-
-  # Internal: Apply substitutions to the attribute value
-  #
-  # If the value is an inline passthrough macro (e.g., pass:[text]), then
-  # apply the substitutions defined on the macro to the text. Otherwise,
-  # apply the verbatim substitutions to the value.
-  #
-  # value - The String attribute value on which to perform substitutions
-  #
-  # Returns The String value with substitutions performed.
-  def apply_attribute_value_subs(value)
-    if value.match(REGEXP[:pass_macro_basic])
-      # copy match for Ruby 1.8.7 compat
-      m = $~
-      subs = []
-      if !m[1].empty?
-        subs = @document.resolve_subs(m[1])
-      end
-      if !subs.empty?
-        @document.apply_subs(m[2], subs)
-      else
-        m[2]
-      end
-    else
-      @document.apply_header_subs(value)
-    end
+    nil
   end
 end

--- a/lib/asciidoctor/section.rb
+++ b/lib/asciidoctor/section.rb
@@ -90,6 +90,7 @@ class Asciidoctor::Section < Asciidoctor::AbstractBlock
   # Blocks.
   def render
     Asciidoctor.debug { "Now rendering section for #{self}" }
+    @document.playback_attributes @attributes
     renderer.render('section', self)
   end
 

--- a/lib/asciidoctor/substituters.rb
+++ b/lib/asciidoctor/substituters.rb
@@ -421,11 +421,11 @@ module Asciidoctor
               type = :ref
               target = nil
             else
-              fn = @document.references[:footnotes].find {|fn| fn.id == id }
+              footnote = @document.references[:footnotes].find {|fn| fn.id == id }
               target = id
               id = nil
-              index = fn.index
-              text = fn.text
+              index = footnote.index
+              text = footnote.text
               type = :xref
             end
           end
@@ -519,7 +519,7 @@ module Asciidoctor
         lines = text.lines.entries
         return text if lines.size == 1
         last = lines.pop
-        "#{lines.map {|line| Inline.new(self, :break, line.rstrip.chomp(' +'), :type => :line).render } * "\n"}\n#{last}"
+        "#{lines.map {|line| Inline.new(self, :break, line.rstrip.chomp(LINE_BREAK), :type => :line).render } * "\n"}\n#{last}"
       else
         text.gsub(REGEXP[:line_break]) { Inline.new(self, :break, $1, :type => :line).render }
       end

--- a/lib/asciidoctor/table.rb
+++ b/lib/asciidoctor/table.rb
@@ -133,6 +133,7 @@ module Asciidoctor
       Asciidoctor.debug { "Now attempting to render for table my own bad #{self}" }
       Asciidoctor.debug { "Parent is #{@parent}" }
       Asciidoctor.debug { "Renderer is #{renderer}" }
+      @document.playback_attributes @attributes
       renderer.render('block_table', self) 
     end
   
@@ -394,7 +395,7 @@ module Asciidoctor
     def close_open_cell(next_cell_spec = {})
       push_cell_spec next_cell_spec
       close_cell(true) if cell_open?
-      next_line
+      advance
       nil
     end
   
@@ -498,7 +499,7 @@ module Asciidoctor
   
     # Internal: Advance to the next line (which may come after the parser begins processing
     # the next line if the last cell had wrapped content).
-    def next_line
+    def advance
       @linenum += 1
     end
   

--- a/test/lexer_test.rb
+++ b/test/lexer_test.rb
@@ -355,4 +355,12 @@ context "Lexer" do
     assert_equal '2013-12-18', metadata['revdate']
   end
 
+  test "attribute entry overrides generated author initials" do
+    blankdoc = Asciidoctor::Document.new
+    reader = Asciidoctor::Reader.new "Stuart Rackham <founder@asciidoc.org>\n:Author Initials: SJR".lines.entries
+    metadata = Asciidoctor::Lexer.parse_header_metadata(reader, blankdoc)
+    assert_equal 'SR', metadata['authorinitials']
+    assert_equal 'SJR', blankdoc.attributes['authorinitials']
+  end
+
 end

--- a/test/lists_test.rb
+++ b/test/lists_test.rb
@@ -88,6 +88,22 @@ List
       assert_xpath '(//ul)[2]/preceding-sibling::*[@class = "title"][text() = "Also"]', output, 1
     end
 
+    test "dash elements separated by an attribute entry offset by a blank line should not merge lists" do
+      input = <<-EOS
+== List
+
+- Foo
+- Boo
+
+:foo: bar
+- Blech
+      EOS
+      output = render_embedded_string input
+      assert_xpath '//ul', output, 2
+      assert_xpath '(//ul)[1]/li', output, 2
+      assert_xpath '(//ul)[2]/li', output, 1
+    end
+
     test 'a non-indented wrapped line is folded into text of list item' do
       input = <<-EOS
 List
@@ -102,6 +118,36 @@ wrapped content
       assert_xpath '//ul', output, 1
       assert_xpath '//ul/li[1]/*', output, 1
       assert_xpath "//ul/li[1]/p[text() = 'Foo\nwrapped content']", output, 1
+    end
+
+    test 'a non-indented wrapped line that resembles a block title is folded into text of list item' do
+      input = <<-EOS
+== List
+
+- Foo
+.wrapped content
+- Boo
+- Blech
+      EOS
+      output = render_embedded_string input
+      assert_xpath '//ul', output, 1
+      assert_xpath '//ul/li[1]/*', output, 1
+      assert_xpath "//ul/li[1]/p[text() = 'Foo\n.wrapped content']", output, 1
+    end
+
+    test 'a non-indented wrapped line that resembles an attribute entry is folded into text of list item' do
+      input = <<-EOS
+== List
+
+- Foo
+:foo: bar
+- Boo
+- Blech
+      EOS
+      output = render_embedded_string input
+      assert_xpath '//ul', output, 1
+      assert_xpath '//ul/li[1]/*', output, 1
+      assert_xpath "//ul/li[1]/p[text() = 'Foo\n:foo: bar']", output, 1
     end
 
     test 'an indented wrapped line is unindented and folded into text of list item' do
@@ -355,6 +401,22 @@ List
       assert_xpath '(//ul)[1]/li', output, 2
       assert_xpath '(//ul)[2]/li', output, 1
       assert_xpath '(//ul)[2]/preceding-sibling::*[@class = "title"][text() = "Also"]', output, 1
+    end
+
+    test "asterisk elements separated by an attribute entry offset by a blank line should not merge lists" do
+      input = <<-EOS
+== List
+
+* Foo
+* Boo
+
+:foo: bar
+* Blech
+      EOS
+      output = render_embedded_string input
+      assert_xpath '//ul', output, 2
+      assert_xpath '(//ul)[1]/li', output, 2
+      assert_xpath '(//ul)[2]/li', output, 1
     end
 
     test "list should terminate before next lower section heading" do
@@ -815,6 +877,7 @@ Lists
 
 * Item one, paragraph one
 +
+:foo: bar
 [[beck]]
 .Read the following aloud to yourself
 [source, ruby]
@@ -1294,6 +1357,22 @@ List
       assert_xpath '(//ol)[1]/li', output, 2
       assert_xpath '(//ol)[2]/li', output, 1
       assert_xpath '(//ol)[2]/preceding-sibling::*[@class = "title"][text() = "Also"]', output, 1
+    end
+
+    test "dot elements separated by an attribute entry offset by a blank line should not merge lists" do
+      input = <<-EOS
+== List
+
+. Foo
+. Boo
+
+:foo: bar
+. Blech
+      EOS
+      output = render_embedded_string input
+      assert_xpath '//ol', output, 2
+      assert_xpath '(//ol)[1]/li', output, 2
+      assert_xpath '(//ol)[2]/li', output, 1
     end
   end
 end


### PR DESCRIPTION
Process attribute entries and preprocessor directives when parsing.
- move processing of all lines into parser so the logic is contextual
- add preprocessing mode to Reader for handling preprocessing directives
- record attribute assignments below header and playback during rendering
- parse document header in distinct parsing step
- strip whitespace from end of all lines
- remove unnecessary trailing whitespace match from line regular expressions
- use chomp instead of rstrip when checking for blank lines
- improve/optimize several of the regular expressions
- add support for multiple attributes in ifdef and ifndef
- add very constrained version of ifeval for comparing attribute values
- support nested includes (by way of flattening source)
- preliminary support for tracking line numbers (don't expect much yet)
- move hard-coded english captions into attributes
- add option to stop parsing document after header
- add convenience methods to Document for author and revdate
- rename several methods on Reader for readability
- add multiple-line support to peek_lines
- if the caption attribute exists on document, it should disable automatic captions
- add automatic caption for listing block (if listing-caption attribute is assigned)
- fix a list bug where it was not treating certain wrapped lines as text
- add check for attribute entry in list handling code
- optimizations
- TomDoc
- tests!
