### PR TITLE
resolves #172 Add kbd inline macro

### DIFF
--- a/compat/asciidoc.conf
+++ b/compat/asciidoc.conf
@@ -60,7 +60,19 @@ template::[tabledef-default]
 delimiter=^:={3,}$
 format=dsv
 
+[macros]
+# kbd:[F11] or kbd:[Ctrl+T] or kbd:[Ctrl,T]
+(?su)(?<!\w)\\?kbd:\[(?P<attrlist>(?:\\\]|[^\]])+?)\]=keyboard
+
 ifdef::basebackend-html[]
+
+[keyboard-inlinemacro]
+{set2:keys:{eval:re.split(r'(?<!\+ |.\+)\+', '{1}')}}
+{2%}{eval:len({keys}) == 1}<kbd>{1}</kbd>
+{2%}{eval:len({keys}) == 2}<kbd class="combo"><kbd>{eval:{keys}[0].strip()}</kbd>+<kbd>{eval:{keys}[1].strip()}</kbd></kbd>
+{2%}{eval:len({keys}) == 3}<kbd class="combo"><kbd>{eval:{keys}[0].strip()}</kbd>+<kbd>{eval:{keys}[1].strip()}</kbd>+<kbd>{eval:{keys}[2].strip()}</kbd></kbd>
+{2#}{3%}<kbd class="combo"><kbd>{1}</kbd>+<kbd>{2}</kbd></kbd>
+{3#}<kbd class="combo"><kbd>{1}</kbd>+<kbd>{2}</kbd>+<kbd>{3}</kbd></kbd>
 
 [literal-inlinemacro]
 <code>{passtext}</code>
@@ -168,6 +180,14 @@ endif::basebackend-html[]
 
 # Override docinfo to support subtitle
 ifdef::basebackend-docbook[]
+
+[keyboard-inlinemacro]
+{set2:keys:{eval:re.split(r'(?<!\+ |.\+)\+', '{1}')}}
+{2%}{eval:len({keys}) == 1}<keycap>{1}</keycap>
+{2%}{eval:len({keys}) == 2}<keycombo><keycap>{eval:{keys}[0].strip()}</keycap><keycap>{eval:{keys}[1].strip()}</keycap></keycombo>
+{2%}{eval:len({keys}) == 3}<keycombo><keycap>{eval:{keys}[0].strip()}</keycap><keycap>{eval:{keys}[1].strip()}</keycap><keycap>{eval:{keys}[2].strip()}</keycap></keycombo>
+{2#}{3%}<keycombo><keycap>{1}</keycap><keycap>{2}</keycap></keycombo>
+{3#}<keycombo><keycap>{1}</keycap><keycap>{2}</keycap><keycap>{3}</keycap></keycombo>
 
 # override tabletags to support cellbgcolor
 [tabletags-default]

--- a/lib/asciidoctor.rb
+++ b/lib/asciidoctor.rb
@@ -325,13 +325,12 @@ module Asciidoctor
     # one two	three
     :space_delim      => /([^\\])[[:blank:]]+/,
 
+    # Ctrl + Alt+T
+    # Ctrl,T
+    :kbd_delim        => /(?:\+|,)(?=[[:blank:]]*[^\1])/,
+
     # one\ two\	three
     :escaped_space    => /\\([[:blank:]])/,
-
-    # one+two
-    # one+ two
-    # one + two
-    :plus_delim  => /[[:blank:]]*\+[[:blank:]]*/,
 
     # 29
     :digits           => /^\d+$/,
@@ -360,6 +359,12 @@ module Asciidoctor
     # footnoteref:[id,text]
     # footnoteref:[id]
     :footnote_macro   => /\\?(footnote|footnoteref):\[((?:\\\]|[^\]])*?)\]/,
+
+    # kbd:[F3]
+    # kbd:[Ctrl+Shift+T]
+    # kbd:[Ctrl+\]]
+    # kbd:[Ctrl,T]
+    :kbd_macro        => /\\?kbd:\[((?:\\\]|[^\]])+?)\]/,
 
     # image::filename.png[Caption]
     # video::http://youtube.com/12345[Cats vs Dogs]
