### PR TITLE
Resolves #103 include document title when header/footer disabled

### DIFF
--- a/lib/asciidoctor/backends/html5.rb
+++ b/lib/asciidoctor/backends/html5.rb
@@ -143,7 +143,8 @@ end
 class EmbeddedTemplate < ::Asciidoctor::BaseTemplate
   def template
     @template ||= @eruby.new <<-EOS
-<%#encoding:UTF-8%><%= content %>
+<%#encoding:UTF-8%><% unless notitle || !has_header? %><h1#{id}><%= header.title %></h1>
+<% end %><%= content %>
     EOS
   end
 end

--- a/lib/asciidoctor/document.rb
+++ b/lib/asciidoctor/document.rb
@@ -132,6 +132,7 @@ class Asciidoctor::Document < Asciidoctor::AbstractBlock
     @attributes['asciidoctor-version'] = VERSION
     @attributes['sectids'] = ''
     @attributes['encoding'] = 'UTF-8'
+    @attributes['notitle'] = '' if !@options[:header_footer]
 
     # language strings
     # TODO load these based on language settings

--- a/test/document_test.rb
+++ b/test/document_test.rb
@@ -335,6 +335,7 @@ more info...
       result = render_string("= Title\n\npreamble")
       assert_xpath '/html', result, 1
       assert_xpath '//*[@id="header"]', result, 1
+      assert_xpath '//*[@id="header"]/h1', result, 1
       assert_xpath '//*[@id="footer"]', result, 1
       assert_xpath '//*[@id="preamble"]', result, 1
     end
@@ -342,9 +343,21 @@ more info...
     test 'no header footer' do
       result = render_string("= Title\n\npreamble", :header_footer => false)
       assert_xpath '/html', result, 0
+      assert_xpath '/h1', result, 0
       assert_xpath '/*[@id="header"]', result, 0
       assert_xpath '/*[@id="footer"]', result, 0
       assert_xpath '/*[@id="preamble"]', result, 1
+    end
+
+    test 'wip enable title when no header footer' do
+      result = render_string("= Title\n\npreamble", :header_footer => false, :attributes => {'notitle!' => ''})
+      assert_xpath '/html', result, 0
+      assert_xpath '/h1', result, 1
+      assert_xpath '/*[@id="header"]', result, 0
+      assert_xpath '/*[@id="footer"]', result, 0
+      assert_xpath '/*[@id="preamble"]', result, 1
+      assert_xpath '(/*)[1]/self::h1', result, 1
+      assert_xpath '(/*)[2]/self::*[@id="preamble"]', result, 1
     end
 
     test 'parse header only' do


### PR DESCRIPTION
- unset the notitle attribute to enable <h1> at top of embedded output
