### PR TITLE
resolves #260 use code element instead of tt

### DIFF
--- a/README.asciidoc
+++ b/README.asciidoc
@@ -219,8 +219,13 @@ Here are the known cases where Asciidoctor differs from AsciiDoc:
 * Asciidoctor strips XML entities from the section title before
   generating the id (makes for cleaner section ids)
 
-* Asciidoctor use +<tt>+ instead of +<span class="monospace">+ around
+* Asciidoctor uses +<code>+ instead of +<span class="monospace">+ around
   inline literal text in the HTML backend
+
+* Asciidoctor does not wrap email next to author name in header in
+  angle brackets
+
+* Asciidoctor allows email field to be a URL and renders it as such
 
 * Asciidoctor is much more lenient about attribute list parsing (double
   quotes are rarely needed, though you may want to keep them for

--- a/lib/asciidoctor/backends/html5.rb
+++ b/lib/asciidoctor/backends/html5.rb
@@ -105,7 +105,7 @@ pre code { background-color: #F8F8F8; padding: 0; }
       <h1><%= @header.title %></h1>
       <% end %>
       <% if attr? :author %><span id="author"><%= attr :author %></span><br>
-      <% if attr? :email %><span id="email" class="monospaced">&lt;<%= attr :email %>&gt;</span><br><% end %><% end %>
+      <% if attr? :email %><span id="email"><%= sub_macros(attr :email) %></span><br><% end %><% end %>
       <% if attr? :revnumber %><span id="revnumber">version <%= attr :revnumber %><%= attr?(:revdate) ? ',' : '' %></span><% end %>
       <% if attr? :revdate %><span id="revdate"><%= attr :revdate %></span><% end %>
       <% if attr? :revremark %><br><span id="revremark"><%= attr :revremark %></span><% end %>
@@ -618,7 +618,7 @@ class InlineQuotedTemplate < BaseTemplate
   QUOTED_TAGS = {
     :emphasis => ['<em>', '</em>'],
     :strong => ['<strong>', '</strong>'],
-    :monospaced => ['<tt>', '</tt>'],
+    :monospaced => ['<code>', '</code>'],
     :superscript => ['<sup>', '</sup>'],
     :subscript => ['<sub>', '</sub>'],
     :double => ['&#8220;', '&#8221;'],

--- a/test/attributes_test.rb
+++ b/test/attributes_test.rb
@@ -227,7 +227,7 @@ preamble
 To use {gem_name}, the first thing to do is to import it in your Ruby source file.
       EOS
       output = render_embedded_string input
-      assert_xpath '//*[@class="title"]/tt[text()="asciidoctor"]', output, 1
+      assert_xpath '//*[@class="title"]/code[text()="asciidoctor"]', output, 1
     end
 
     test 'renders attribute until it is deleted' do

--- a/test/document_test.rb
+++ b/test/document_test.rb
@@ -434,7 +434,7 @@ more info...
       EOS
       output = render_string input
       assert_xpath '//*[@id="header"]/span[@id="author"][text() = "Stuart Rackham"]', output, 1
-      assert_xpath '//*[@id="header"]/span[@id="email"][contains(text(), "founder@asciidoc.org")]', output, 1
+      assert_xpath '//*[@id="header"]/span[@id="email"]/a[@href="mailto:founder@asciidoc.org"][text() = "founder@asciidoc.org"]', output, 1
       assert_xpath '//*[@id="header"]/span[@id="revnumber"][text() = "version 8.6.8,"]', output, 1
       assert_xpath '//*[@id="header"]/span[@id="revdate"][text() = "2012-07-12"]', output, 1
       assert_xpath '//*[@id="header"]/span[@id="revremark"][text() = "See changelog."]', output, 1

--- a/test/lists_test.rb
+++ b/test/lists_test.rb
@@ -472,7 +472,7 @@ List
       assert_xpath '//ul/li', output, 3
       assert_xpath '(//ul/li)[1]//strong', output, 1
       assert_xpath '(//ul/li)[2]//em', output, 1
-      assert_xpath '(//ul/li)[3]//tt', output, 1
+      assert_xpath '(//ul/li)[3]//code', output, 1
     end
 
     test "attribute substitutions" do

--- a/test/substitutions_test.rb
+++ b/test/substitutions_test.rb
@@ -158,7 +158,7 @@ context 'Substitutions' do
     test 'single-line constrained monospaced string' do
       para = block_from_string(%q{`a few <\{monospaced\}> words`})
       # NOTE must use apply_normal_subs because constrained monospaced is handled as a passthrough
-      assert_equal '<tt>a few &lt;{monospaced}&gt; words</tt>', para.apply_normal_subs(para.buffer)
+      assert_equal '<code>a few &lt;{monospaced}&gt; words</code>', para.apply_normal_subs(para.buffer)
     end
 
     test 'escaped single-line constrained monospaced string' do
@@ -170,7 +170,7 @@ context 'Substitutions' do
     test 'multi-line constrained monospaced string' do
       para = block_from_string(%Q{`a few\n<\{monospaced\}> words`})
       # NOTE must use apply_normal_subs because constrained monospaced is handled as a passthrough
-      assert_equal "<tt>a few\n&lt;{monospaced}&gt; words</tt>", para.apply_normal_subs(para.buffer)
+      assert_equal "<code>a few\n&lt;{monospaced}&gt; words</code>", para.apply_normal_subs(para.buffer)
     end
 
     test 'single-line unconstrained strong chars' do
@@ -231,17 +231,17 @@ context 'Substitutions' do
 
     test 'single-line unconstrained monospaced chars' do
       para = block_from_string(%q{Git++Hub++})
-      assert_equal 'Git<tt>Hub</tt>', para.sub_quotes(para.buffer.join)
+      assert_equal 'Git<code>Hub</code>', para.sub_quotes(para.buffer.join)
     end
 
     test 'escaped single-line unconstrained monospaced chars' do
       para = block_from_string(%q{Git\++Hub++})
-      assert_equal 'Git+<tt>Hub</tt>+', para.sub_quotes(para.buffer.join)
+      assert_equal 'Git+<code>Hub</code>+', para.sub_quotes(para.buffer.join)
     end
 
     test 'multi-line unconstrained monospaced chars' do
       para = block_from_string(%Q{Git++\nH\nu\nb++})
-      assert_equal "Git<tt>\nH\nu\nb</tt>", para.sub_quotes(para.buffer.join)
+      assert_equal "Git<code>\nH\nu\nb</code>", para.sub_quotes(para.buffer.join)
     end
 
     test 'single-line superscript chars' do

--- a/test/tables_test.rb
+++ b/test/tables_test.rb
@@ -279,14 +279,14 @@ d|9 2+>|10
       assert_css 'table tr:nth-child(1) > td:nth-child(4).halign-right.valign-top p strong', output, 1
 
       assert_css 'table tr:nth-child(2) > td:nth-child(1).halign-center.valign-top p em', output, 1
-      assert_css 'table tr:nth-child(2) > td:nth-child(2).halign-center.valign-middle[colspan="2"][rowspan="2"] p tt', output, 1
-      assert_css 'table tr:nth-child(2) > td:nth-child(3).halign-left.valign-bottom[rowspan="3"] p tt', output, 1
+      assert_css 'table tr:nth-child(2) > td:nth-child(2).halign-center.valign-middle[colspan="2"][rowspan="2"] p code', output, 1
+      assert_css 'table tr:nth-child(2) > td:nth-child(3).halign-left.valign-bottom[rowspan="3"] p code', output, 1
 
       assert_css 'table tr:nth-child(3) > td:nth-child(1).halign-center.valign-top p em', output, 1
 
       assert_css 'table tr:nth-child(4) > td:nth-child(1).halign-left.valign-top p', output, 1
       assert_css 'table tr:nth-child(4) > td:nth-child(1).halign-left.valign-top p em', output, 0
-      assert_css 'table tr:nth-child(4) > td:nth-child(2).halign-right.valign-top[colspan="2"] p tt', output, 1
+      assert_css 'table tr:nth-child(4) > td:nth-child(2).halign-right.valign-top[colspan="2"] p code', output, 1
     end
 
     test 'supports repeating cells' do

--- a/test/text_test.rb
+++ b/test/text_test.rb
@@ -89,7 +89,7 @@ context "Text" do
   end
 
   test "backtick-escaped text followed by single-quoted text" do
-    assert_match(/<tt>foo<\/tt>/, render_string(%Q(run `foo` 'dog')))
+    assert_match(/<code>foo<\/code>/, render_string(%Q(run `foo` 'dog')))
   end
 
   context "basic styling" do
@@ -106,7 +106,7 @@ context "Text" do
     end
 
     test "monospaced" do
-      assert_xpath "//tt", @rendered
+      assert_xpath "//code", @rendered
     end
 
     test "superscript" do
@@ -118,21 +118,21 @@ context "Text" do
     end
 
     test "backticks" do
-      assert_xpath "//tt", render_string("This is `totally cool`.")
+      assert_xpath "//code", render_string("This is `totally cool`.")
     end
 
     test "nested styles" do
       rendered = render_string("Winning *big _time_* in the +city *boyeeee*+.")
 
       assert_xpath "//strong/em", rendered
-      assert_xpath "//tt/strong", rendered
+      assert_xpath "//code/strong", rendered
     end
 
     test "unconstrained quotes" do
       rendered_chars = render_string("**B**__I__++M++")
       assert_xpath "//strong", rendered_chars
       assert_xpath "//em", rendered_chars
-      assert_xpath "//tt", rendered_chars
+      assert_xpath "//code", rendered_chars
     end
   end
 end


### PR DESCRIPTION
- perform macro sustitution on email in document header
