### PR TITLE
Typofix: Drop extra the from template control section of manpage

### DIFF
--- a/man/asciidoctor.1
+++ b/man/asciidoctor.1
@@ -164,7 +164,7 @@ Suppress the document header and footer in the output\&.
 .PP
 \fB\-T, \-\-template\-dir\fR=\fIDIR\fR
 .RS 4
-Directory containing custom render templates that override one or more templates from the the built\-in set\&. If there is a folder in the directory that matches the backend, the templates from that folder will be used\&.
+Directory containing custom render templates that override one or more templates from the built\-in set\&. If there is a folder in the directory that matches the backend, the templates from that folder will be used\&.
 .RE
 .SS "Processing Information"
 .PP

--- a/man/asciidoctor.ad
+++ b/man/asciidoctor.ad
@@ -101,7 +101,7 @@ Rendering Control
 
 *-T, --template-dir*='DIR'::
     Directory containing custom render templates that override one or more
-    templates from the the built-in set. If there is a folder in the directory
+    templates from the built-in set. If there is a folder in the directory
     that matches the backend, the templates from that folder will be used.
 
 Processing Information


### PR DESCRIPTION
Noticed superfluous "the" show up in a sentence on the "Rendering Control - Template" section of the manpage.
