### PR TITLE
Do not use pending gem in tests

### DIFF
--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -5,7 +5,7 @@ require 'test/unit'
 require "#{File.expand_path(File.dirname(__FILE__))}/../lib/asciidoctor.rb"
 
 require 'nokogiri'
-require 'pending'
+#require 'pending'
 
 ENV['SUPPRESS_DEBUG'] ||= 'true'
 


### PR DESCRIPTION
This patch is in the Debian package.

Since the `pending` gem is not packaged for Debian I removed the require in the tests.
All tests run fine without it AFAICS.
