### PR TITLE
Patch for GH-317 to mark part headers more prominent in the TOC.

### DIFF
--- a/lib/asciidoctor/backends/html5.rb
+++ b/lib/asciidoctor/backends/html5.rb
@@ -38,7 +38,9 @@ class DocumentTemplate < BaseTemplate
       end
       toc_level << "#{indent}<ol>\n" if nested
       sections.each do |section|
-        toc_level << "#{indent}  <li><a href=\"##{section.id}\">#{!section.special && section.level > 0 ? "#{section.sectnum} " : ''}#{section.attr('caption')}#{section.title}</a></li>\n"
+        section_num = !section.special && section.level > 0 ? "#{section.sectnum} " : ''
+        section_class = (node.document.doctype == 'book' && section.level == 0)? "class=\"toc-part\"" : ''
+        toc_level << "#{indent}  <li><a href=\"##{section.id}\"#{section_class}>#{section_num}#{section.attr('caption')}#{section.title}</a></li>\n"
         if section.level < to_depth && (child_toc_level = outline(section, to_depth))
           if section.document.doctype != 'book' || section.level > 0
             toc_level << "#{indent}  <li>\n#{child_toc_level}\n#{indent}  </li>\n"

--- a/stylesheets/asciidoctor.css
+++ b/stylesheets/asciidoctor.css
@@ -15,6 +15,7 @@ hr { -moz-box-sizing: content-box; box-sizing: content-box; height: 0; }
 mark { background: #ff0; color: #000; }
 code, tt, kbd, pre, samp { font-family: monospace, serif; font-size: 1em; }
 pre { white-space: pre-wrap; }
+.toc-part { text-transform:uppercase; font-size: 135%;}
 q { quotes: "\201C" "\201D" "\2018" "\2019"; }
 small { font-size: 80%; }
 sub, sup { font-size: 75%; line-height: 0; position: relative; vertical-align: baseline; }


### PR DESCRIPTION
This patch allows to render part titles more prominent in the toc for books.