@@ -399,9 +404,6 @@ module Asciidoctor
     # inline link macro
     # link:path[label]
     :link_macro       => /\\?(?:link|mailto):([^\s\[]+)(?:\[((?:\\\]|[^\]])*?)\])/,
-
-    # key:Enter[] or key:[Ctrl+T] or key:[Ctrl+Shift+T]
-    :key_macro        => /\\?(key|kbd):([^\[]*)(?:\[([^\]]*)\])/,
 
     # inline email address
     # doc.writer@asciidoc.org

--- a/lib/asciidoctor/backends/_stylesheets.rb
+++ b/lib/asciidoctor/backends/_stylesheets.rb
@@ -143,6 +143,10 @@ table tr.even, table tr.alt, table tr:nth-of-type(even) { background: #f9f9f9; }
 table thead tr th, table tfoot tr th, table tbody tr td, table tr td, table tfoot tr td { display: table-cell; line-height: 1.6; }
 pre > code, pre > tt { color: #222222; }
 tt { font-size: 0.9375em; padding: 1px 3px 0; white-space: nowrap; background-color: #f2f2f2; border: 1px solid #cccccc; -webkit-border-radius: 4px; border-radius: 4px; text-shadow: none; }
+kbd.combo { color: #555555; }
+kbd:not(.combo) { display: inline-block; color: #222222; font-size: 0.75em; line-height: 1.4; background-color: #F7F7F7; border: 1px solid #ccc; -webkit-border-radius: 3px; border-radius: 3px; -webkit-box-shadow: 0 1px 0 rgba(0, 0, 0, 0.2), 0 0 0 2px white inset; box-shadow: 0 1px 0 rgba(0, 0, 0, 0.2), 0 0 0 2px white inset; margin: -0.15em 0.15em 0 0.15em; padding: 0.2em 0.6em 0.2em 0.5em; vertical-align: middle; white-space: nowrap; }
+kbd kbd:first-child { margin-left: 0; }
+kbd kbd:last-child { margin-right: 0; }
 p a > tt { text-decoration: underline; }
 p a > tt:hover { color: #561309; }
 #header, #content, #footnotes, #footer { width: 100%; margin-left: auto; margin-right: auto; margin-top: 0; margin-bottom: 0; max-width: 62.5em; *zoom: 1; position: relative; padding-left: 0.9375em; padding-right: 0.9375em; }

--- a/lib/asciidoctor/backends/docbook45.rb
+++ b/lib/asciidoctor/backends/docbook45.rb
@@ -650,20 +650,15 @@ class InlineQuotedTemplate < BaseTemplate
   end
 end
 
-class InlineKeyTemplate < BaseTemplate
-  def key(keys)
-    case keys.size
-      when 1
-        %(<keycap>#{keys[0]}</keycap>)
-      when 2
-        %(<keycombo><keycap>#{keys[0]}</keycap><keycap>#{keys[1]}</keycap></keycombo>)
-      when 3
-        %(<keycombo><keycap>#{keys[0]}</keycap><keycap>#{keys[1]}</keycap><keycap>#{keys[2]}</keycap></keycombo>)
-    end
-  end
-
+class InlineKbdTemplate < BaseTemplate
   def result(node)
-    key(node.attr('keys'))
+    keys = node.attr 'keys'
+    if keys.size == 1
+      %(<keycap>#{keys.first}</keycap>)
+    else
+      key_combo = keys.map{|key| %(<keycap>#{key}</keycap>) }.join
+      %(<keycombo>#{key_combo}</keycombo>)
+    end
   end
 
   def template

--- a/lib/asciidoctor/backends/html5.rb
+++ b/lib/asciidoctor/backends/html5.rb
@@ -858,20 +858,15 @@ class InlineQuotedTemplate < BaseTemplate
   end
 end
 
-class InlineKeyTemplate < BaseTemplate
-  def key(keys)
-    case keys.size
-      when 1
-        %(<button>#{keys[0]}</button>)
-      when 2
-        %(<button>#{keys[0]}</button> + <button>#{keys[1]}</button>)
-      when 3
-        %(<button>#{keys[0]}</button> + <button>#{keys[1]}</button> + <button>#{keys[2]}</button>)
-    end
-  end
-
+class InlineKbdTemplate < BaseTemplate
   def result(node)
-    key(node.attr('keys'))
+    keys = node.attr 'keys'
+    if keys.size == 1
+      %(<kbd>#{keys.first}</kbd>)
+    else
+      key_combo = keys.map{|key| %(<kbd>#{key}</kbd>+) }.join.chop
+      %(<kbd class="combo">#{key_combo}</kbd>)
+    end
   end
 
   def template

--- a/lib/asciidoctor/substituters.rb
+++ b/lib/asciidoctor/substituters.rb
@@ -349,6 +349,37 @@ module Substituters
     found[:macroish_short_form] = (found[:square_bracket] && found[:colon] && result.include?(':['))
     found[:uri] = (found[:colon] && result.include?('://'))
     use_link_attrs = @document.attributes.has_key?('use-link-attrs')
+    experimental = @document.attributes.has_key?('experimental')
+
+    if experimental
+      if found[:macroish_short_form] && result.include?('kbd:')
+        result.gsub!(REGEXP[:kbd_macro]) {
+          captured = $~[0]
+          keys = $~[1]
+          # honor the escape
+          if captured.start_with? '\\'
+            next captured[1..-1]
+          end
+
+          keys = unescape_bracketed_text keys
+          if keys == '+'
+            keys = ['+']
+          else
+            # need to use closure to work around lack of negative lookbehind
+            keys = keys.split(REGEXP[:kbd_delim]).inject([]) {|c, key|
+              if key.end_with?('++')
+                c << key[0..-3].strip
+                c << '+'
+              else
+                c << key.strip
+              end
+              c
+            }
+          end
+          Inline.new(self, :kbd, nil, :attributes => {'keys' => keys}).render 
+        }
+      end
+    end
 
     if found[:macroish] && result.include?('image:')
       # image:filename.png[Alt Text]
@@ -491,17 +522,6 @@ module Substituters
         @document.register(:links, target)
 
         Inline.new(self, :anchor, (!text.empty? ? text : raw_target), :type => :link, :target => target, :attributes => attrs).render
-      }
-    end
-
-    if found[:macroish] && (result.include?('key:') || result.include?('kbd:'))
-      result.gsub!(REGEXP[:key_macro]) {
-        # alias match for Ruby 1.8.7 compat
-        m = $~
-        string = m[2].empty? ? m[3] : m[2];
-        keys = string.split(REGEXP[:plus_delim])
-
-        Inline.new(self, :key, nil, :attributes => {'keys' => keys}).render
       }
     end
 

--- a/test/document_test.rb
+++ b/test/document_test.rb
@@ -505,7 +505,7 @@ text
       assert !renderer.nil?
       views = renderer.views
       assert !views.nil?
-      assert_equal 33, views.size
+      assert_equal 34, views.size
       assert views.has_key? 'document'
       assert views['document'].is_a?(Asciidoctor::HTML5::DocumentTemplate)
       assert_equal 'ERB', views['document'].eruby.to_s
@@ -521,7 +521,7 @@ text
       assert !renderer.nil?
       views = renderer.views
       assert !views.nil?
-      assert_equal 33, views.size
+      assert_equal 34, views.size
       assert views.has_key? 'document'
       assert views['document'].is_a?(Asciidoctor::DocBook45::DocumentTemplate)
       assert_equal 'ERB', views['document'].eruby.to_s

--- a/test/substitutions_test.rb
+++ b/test/substitutions_test.rb
@@ -615,24 +615,56 @@ context 'Substitutions' do
       assert_equal ['panthera tigris'], terms[1]
     end
 
-    test 'Single key macro with empty brackets' do
-      para = block_from_string('key:Enter[]')
-      assert_equal %q{<button>Enter</button>}, para.sub_macros(para.buffer.join)
-    end
-
-    test 'Single key macro within brackets' do
-      para = block_from_string('key:[Enter]')
-      assert_equal %q{<button>Enter</button>}, para.sub_macros(para.buffer.join)
-    end
-
-    test 'Two key macro within brackets' do
-      para = block_from_string('key:[Shift+Enter]')
-      assert_equal %q{<button>Shift</button> + <button>Enter</button>}, para.sub_macros(para.buffer.join)
-    end
-
-    test 'Three key macro within brackets' do
-      para = block_from_string('key:[Ctrl+Shift+Enter]')
-      assert_equal %q{<button>Ctrl</button> + <button>Shift</button> + <button>Enter</button>}, para.sub_macros(para.buffer.join)
+    context 'Keyboard macro' do
+      test 'kbd macro with single key' do
+        para = block_from_string('kbd:[F3]', :attributes => {'experimental' => ''})
+        assert_equal %q{<kbd>F3</kbd>}, para.sub_macros(para.buffer.join)
+      end
+  
+      test 'kbd macro with single key, docbook backend' do
+        para = block_from_string('kbd:[F3]', :backend => 'docbook', :attributes => {'experimental' => ''})
+        assert_equal %q{<keycap>F3</keycap>}, para.sub_macros(para.buffer.join)
+      end
+  
+      test 'kbd macro with key combination' do
+        para = block_from_string('kbd:[Ctrl+Shift+T]', :attributes => {'experimental' => ''})
+        assert_equal %q{<kbd class="combo"><kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>T</kbd></kbd>}, para.sub_macros(para.buffer.join)
+      end
+  
+      test 'kbd macro with key combination with spaces' do
+        para = block_from_string('kbd:[Ctrl + Shift + T]', :attributes => {'experimental' => ''})
+        assert_equal %q{<kbd class="combo"><kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>T</kbd></kbd>}, para.sub_macros(para.buffer.join)
+      end
+  
+      test 'kbd macro with key combination delimited by commas' do
+        para = block_from_string('kbd:[Ctrl,Shift,T]', :attributes => {'experimental' => ''})
+        assert_equal %q{<kbd class="combo"><kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>T</kbd></kbd>}, para.sub_macros(para.buffer.join)
+      end
+  
+      test 'kbd macro with key combination containing a plus key no spaces' do
+        para = block_from_string('kbd:[Ctrl++]', :attributes => {'experimental' => ''})
+        assert_equal %q{<kbd class="combo"><kbd>Ctrl</kbd>+<kbd>+</kbd></kbd>}, para.sub_macros(para.buffer.join)
+      end
+  
+      test 'kbd macro with key combination delimited by commands containing a comma key' do
+        para = block_from_string('kbd:[Ctrl,,]', :attributes => {'experimental' => ''})
+        assert_equal %q{<kbd class="combo"><kbd>Ctrl</kbd>+<kbd>,</kbd></kbd>}, para.sub_macros(para.buffer.join)
+      end
+  
+      test 'kbd macro with key combination containing a plus key with spaces' do
+        para = block_from_string('kbd:[Ctrl + +]', :attributes => {'experimental' => ''})
+        assert_equal %q{<kbd class="combo"><kbd>Ctrl</kbd>+<kbd>+</kbd></kbd>}, para.sub_macros(para.buffer.join)
+      end
+  
+      test 'kbd macro with key combination containing escaped bracket' do
+        para = block_from_string('kbd:[Ctrl + \]]', :attributes => {'experimental' => ''})
+        assert_equal %q{<kbd class="combo"><kbd>Ctrl</kbd>+<kbd>]</kbd></kbd>}, para.sub_macros(para.buffer.join)
+      end
+  
+      test 'kbd macro with key combination, docbook backend' do
+        para = block_from_string('kbd:[Ctrl+Shift+T]', :backend => 'docbook', :attributes => {'experimental' => ''})
+        assert_equal %q{<keycombo><keycap>Ctrl</keycap><keycap>Shift</keycap><keycap>T</keycap></keycombo>}, para.sub_macros(para.buffer.join)
+      end
     end
   end
 


### PR DESCRIPTION
- add keyboard macro following pattern kbd:[key(+key)*]
- add inline keyboard template
- update default stylesheet to include styling for kbd element
- include compatibility configuration for AsciiDoc
