### PR TITLE
resolves #187 complete masquerade functionality for blocks & paragraphs

### DIFF
--- a/lib/asciidoctor/abstract_block.rb
+++ b/lib/asciidoctor/abstract_block.rb
@@ -189,6 +189,45 @@ class AbstractBlock < AbstractNode
     }
   end
 
+  # Public: Generate a caption and assign it to this block if one
+  # is not already assigned.
+  #
+  # If the block has a title and a caption prefix is available
+  # for this block, then build a caption from this information,
+  # assign it a number and store it to the caption attribute on
+  # the block.
+  #
+  # If an explicit caption has been specified on this block, then
+  # do nothing.
+  #
+  # key         - The prefix of the caption and counter attribute names.
+  #               If not provided, the name of the context for this block
+  #               is used. (default: nil).
+  #
+  # returns nothing
+  def assign_caption(caption = nil, key = nil)
+    unless title? || @caption.nil?
+      return nil
+    end
+
+    if caption.nil?
+      if @document.attr?('caption')
+        @caption = @document.attr('caption')
+      else
+        key ||= @context.to_s
+        caption_key = "#{key}-caption"
+        if @document.attributes.has_key?(caption_key)
+          caption_title = @document.attributes["#{key}-caption"]
+          caption_num = @document.counter_increment("#{key}-number", self)
+          @caption = @attributes['caption'] = "#{caption_title} #{caption_num}. "
+        end
+      end
+    else
+      @caption = caption
+    end
+    nil
+  end
+
   # Internal: Assign the next index (0-based) to this section
   #
   # Assign the next index of this section within the parent

--- a/lib/asciidoctor/abstract_node.rb
+++ b/lib/asciidoctor/abstract_node.rb
@@ -94,6 +94,27 @@ class AbstractNode
     end
   end
 
+  # Public: Assign the value to the specified key in this
+  # block's attributes hash.
+  #
+  # key - The attribute key (or name)
+  # val - The value to assign to the key
+  #
+  # returns a flag indicating whether the assignment was performed
+  def set_attr(key, val, overwrite = nil)
+    if overwrite.nil?
+      @attributes[key] = val
+      true
+    else
+      if overwrite || @attributes.has_key?(key)
+        @attributes[key] = val
+        true
+      else
+        false
+      end
+    end
+  end
+
   # Public: Get the execution context of this object (via Kernel#binding).
   #
   # This method is used to set the 'self' reference as well as local variables

--- a/lib/asciidoctor/attribute_list.rb
+++ b/lib/asciidoctor/attribute_list.rb
@@ -84,6 +84,7 @@ class AttributeList
 
   def self.rekey(attributes, pos_attrs)
     pos_attrs.each_with_index do |key, index|
+      next if key.nil?
       pos = index + 1
       unless (val = attributes[pos]).nil?
         attributes[key] = val

--- a/lib/asciidoctor/backends/html5.rb
+++ b/lib/asciidoctor/backends/html5.rb
@@ -344,8 +344,8 @@ end
 
 class BlockParagraphTemplate < BaseTemplate
   def paragraph(id, role, title, content)
-    %(<div#{id && " id=\"#{id}\""} class=\"paragraph#{role && " #{role}"}\">
-  #{title && "<div class=\"title\">#{title}</div>"}  
+    %(<div#{id && " id=\"#{id}\""} class=\"paragraph#{role && " #{role}"}\">#{title && "
+  <div class=\"title\">#{title}</div>"}  
   <p>#{content}</p>
 </div>)
   end

--- a/lib/asciidoctor/block.rb
+++ b/lib/asciidoctor/block.rb
@@ -26,6 +26,7 @@ class Block < AbstractBlock
   def initialize(parent, context, buffer = nil)
     super(parent, context)
     @buffer = buffer
+    @caption = nil
   end
 
   # Public: Get the rendered String content for this Block.  If the block
@@ -95,7 +96,7 @@ class Block < AbstractBlock
   #   => ["<em>This</em> is what happens when you &lt;meet&gt; a stranger in the &lt;alps&gt;!"]
   def content
     case @context
-    when :preamble, :open, :example, :sidebar
+    when :preamble, :open
       @blocks.map {|b| b.render }.join
     # lists get iterated in the template (for now)
     # list items recurse into this block when their text and content methods are called
