### PR TITLE
Turn include into a link to source file in secure mode

### DIFF
--- a/README.asciidoc
+++ b/README.asciidoc
@@ -303,11 +303,18 @@ NOTE: In general, Asciidoctor handles whitespace much more intelligently
 * Asciidoctor allows the document id to be set using [[id]] above the
   document header (adds id attribute to +<body>+ tag)
 
+* Asciidoctor allows the author and revision attributes to be referenced
+  in subsequent attribute entries in header (unlike AsciiDoc)
+
 * Assigning value to the +listing-caption+ attribute will enable
   automatic captions for listings (like examples, tables and figures)
 
 * The +ifeval::[]+ macro is constrained for the strict purpose of
   comparing values of attributes
+
+* The +include::[]+ macro is converted to a link to the target document
+  when SafeMode is SECURE or greater (this makes for a friendly
+  experience on GitHub)
 
 If there's a difference you don't see in this list, check the {issues}[issue
 tracker] to see if it's an outstanding feature, or file an issue to report the

--- a/lib/asciidoctor/reader.rb
+++ b/lib/asciidoctor/reader.rb
@@ -424,7 +424,9 @@ class Reader
   # returns a Boolean indicating whether the line under the cursor has changed.
   def preprocess_include(target)
     # if running in SafeMode::SECURE or greater, don't process this directive
+    # however, be friendly and at least make it a link to the source document
     if @document.safe >= SafeMode::SECURE
+      @lines[0] = "link:#{target}[#{target}]"
       @next_line_preprocessed = true
       false
     # assume that if a block is given, the developer wants

--- a/test/reader_test.rb
+++ b/test/reader_test.rb
@@ -153,13 +153,14 @@ This is a paragraph outside the block.
   end
 
   context 'Include Macro' do
-    test 'include macro is disabled by default' do
+    test 'include macro is disabled by default and becomes a link' do
       input = <<-EOS
 include::include-file.asciidoc[]
       EOS
       para = block_from_string input, :attributes => { 'include-depth' => 0 }
       assert_equal 1, para.buffer.size
-      assert_equal 'include::include-file.asciidoc[]', para.buffer.join
+      #assert_equal 'include::include-file.asciidoc[]', para.buffer.join
+      assert_equal 'link:include-file.asciidoc[include-file.asciidoc]', para.buffer.join
     end
 
     test 'include macro is enabled when safe mode is less than SECURE' do


### PR DESCRIPTION
I think this is a really nice change for the user experience on GitHub. Since we aren't (yet) going to process the include macro, the least we can do is link to the target document so they can continue browsing the content.
