### PR TITLE
resolves #213 support email links and mailto macros

### DIFF
--- a/lib/asciidoctor.rb
+++ b/lib/asciidoctor.rb
@@ -1,4 +1,3 @@
-require 'rubygems'
 require 'strscan'
 
 $:.unshift(File.dirname(__FILE__))
@@ -303,7 +302,11 @@ module Asciidoctor
 
     # inline link macro
     # link:path[label]
-    :link_macro       => /\\?link:([^\s\[]+)(?:\[((?:\\\]|[^\]])*?)\])/,
+    :link_macro       => /\\?(?:link|mailto):([^\s\[]+)(?:\[((?:\\\]|[^\]])*?)\])/,
+
+    # inline email address
+    # doc.writer@asciidoc.org
+    :email_inline     => /[\\>:]?\w[\w.%+-]*@[[:alnum:]][[:alnum:].-]*\.[[:alpha:]]{2,4}\b/, 
 
     # ----
     #:listing          => /^\-{4,}$/,

--- a/lib/asciidoctor/backends/html5.rb
+++ b/lib/asciidoctor/backends/html5.rb
@@ -642,10 +642,10 @@ class InlineAnchorTemplate < BaseTemplate
       %(<a href="##{target}">#{text}</a>)
     when :ref
       %(<a id="#{target}"></a>)
-    when :bibref
-      %(<a id="#{target}"></a>[#{target}])
     when :link
       %(<a href="#{target}"#{window && " target=\"#{window}\""}>#{text}</a>)
+    when :bibref
+      %(<a id="#{target}"></a>[#{target}])
     end
   end
 

--- a/lib/asciidoctor/helpers.rb
+++ b/lib/asciidoctor/helpers.rb
@@ -21,6 +21,22 @@ module Helpers
     require name
   end
 
+  # Public: Encode a string for inclusion in a URI
+  #
+  # str - the string to encode
+  #
+  # returns an encoded version of the str
+  def self.encode_uri(str)
+    str.gsub /[^\w\-.!~*';:@=+$,()\[\]]/ do
+      match = $&
+      buf = ''
+      match.each_byte do |c|
+        buf << sprintf('%%%02X', c)
+      end
+      buf
+    end
+  end
+
   # Public: A generic capture output routine to be used in templates
   #def self.capture_output(*args, &block)
   #  Proc.new { block.call(*args) }

--- a/test/substitutions_test.rb
+++ b/test/substitutions_test.rb
@@ -286,6 +286,42 @@ context 'Substitutions' do
       assert_equal %q{<a href="/home.html">Home</a>}, para.sub_macros(para.buffer.join)
     end
 
+    test 'a mailto macro should be interpreted as a mailto link' do
+      para = block_from_string('mailto:doc.writer@asciidoc.org[]')
+      assert_equal %q{<a href="mailto:doc.writer@asciidoc.org">doc.writer@asciidoc.org</a>}, para.sub_macros(para.buffer.join)
+    end
+
+    test 'a mailto macro with text should be interpreted as a mailto link' do
+      para = block_from_string('mailto:doc.writer@asciidoc.org[Doc Writer]')
+      assert_equal %q{<a href="mailto:doc.writer@asciidoc.org">Doc Writer</a>}, para.sub_macros(para.buffer.join)
+    end
+
+    test 'a mailto macro with text and subject should be interpreted as a mailto link' do
+      para = block_from_string('mailto:doc.writer@asciidoc.org[Doc Writer, Pull request]', :attributes => {'linkattrs' => ''})
+      assert_equal %q{<a href="mailto:doc.writer@asciidoc.org?subject=Pull%20request">Doc Writer</a>}, para.sub_macros(para.buffer.join)
+    end
+
+    test 'a mailto macro with text, subject and body should be interpreted as a mailto link' do
+      para = block_from_string('mailto:doc.writer@asciidoc.org[Doc Writer, Pull request, Please accept my pull request]', :attributes => {'linkattrs' => ''})
+      assert_equal %q{<a href="mailto:doc.writer@asciidoc.org?subject=Pull%20request&amp;body=Please%20accept%20my%20pull%20request">Doc Writer</a>}, para.sub_macros(para.buffer.join)
+    end
+
+    test 'should recognize inline email addresses' do
+      para = block_from_string('doc.writer@asciidoc.org')
+      assert_equal %q{<a href="mailto:doc.writer@asciidoc.org">doc.writer@asciidoc.org</a>}, para.sub_macros(para.buffer.join)
+      para = block_from_string('<doc.writer@asciidoc.org>')
+      assert_equal %q{&lt;<a href="mailto:doc.writer@asciidoc.org">doc.writer@asciidoc.org</a>&gt;}, para.apply_normal_subs(para.buffer)
+      para = block_from_string('author+website@4fs.no')
+      assert_equal %q{<a href="mailto:author+website@4fs.no">author+website@4fs.no</a>}, para.sub_macros(para.buffer.join)
+      para = block_from_string('john@domain.uk.co')
+      assert_equal %q{<a href="mailto:john@domain.uk.co">john@domain.uk.co</a>}, para.sub_macros(para.buffer.join)
+    end
+
+    test 'should ignore escaped inline email address' do
+      para = block_from_string('\doc.writer@asciidoc.org')
+      assert_equal %q{doc.writer@asciidoc.org}, para.sub_macros(para.buffer.join)
+    end
+
     test 'a single-line raw url should be interpreted as a link' do
       para = block_from_string('http://google.com')
       assert_equal %q{<a href="http://google.com">http://google.com</a>}, para.sub_macros(para.buffer.join)


### PR DESCRIPTION
I also removed the require 'rubygems' import since this is no no in Ruby land.
