### PR TITLE
resolves #369 make level 0 section titles more prominent in TOC

### DIFF
--- a/lib/asciidoctor/backends/_stylesheets.rb
+++ b/lib/asciidoctor/backends/_stylesheets.rb
@@ -157,13 +157,16 @@ p a > tt:hover { color: #561309; }
 #header br + span:before { content: "\2013 \0020"; }
 #toc { border-bottom: 3px double #ebebeb; padding-bottom: 1.25em; }
 #toc > ol { margin-left: 0.25em; }
+#toc ol.sectlevel0 > li > a { font-style: italic; }
+#toc ol.sectlevel0 ol.sectlevel1 { margin-left: 0; margin-top: 0.5em; margin-bottom: 0.5em; }
 #toc ol { list-style-type: none; }
 #toctitle { color: #7a2518; }
 @media only screen and (min-width: 80em) { body.toc2 { padding-left: 20em; }
   #toc.toc2 { position: fixed; width: 20em; left: 0; top: 0; border-right: 1px solid #ebebeb; border-bottom: 0; z-index: 1000; padding: 1em; height: 100%; overflow: auto; }
   #toc.toc2 #toctitle { margin-top: 0; }
   #toc.toc2 > ol { font-size: .95em; }
-  #toc.toc2 ol li ol { margin-left: 0; padding-left: 1em; } }
+  #toc.toc2 ol ol { margin-left: 0; padding-left: 1em; }
+  #toc.toc2 ol.sectlevel0 ol.sectlevel1 { padding-left: 0; margin-top: 0.5em; margin-bottom: 0.5em; } }
 #footer { max-width: 100%; background-color: #222222; padding: 1.25em; }
 #footer-text { color: #dddddd; line-height: 1.44; }
 .sect1 { border-bottom: 3px double #ebebeb; padding-bottom: 1.25em; }

--- a/test/sections_test.rb
+++ b/test/sections_test.rb
@@ -1013,11 +1013,14 @@ That's all she wrote!
       assert_xpath '//*[@id="header"]//*[@id="toc"][@class="toc"]', output, 1
       assert_xpath '//*[@id="header"]//*[@id="toc"]/*[@id="toctitle"][text()="Table of Contents"]', output, 1
       assert_xpath '//*[@id="header"]//*[@id="toc"]/ol', output, 1
-      assert_xpath '//*[@id="header"]//*[@id="toc"]/ol[@type="none"]', output, 1
+      assert_xpath '//*[@id="header"]//*[@id="toc"]/ol[@type="none"][@class="sectlevel1"]', output, 1
       assert_xpath '//*[@id="header"]//*[@id="toc"]//ol', output, 2
       assert_xpath '//*[@id="header"]//*[@id="toc"]//ol[@type="none"]', output, 2
       assert_xpath '//*[@id="header"]//*[@id="toc"]/ol/li', output, 4
       assert_xpath '//*[@id="header"]//*[@id="toc"]/ol/li[1]/a[@href="#_section_one"][text()="Section One"]', output, 1
+      assert_xpath '//*[@id="header"]//*[@id="toc"]/ol/li/ol', output, 1
+      assert_xpath '//*[@id="header"]//*[@id="toc"]/ol/li/ol[@type="none"]', output, 1
+      assert_xpath '//*[@id="header"]//*[@id="toc"]/ol/li/ol[@class="sectlevel2"]', output, 1
       assert_xpath '//*[@id="header"]//*[@id="toc"]/ol/li/ol/li', output, 1
       assert_xpath '//*[@id="header"]//*[@id="toc"]/ol/li/ol/li/a[@href="#_interlude"][text()="Interlude"]', output, 1
       assert_xpath '((//*[@id="header"]//*[@id="toc"]/ol)[1]/li)[4]/a[@href="#_section_three"][text()="Section Three"]', output, 1
@@ -1093,6 +1096,43 @@ That's all she wrote!
       assert_xpath '//*[@id="header"]//*[@id="toc"]/ol/li', output, 4
       assert_xpath '//*[@id="header"]//*[@id="toc"]/ol/li[1]/a[@href="#_section_one"][text()="1. Section One"]', output, 1
       assert_xpath '((//*[@id="header"]//*[@id="toc"]/ol)[1]/li)[4]/a[@href="#_section_three"][text()="Section Three"]', output, 1
+    end
+
+    test 'should not number parts in table of contents for book doctype when numbered attribute is set' do
+      input = <<-EOS
+= Book
+:doctype: book
+:toc:
+:numbered:
+
+= Part 1
+
+== First Section of Part 1
+
+blah
+
+== Second Section of Part 1
+
+blah
+
+= Part 2
+
+== First Section of Part 2
+
+blah
+      EOS
+
+      output = render_string input
+      assert_xpath '//*[@id="toc"]', output, 1
+      assert_xpath '//*[@id="toc"]/ol', output, 1
+      assert_xpath '//*[@id="toc"]/ol[@type="none"][@class="sectlevel0"]', output, 1
+      assert_xpath '//*[@id="toc"]/ol[@type="none"][@class="sectlevel0"]/li', output, 4
+      assert_xpath '(//*[@id="toc"]/ol[@type="none"][@class="sectlevel0"]/li)[1]/a[text()="Part 1"]', output, 1
+      assert_xpath '(//*[@id="toc"]/ol[@type="none"][@class="sectlevel0"]/li)[3]/a[text()="Part 2"]', output, 1
+      assert_xpath '(//*[@id="toc"]/ol[@type="none"][@class="sectlevel0"]/li)[2]/ol', output, 1
+      assert_xpath '(//*[@id="toc"]/ol[@type="none"][@class="sectlevel0"]/li)[2]/ol[@type="none"][@class="sectlevel1"]', output, 1
+      assert_xpath '(//*[@id="toc"]/ol[@type="none"][@class="sectlevel0"]/li)[2]/ol/li', output, 2
+      assert_xpath '((//*[@id="toc"]/ol[@type="none"][@class="sectlevel0"]/li)[2]/ol/li)[1]/a[text()="1. First Section of Part 1"]', output, 1
     end
 
     test 'should render table of contents in header if toc2 attribute is set' do
@@ -1387,7 +1427,7 @@ That's all she wrote!
   end
 
   context 'book doctype' do
-    test 'wip document title with level 0 headings' do
+    test 'document title with level 0 headings' do
       input = <<-EOS
 = Book
 Doc Writer


### PR DESCRIPTION
- put level 0 section titles in their own level
- add class to each nested outline that cooresponds to the section level
- default stylesheet updates:
- make level 0 section titles italic
- align level 0 and level 1 section titles
- add margin around level 1 section nested in a level 0 section
- add additional toc tests