@@ -105,7 +106,7 @@ class Block < AbstractBlock
       apply_literal_subs(@buffer)
     when :pass
       apply_passthrough_subs(@buffer)
-    when :quote, :verse, :admonition
+    when :admonition, :example, :sidebar, :quote, :verse
       if !@buffer.nil?
         apply_para_subs(@buffer)
       else

--- a/lib/asciidoctor/document.rb
+++ b/lib/asciidoctor/document.rb
@@ -269,6 +269,18 @@ class Document < AbstractBlock
     (@attributes[name] = @counters[name])
   end
 
+  # Public: Increment the specified counter and store it in the block's attributes
+  #
+  # counter_name - the String name of the counter attribute
+  # block        - the Block on which to save the counter
+  #
+  # returns the next number in the sequence for the specified counter
+  def counter_increment(counter_name, block)
+    val = counter(counter_name)
+    AttributeEntry.new(counter_name, val).save_to(block.attributes)
+    val
+  end
+
   # Internal: Get the next value in the sequence.
   #
   # Handles both integer and character sequences.

--- a/test/attributes_test.rb
+++ b/test/attributes_test.rb
@@ -403,10 +403,10 @@ of the attribute named foo in your document.
     
   end
 
-  context "Block attributes" do
-    test "Position attributes assigned to block" do
+  context 'Block attributes' do
+    test 'Positional attributes assigned to block' do
       input = <<-EOS
-[quote, Name, Source]
+[quote, author, source]
 ____
 A famous quote.
 ____
@@ -415,13 +415,13 @@ ____
       qb = doc.blocks.first
       assert_equal 'quote', qb.attributes['style']
       assert_equal 'quote', qb.attr(:style)
-      assert_equal 'Name', qb.attributes['attribution']
-      assert_equal 'Source', qb.attributes['citetitle']
+      assert_equal 'author', qb.attributes['attribution']
+      assert_equal 'source', qb.attributes['citetitle']
     end
 
-    test "Normal substitutions are performed on single-quoted attributes" do
+    test 'Normal substitutions are performed on single-quoted attributes' do
       input = <<-EOS
-[quote, Name, 'http://wikipedia.org[Source]']
+[quote, author, 'http://wikipedia.org[source]']
 ____
 A famous quote.
 ____
@@ -430,8 +430,36 @@ ____
       qb = doc.blocks.first
       assert_equal 'quote', qb.attributes['style']
       assert_equal 'quote', qb.attr(:style)
-      assert_equal 'Name', qb.attributes['attribution']
-      assert_equal '<a href="http://wikipedia.org">Source</a>', qb.attributes['citetitle']
+      assert_equal 'author', qb.attributes['attribution']
+      assert_equal '<a href="http://wikipedia.org">source</a>', qb.attributes['citetitle']
+    end
+
+    test 'attribute list may begin with space' do
+      input = <<-EOS
+[ quote]
+____
+A famous quote.
+____
+      EOS
+
+      doc = document_from_string input
+      qb = doc.blocks.first
+      assert_equal 'quote', qb.attributes['style']
+    end
+
+    test 'attribute list may begin with comma' do
+      input = <<-EOS
+[, author, source]
+____
+A famous quote.
+____
+      EOS
+
+      doc = document_from_string input
+      qb = doc.blocks.first
+      assert_equal 'quote', qb.attributes['style']
+      assert_equal 'author', qb.attributes['attribution']
+      assert_equal 'source', qb.attributes['citetitle']
     end
 
     test "Attribute substitutions are performed on attribute list before parsing attributes" do

--- a/test/lists_test.rb
+++ b/test/lists_test.rb
@@ -2666,6 +2666,55 @@ para
       assert_xpath '//*[@class="dlist"]//dd/*[@class="paragraph"]', output, 1
       assert_xpath '//*[@class="dlist"]//dd/*[@class="paragraph"]/p[text()="para"]', output, 1
     end
