### PR TITLE
cleanups and minor improvements

### DIFF
--- a/asciidoctor.gemspec
+++ b/asciidoctor.gemspec
@@ -34,8 +34,6 @@ EOS
   ## testing
   s.add_development_dependency('coderay')
   s.add_development_dependency('erubis')
-  s.add_development_dependency('htmlentities')
-  s.add_development_dependency('mocha')
   s.add_development_dependency('nokogiri')
   s.add_development_dependency('pending')
   s.add_development_dependency('rake')

--- a/lib/asciidoctor/abstract_node.rb
+++ b/lib/asciidoctor/abstract_node.rb
@@ -257,7 +257,9 @@ class AbstractNode
   def generate_data_uri(target_image, asset_dir_key = nil)
     Helpers.require_library 'base64'
 
-    mimetype = 'image/' + File.extname(target_image)[1..-1]
+    ext = File.extname(target_image)[1..-1]
+    mimetype = 'image/' + ext
+    mimetype = "#{mimetype}+xml" if ext == 'svg'
     if asset_dir_key
       #asset_dir_path = normalize_system_path(@document.attr(asset_dir_key), nil, nil, :target_name => asset_dir_key)
       #image_path = normalize_system_path(target_image, asset_dir_path, nil, :target_name => 'image')

--- a/lib/asciidoctor/backends/docbook45.rb
+++ b/lib/asciidoctor/backends/docbook45.rb
@@ -372,7 +372,7 @@ class BlockOpenTemplate < BaseTemplate
         puts 'asciidoctor: WARNING: abstract block cannot be used in a document without a title when doctype is book. Excluding block content.'
         ''
       else
-        %(<abstract>#{title && "\n<title>#{node.title}</title>"}
+        %(<abstract>#{title && "\n<title>#{title}</title>"}
 #{content node}
 </abstract>\n)
       end

--- a/lib/asciidoctor/document.rb
+++ b/lib/asciidoctor/document.rb
@@ -197,11 +197,11 @@ class Document < AbstractBlock
 
     # allow common attributes backend and doctype to be set using options hash
     unless @options[:backend].nil?
-      @attribute_overrides['backend'] = @options[:backend]
+      @attribute_overrides['backend'] = @options[:backend].to_s
     end
 
     unless @options[:doctype].nil?
-      @attribute_overrides['doctype'] = @options[:doctype]
+      @attribute_overrides['doctype'] = @options[:doctype].to_s
     end
 
     if @safe >= SafeMode::SERVER

--- a/lib/asciidoctor/lexer.rb
+++ b/lib/asciidoctor/lexer.rb
@@ -1138,7 +1138,7 @@ class Lexer
     end
 
     #puts "BUFFER[#{list_type},#{sibling_trait}]>#{buffer.join}<BUFFER"
-    #puts "BUFFER[#{list_type},#{sibling_trait}]>#{buffer}<BUFFER"
+    #puts "BUFFER[#{list_type},#{sibling_trait}]>#{buffer.inspect}<BUFFER"
 
     buffer
   end

--- a/lib/asciidoctor/renderer.rb
+++ b/lib/asciidoctor/renderer.rb
@@ -55,7 +55,8 @@ class Renderer
         :slim => { :disable_escape => true, :sort_attrs => false, :pretty => false }
       }
 
-      if backend == 'html5'
+      # workaround until we have a proper way to configure
+      if {'html5' => true, 'dzslides' => true, 'deckjs' => true, 'revealjs' => true}.has_key? backend
         view_opts[:haml][:format] = view_opts[:slim][:format] = :html5
       end
 

--- a/lib/asciidoctor/substituters.rb
+++ b/lib/asciidoctor/substituters.rb
@@ -295,7 +295,7 @@ module Substituters
           args = m[2].split(':')
           @document.counter(args[1], args[2])
           ''
-        elsif document.attributes.has_key? key
+        elsif @document.attributes.has_key? key
           @document.attributes[key]
         elsif INTRINSICS.has_key? key
           INTRINSICS[key]

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -4,12 +4,6 @@ require 'test/unit'
 
 require "#{File.expand_path(File.dirname(__FILE__))}/../lib/asciidoctor.rb"
 
-begin
-  require 'mocha/setup'
-rescue LoadError
-  require 'mocha'
-end
-require 'htmlentities'
 require 'nokogiri'
 require 'pending'
 


### PR DESCRIPTION
- remove unused dependencies (mocha, htmlentities)
- use proper mimetype for SVG
- allow backend option to be specified as symbol
- set haml format to html5 for all html backends (including slides)
