### PR TITLE
resolves #365 add indent attribute to verbatim blocks

### DIFF
--- a/test/blocks_test.rb
+++ b/test/blocks_test.rb
@@ -550,6 +550,60 @@ source line 2\r
       assert_xpath %(/*[@class="listingblock"]//pre/code[text()="source line 1\nsource line 2"]), output, 1
     end
 
+    test 'should remove block indent if indent attribute is 0' do
+      input = <<-EOS
+[indent="0"]
+----
+    def names
+
+      @names.split ' '
+
+    end
+----
+      EOS
+
+      expected = <<-EOS
+def names
+
+  @names.split ' '
+
+end
+      EOS
+
+      output = render_embedded_string input
+      assert_css 'pre', output, 1
+      assert_css '.listingblock pre', output, 1
+      result = xmlnodes_at_xpath('//pre', output, 1).text
+      assert_equal expected.chomp, result
+    end
+
+    test 'should set block indent to value specified by indent attribute' do
+      input = <<-EOS
+[indent="1"]
+----
+    def names
+
+      @names.split ' '
+
+    end
+----
+      EOS
+
+      expected = <<-EOS
+ def names
+ 
+   @names.split ' '
+ 
+ end
+      EOS
+
+      output = render_embedded_string input
+      assert_css 'pre', output, 1
+      assert_css '.listingblock pre', output, 1
+      result = xmlnodes_at_xpath('//pre', output, 1).text
+      assert_equal expected.chomp, result
+    end
+
     test 'literal block should honor explicit subs list' do
       input = <<-EOS
 [subs="verbatim,quotes"]

--- a/test/lexer_test.rb
+++ b/test/lexer_test.rb
@@ -487,4 +487,95 @@ context "Lexer" do
     assert_equal 'SJR', blankdoc.attributes['authorinitials']
   end
 
+  test 'reset block indent to 0' do
+    input = <<-EOS
+    def names
+
+      @name.split ' '
+
+    end
+    EOS
+
+    expected = <<-EOS
+def names
+
+  @name.split ' '
+
+end
+    EOS
+
+    lines = input.lines.entries
+    Asciidoctor::Lexer.reset_block_indent! lines
+    assert_equal expected, lines.join
+  end
+
+  test 'reset block indent mixed with tabs and spaces to 0' do
+    input = <<-EOS
+    def names
+
+\t  @name.split ' '
+
+    end
+    EOS
+
+    expected = <<-EOS
+def names
+
+  @name.split ' '
+
+end
+    EOS
+
+    lines = input.lines.entries
+    Asciidoctor::Lexer.reset_block_indent! lines
+    assert_equal expected, lines.join
+  end
+
+  test 'reset block indent to non-zero' do
+    input = <<-EOS
+    def names
+
+      @name.split ' '
+
+    end
+    EOS
+
+    expected = <<-EOS
+  def names
+  
+    @name.split ' '
+  
+  end
+    EOS
+
+    lines = input.lines.entries
+    Asciidoctor::Lexer.reset_block_indent! lines, 2
+    assert_equal expected, lines.join
+  end
+
+  test 'preserve block indent' do
+    input = <<-EOS
+    def names
+    
+      @name.split ' '
+    
+    end
+    EOS
+
+    expected = input
+
+    lines = input.lines.entries
+    Asciidoctor::Lexer.reset_block_indent! lines, nil
+    assert_equal expected, lines.join
+  end
+
+  test 'reset block indent hands empty lines gracefully' do
+    input = []
+    expected = input
+
+    lines = input.dup
+    Asciidoctor::Lexer.reset_block_indent! lines
+    assert_equal expected, lines
+  end
+
 end

--- a/test/reader_test.rb
+++ b/test/reader_test.rb
@@ -243,6 +243,19 @@ include::fixtures/include-file.asciidoc[lines=1, tags=snippetA;snippetB]
       assert_no_match(/snippetB content/, output)
     end
 
+    test 'indent of included file can be reset to size of indent attribute' do
+      input = <<-EOS
+[source, xml]
+----
+include::fixtures/basic-docinfo.xml[lines=2..3, indent=0]
+----
+      EOS
+
+      output = render_string input, :safe => Asciidoctor::SafeMode::SAFE, :header_footer => false, :attributes => {'docdir' => File.dirname(__FILE__)}
+      result = xmlnodes_at_xpath('//pre', output, 1).text
+      assert_equal "<year>2013</year>\n<holder>Acme, Inc.</holder>", result
+    end
+
     test "block is called to handle an include macro" do
       input = <<-EOS
 first line


### PR DESCRIPTION
- indent attribute on block controls leading block indent
- indent attribute on include macro controls leading block indent
- add tests
- change last argument to build_block to options