+
+    test 'attached paragraph does not break on adjacent nested labeled list term' do
+      input = <<-EOS
+term1:: def
++
+more definition
+not a term::: def
+      EOS
+
+      output = render_embedded_string input
+      assert_css '.dlist > dl > dt', output, 1
+      assert_css '.dlist > dl > dd', output, 1
+      assert_css '.dlist > dl > dd > .paragraph', output, 1
+      assert output.include?('not a term::: def')
+    end
+
+    # FIXME pending
+=begin
+    test 'attached paragraph does not break on adjacent sibling labeled list term' do
+      input = <<-EOS
+term1:: def
++
+more definition
+not a term:: def
+      EOS
+
+      output = render_embedded_string input
+      assert_css '.dlist > dl > dt', output, 1
+      assert_css '.dlist > dl > dd', output, 1
+      assert_css '.dlist > dl > dd > .paragraph', output, 1
+      assert output.include?('not a term:: def')
+    end
+=end
+
+    test 'attached styled paragraph does not break on adjacent nested labeled list term' do
+      input = <<-EOS
+term1:: def
++
+[quote]
+more definition
+not a term::: def
+      EOS
+
+      output = render_embedded_string input
+      assert_css '.dlist > dl > dt', output, 1
+      assert_css '.dlist > dl > dd', output, 1
+      assert_css '.dlist > dl > dd > .quoteblock', output, 1
+      assert output.include?('not a term::: def')
+    end
   
     test 'appends line as paragraph if attached by continuation following blank line and line comment when term has no inline definition' do
       input = <<-EOS

--- a/test/sections_test.rb
+++ b/test/sections_test.rb
@@ -257,6 +257,23 @@ not in section
       assert floatingtitle.is_a?(Asciidoctor::Block)
       assert !floatingtitle.is_a?(Asciidoctor::Section)
       assert_equal :floating_title, floatingtitle.context
+      assert_equal '_plain_ol_heading', floatingtitle.id
+      assert doc.references[:ids].has_key?('_plain_ol_heading')
+    end
+
+    test 'can assign explicit id to floating title' do
+      input = <<-EOS
+[[unchained]]
+[float]
+=== Plain Ol' Heading
+
+not in section
+      EOS
+
+      doc = document_from_string input
+      floating_title = doc.blocks.first
+      assert_equal 'unchained', floating_title.id
+      assert doc.references[:ids].has_key?('unchained')
     end
 
     test 'should not include floating title in toc' do

--- a/test/substitutions_test.rb
+++ b/test/substitutions_test.rb
@@ -255,8 +255,8 @@ context 'Substitutions' do
     end
 
     test 'multi-line superscript chars' do
-      para = block_from_string(%Q{x^(n\n+\n1)^})
-      assert_equal "x<sup>(n\n+\n1)</sup>", para.sub_quotes(para.buffer.join)
+      para = block_from_string(%Q{x^(n\n-\n1)^})
+      assert_equal "x<sup>(n\n-\n1)</sup>", para.sub_quotes(para.buffer.join)
     end
 
     test 'single-line subscript chars' do

--- a/test/tables_test.rb
+++ b/test/tables_test.rb
@@ -43,6 +43,21 @@ context 'Tables' do
       assert_xpath '/table/caption/following-sibling::colgroup', output, 1
     end
 
+    test 'renders explicit caption on simple psv table' do
+      input = <<-EOS
+[caption="All the Data. "]
+.Simple psv table
+|=======
+|A |B |C
+|a |b |c
+|1 |2 |3
+|=======
+      EOS
+      output = render_embedded_string input
+      assert_xpath '/table/caption[@class="title"][text()="All the Data. Simple psv table"]', output, 1
+      assert_xpath '/table/caption/following-sibling::colgroup', output, 1
+    end
+
     test 'ignores escaped separators' do
       input = <<-EOS
 |===

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -67,8 +67,8 @@ class Test::Unit::TestCase
     xmlnodes_at_path(:css, css, content)
   end
 
-  def xmlnodes_at_xpath(css, content, count = nil)
-    xmlnodes_at_path(:xpath, css, content)
+  def xmlnodes_at_xpath(xpath, content, count = nil)
+    xmlnodes_at_path(:xpath, xpath, content)
   end
 
   def xmlnodes_at_path(type, path, content, count = nil)


### PR DESCRIPTION
- rework block parsing
- move block creation to a separate method
- add method to assign or generate block caption
- add set_attr method to block
- use sets where appropriate to improve speed
- cleanup two-line section matching
- optimize reader operations
- add flags to control compliance w/ AsciiDoc
- tests for masquerading, captions and other compliance

NOTE: this pull request will likely conflict with #258. Request rebase once that pull request is merged.
