### PR TITLE
recognize opts as shorthand for options

### DIFF
--- a/README.asciidoc
+++ b/README.asciidoc
@@ -30,7 +30,7 @@ Asciidoctor uses a set of built-in ERB templates to render the document
 to HTML 5 or DocBook 4.5. We've matched the rendered output as close as
 possible to the default output of the native Python processor. You can
 override this behavior by providing {tilt}[Tilt]-compatible templates.
-See the xref:usage[Usage section] for more details.
+See <<usage,Usage>> for more details.
 
 Asciidoctor currently works (read as 'tested') with Ruby 1.8.7, Ruby
 1.9.3, Ruby 2.0.0, JRuby 1.7.2 and Rubinius 1.2.4 (on Linux, Mac and
@@ -225,6 +225,8 @@ Here are the known cases where Asciidoctor differs from AsciiDoc:
 * Asciidoctor is much more lenient about attribute list parsing (double
   quotes are rarely needed, though you may want to keep them for
   compatibility)
+
+* Asciidoctor recognizes +opts+ as an alias for the +options+ attribute.
 
 * Asciidoctor creates xref labels using the text from the linked section
   title when rendering HTML to match how DocBook works

--- a/lib/asciidoctor/attribute_list.rb
+++ b/lib/asciidoctor/attribute_list.rb
@@ -166,9 +166,10 @@ class AttributeList
     else
       resolved_value = value
       # example: options="opt1,opt2,opt3"
-      if name == 'options'
+      if name == 'options' || name == 'opts'
+        name = 'options'
         resolved_value.split(CSV_SPLIT_PATTERN).each do |o|
-          @attributes[o + '-option'] = nil
+          @attributes[o + '-option'] = ''
         end
       elsif single_quoted_value && !@block.nil?
         resolved_value = @block.apply_normal_subs(value)

--- a/test/lexer_test.rb
+++ b/test/lexer_test.rb
@@ -154,7 +154,15 @@ context "Lexer" do
   test "collect options attribute" do
     attributes = {}
     line = "quote, options='opt1,opt2 , opt3'"
-    expected = {1 => 'quote', 'options' => 'opt1,opt2 , opt3', 'opt1-option' => nil, 'opt2-option' => nil, 'opt3-option' => nil}
+    expected = {1 => 'quote', 'options' => 'opt1,opt2 , opt3', 'opt1-option' => '', 'opt2-option' => '', 'opt3-option' => ''}
+    Asciidoctor::AttributeList.new(line).parse_into(attributes)
+    assert_equal expected, attributes
+  end
+
+  test "collect opts attribute as options" do
+    attributes = {}
+    line = "quote, opts='opt1,opt2 , opt3'"
+    expected = {1 => 'quote', 'options' => 'opt1,opt2 , opt3', 'opt1-option' => '', 'opt2-option' => '', 'opt3-option' => ''}
     Asciidoctor::AttributeList.new(line).parse_into(attributes)
     assert_equal expected, attributes
   end


### PR DESCRIPTION
- allow opts attribute to be used as a shorthand to options
- set the default value of each option to empty string instead of nil
