### PR TITLE
Remove require rubygems

### DIFF
--- a/bin/asciidoctor
+++ b/bin/asciidoctor
@@ -2,6 +2,9 @@
 
 $:.unshift File.join(File.dirname(__FILE__), '..', 'lib')
 
+if RUBY_VERSION < '1.9'
+  require 'rubygems'
+end
 require 'asciidoctor'
 require 'asciidoctor/cli/options'
 require 'asciidoctor/cli/invoker'

--- a/bin/asciidoctor-safe
+++ b/bin/asciidoctor-safe
@@ -2,6 +2,9 @@
 
 $:.unshift File.join(File.dirname(__FILE__), '..', 'lib')
 
+if RUBY_VERSION < '1.9'
+  require 'rubygems'
+end
 require 'asciidoctor'
 require 'asciidoctor/cli/options'
 require 'asciidoctor/cli/invoker'

--- a/lib/asciidoctor.rb
+++ b/lib/asciidoctor.rb
@@ -1,7 +1,4 @@
 RUBY_ENGINE = 'unknown' unless defined? RUBY_ENGINE
-if RUBY_VERSION < '1.9'
-  require 'rubygems'
-end
 require 'strscan'
 require 'set'
 


### PR DESCRIPTION
This patch is in the Debian package.

Require rubygems antipattern is not allowed per Debian Ruby policy draft/packaging practices. (And of course it works fine without it.)

Motivation:

> The system I use to manage my $LOAD_PATH is not your library / app / tests concern. Whether rubygems is used or not is an environment issue. Your library or app should have no say in the matter. Explicitly requiring rubygems is either not necessary or misguided.

http://tomayko.com/writings/require-rubygems-antipattern
