### PR TITLE
resolves #393 numbering should not increment on unnumbered sections

### DIFF
--- a/lib/asciidoctor/abstract_block.rb
+++ b/lib/asciidoctor/abstract_block.rb
@@ -25,7 +25,8 @@ class AbstractBlock < AbstractNode
     else
       @level = nil
     end
-    @next_section_index = 0 
+    @next_section_index = 0
+    @next_section_number = 1
   end
 
   # Public: A convenience method that indicates whether the title instance
@@ -243,6 +244,10 @@ class AbstractBlock < AbstractNode
   def assign_index(section)
     section.index = @next_section_index
     @next_section_index += 1
+    if section.numbered
+      section.number = @next_section_number
+      @next_section_number += 1
+    end
   end
 
   # Internal: Reassign the section indexes
@@ -254,6 +259,7 @@ class AbstractBlock < AbstractNode
   # returns nothing
   def reindex_sections
     @next_section_index = 0
+    @next_section_number = 0
     @blocks.each {|block|
       if block.is_a?(Section)
         assign_index(block)

--- a/lib/asciidoctor/backends/html5.rb
+++ b/lib/asciidoctor/backends/html5.rb
@@ -36,16 +36,8 @@ class DocumentTemplate < BaseTemplate
         sec_level = 1
       end
       toc_level = %(<ol type="none" class="sectlevel#{sec_level}">\n)
-      numbered = node.document.attr? 'numbered'
       sections.each do |section|
-        # need to check playback attributes for change in numbered setting
-        # FIXME encapsulate me
-        if section.attributes.has_key? :attribute_entries
-          if (numbered_override = section.attributes[:attribute_entries].find {|entry| entry.name == 'numbered'})
-            numbered = numbered_override.negate ? false : true
-          end
-        end
-        section_num = numbered && !section.special && section.level > 0 && section.level < 4 ? %(#{section.sectnum} ) : nil
+        section_num = section.numbered ? %(#{section.sectnum} ) : nil
         toc_level = %(#{toc_level}<li><a href=\"##{section.id}\">#{section_num}#{section.caption}#{section.title}</a></li>\n)
         if section.level < to_depth && (child_toc_level = outline(section, to_depth))
           toc_level = %(#{toc_level}<li>\n#{child_toc_level}\n</li>\n)
@@ -270,7 +262,7 @@ class SectionTemplate < BaseTemplate
 #{sec.content}\n)
     else
       role = (sec.attr? 'role') ? " #{sec.attr 'role'}" : nil
-      if !sec.special && (sec.document.attr? 'numbered') && slevel < 4
+      if sec.numbered
         sectnum = "#{sec.sectnum} "
       else
         sectnum = nil

--- a/lib/asciidoctor/document.rb
+++ b/lib/asciidoctor/document.rb
@@ -395,7 +395,7 @@ class Document < AbstractBlock
   end
 
   def title=(title)
-    @header ||= Section.new self
+    @header ||= Section.new(self, 0)
     @header.title = title
   end
 

--- a/lib/asciidoctor/lexer.rb
+++ b/lib/asciidoctor/lexer.rb
@@ -1211,13 +1211,15 @@ class Lexer
   # parent     - the parent Section or Document of this Section
   # attributes - a Hash of attributes to assign to this section (default: {})
   def self.initialize_section(reader, parent, attributes = {})
-    section = Section.new parent
-    section.id, section.title, section.level, _ = parse_section_title(reader, section.document)
+    document = parent.document
+    sect_id, sect_title, sect_level, _ = parse_section_title(reader, document)
+    section = Section.new parent, sect_level, document.attributes.has_key?('numbered')
+    section.id = sect_id
+    section.title = sect_title
     # parse style, id and role from first positional attribute
     if attributes[1]
       section.sectname, _ = parse_style_attribute(attributes)
       section.special = true
-      document = parent.document
       # HACK needs to be refactored so it's driven by config
       if section.sectname == 'abstract' && document.doctype == 'book'
         section.sectname = "sect1"


### PR DESCRIPTION
- set state of numbered flag on section when creating it
- track section number in addition to positional index
- use section number to build outline number (i.e., sectnum)
- number special sections by default
- add more tests
