### PR TITLE
resolves #431 use ul list for TOC in HTML5 backend

### DIFF
--- a/lib/asciidoctor/backends/_stylesheets.rb
+++ b/lib/asciidoctor/backends/_stylesheets.rb
@@ -163,17 +163,17 @@ p a > tt:hover { color: #561309; }
 #header br + span.author { padding-left: 0; }
 #header br + span.author:before { content: ", "; }
 #toc { border-bottom: 3px double #ebebeb; padding-bottom: 1.25em; }
-#toc > ol { margin-left: 0.25em; }
-#toc ol.sectlevel0 > li > a { font-style: italic; }
-#toc ol.sectlevel0 ol.sectlevel1 { margin-left: 0; margin-top: 0.5em; margin-bottom: 0.5em; }
-#toc ol { list-style-type: none; }
+#toc > ul, #toc > ol { margin-left: 0.25em; }
+#toc ul.sectlevel0 > li > a, #toc ol.sectlevel0 > li > a { font-style: italic; }
+#toc ul.sectlevel0 ul.sectlevel1, #toc ol.sectlevel0 ol.sectlevel1 { margin-left: 0; margin-top: 0.5em; margin-bottom: 0.5em; }
+#toc ul, #toc ol { list-style-type: none; }
 #toctitle { color: #7a2518; }
 @media only screen and (min-width: 80em) { body.toc2 { padding-left: 20em; }
   #toc.toc2 { position: fixed; width: 20em; left: 0; top: 0; border-right: 1px solid #ebebeb; border-bottom: 0; z-index: 1000; padding: 1em; height: 100%; overflow: auto; }
   #toc.toc2 #toctitle { margin-top: 0; }
-  #toc.toc2 > ol { font-size: .95em; }
-  #toc.toc2 ol ol { margin-left: 0; padding-left: 1em; }
-  #toc.toc2 ol.sectlevel0 ol.sectlevel1 { padding-left: 0; margin-top: 0.5em; margin-bottom: 0.5em; } }
+  #toc.toc2 > ul, #toc.toc2 > ol { font-size: .95em; }
+  #toc.toc2 ul ul, #toc.toc2 ol ol { margin-left: 0; padding-left: 1em; }
+  #toc.toc2 ul.sectlevel0 ul.sectlevel1, #toc.toc2 ol.sectlevel0 ol.sectlevel1 { padding-left: 0; margin-top: 0.5em; margin-bottom: 0.5em; } }
 #footer { max-width: 100%; background-color: #222222; padding: 1.25em; }
 #footer-text { color: #dddddd; line-height: 1.44; }
 .sect1 { border-bottom: 3px double #ebebeb; padding-bottom: 1.25em; }

--- a/lib/asciidoctor/backends/html5.rb
+++ b/lib/asciidoctor/backends/html5.rb
@@ -35,7 +35,7 @@ class DocumentTemplate < BaseTemplate
       if sec_level == 0 && sections.first.special
         sec_level = 1
       end
-      toc_level = %(<ol type="none" class="sectlevel#{sec_level}">\n)
+      toc_level = %(<ul class="sectlevel#{sec_level}">\n)
       sections.each do |section|
         section_num = section.numbered ? %(#{section.sectnum} ) : nil
         toc_level = %(#{toc_level}<li><a href=\"##{section.id}\">#{section_num}#{section.caption}#{section.title}</a></li>\n)
@@ -43,7 +43,7 @@ class DocumentTemplate < BaseTemplate
           toc_level = %(#{toc_level}<li>\n#{child_toc_level}\n</li>\n)
         end
       end
-      toc_level = %(#{toc_level}</ol>)
+      toc_level = %(#{toc_level}</ul>)
     end
     toc_level
   end

--- a/test/sections_test.rb
+++ b/test/sections_test.rb
@@ -949,11 +949,11 @@ Terms
       EOS
 
       output = render_string input
-      assert_xpath '//*[@id="toc"]/ol//li/a[text()="1. Section One"]', output, 1
-      assert_xpath '//*[@id="toc"]/ol//li/a[text()="Appendix A: Attribute Options"]', output, 1
-      assert_xpath '//*[@id="toc"]/ol//li/a[text()="Appendix B: Migration"]', output, 1
-      assert_xpath '//*[@id="toc"]/ol//li/a[text()="Gotchas"]', output, 1
-      assert_xpath '//*[@id="toc"]/ol//li/a[text()="Glossary"]', output, 1
+      assert_xpath '//*[@id="toc"]/ul//li/a[text()="1. Section One"]', output, 1
+      assert_xpath '//*[@id="toc"]/ul//li/a[text()="Appendix A: Attribute Options"]', output, 1
+      assert_xpath '//*[@id="toc"]/ul//li/a[text()="Appendix B: Migration"]', output, 1
+      assert_xpath '//*[@id="toc"]/ul//li/a[text()="Gotchas"]', output, 1
+      assert_xpath '//*[@id="toc"]/ul//li/a[text()="Glossary"]', output, 1
     end
 
     # reenable once we have :specialnumbered!: implemented
@@ -1022,11 +1022,11 @@ Terms
       EOS
 
       output = render_string input
-      assert_xpath '//*[@id="toc"]/ol//li/a[text()="1. Section One"]', output, 1
-      assert_xpath '//*[@id="toc"]/ol//li/a[text()="Appendix A: Attribute Options"]', output, 1
-      assert_xpath '//*[@id="toc"]/ol//li/a[text()="Appendix B: Migration"]', output, 1
-      assert_xpath '//*[@id="toc"]/ol//li/a[text()="Gotchas"]', output, 1
-      assert_xpath '//*[@id="toc"]/ol//li/a[text()="Glossary"]', output, 1
+      assert_xpath '//*[@id="toc"]/ul//li/a[text()="1. Section One"]', output, 1
+      assert_xpath '//*[@id="toc"]/ul//li/a[text()="Appendix A: Attribute Options"]', output, 1
+      assert_xpath '//*[@id="toc"]/ul//li/a[text()="Appendix B: Migration"]', output, 1
+      assert_xpath '//*[@id="toc"]/ul//li/a[text()="Gotchas"]', output, 1
+      assert_xpath '//*[@id="toc"]/ul//li/a[text()="Glossary"]', output, 1
     end
 =end
 
@@ -1308,18 +1308,16 @@ That's all she wrote!
       output = render_string input
       assert_xpath '//*[@id="header"]//*[@id="toc"][@class="toc"]', output, 1
       assert_xpath '//*[@id="header"]//*[@id="toc"]/*[@id="toctitle"][text()="Table of Contents"]', output, 1
-      assert_xpath '//*[@id="header"]//*[@id="toc"]/ol', output, 1
-      assert_xpath '//*[@id="header"]//*[@id="toc"]/ol[@type="none"][@class="sectlevel1"]', output, 1
-      assert_xpath '//*[@id="header"]//*[@id="toc"]//ol', output, 2
-      assert_xpath '//*[@id="header"]//*[@id="toc"]//ol[@type="none"]', output, 2
-      assert_xpath '//*[@id="header"]//*[@id="toc"]/ol/li', output, 4
-      assert_xpath '//*[@id="header"]//*[@id="toc"]/ol/li[1]/a[@href="#_section_one"][text()="Section One"]', output, 1
-      assert_xpath '//*[@id="header"]//*[@id="toc"]/ol/li/ol', output, 1
-      assert_xpath '//*[@id="header"]//*[@id="toc"]/ol/li/ol[@type="none"]', output, 1
-      assert_xpath '//*[@id="header"]//*[@id="toc"]/ol/li/ol[@class="sectlevel2"]', output, 1
-      assert_xpath '//*[@id="header"]//*[@id="toc"]/ol/li/ol/li', output, 1
-      assert_xpath '//*[@id="header"]//*[@id="toc"]/ol/li/ol/li/a[@href="#_interlude"][text()="Interlude"]', output, 1
-      assert_xpath '((//*[@id="header"]//*[@id="toc"]/ol)[1]/li)[4]/a[@href="#_section_three"][text()="Section Three"]', output, 1
+      assert_xpath '//*[@id="header"]//*[@id="toc"]/ul', output, 1
+      assert_xpath '//*[@id="header"]//*[@id="toc"]/ul[@class="sectlevel1"]', output, 1
+      assert_xpath '//*[@id="header"]//*[@id="toc"]//ul', output, 2
+      assert_xpath '//*[@id="header"]//*[@id="toc"]/ul/li', output, 4
+      assert_xpath '//*[@id="header"]//*[@id="toc"]/ul/li[1]/a[@href="#_section_one"][text()="Section One"]', output, 1
+      assert_xpath '//*[@id="header"]//*[@id="toc"]/ul/li/ul', output, 1
+      assert_xpath '//*[@id="header"]//*[@id="toc"]/ul/li/ul[@class="sectlevel2"]', output, 1
+      assert_xpath '//*[@id="header"]//*[@id="toc"]/ul/li/ul/li', output, 1
+      assert_xpath '//*[@id="header"]//*[@id="toc"]/ul/li/ul/li/a[@href="#_interlude"][text()="Interlude"]', output, 1
+      assert_xpath '((//*[@id="header"]//*[@id="toc"]/ul)[1]/li)[4]/a[@href="#_section_three"][text()="Section Three"]', output, 1
     end
 
     test 'should render numbered table of contents in header if toc and numbered attributes are set' do
@@ -1347,15 +1345,13 @@ That's all she wrote!
       output = render_string input
       assert_xpath '//*[@id="header"]//*[@id="toc"][@class="toc"]', output, 1
       assert_xpath '//*[@id="header"]//*[@id="toc"]/*[@id="toctitle"][text()="Table of Contents"]', output, 1
-      assert_xpath '//*[@id="header"]//*[@id="toc"]/ol', output, 1
-      assert_xpath '//*[@id="header"]//*[@id="toc"]/ol[@type="none"]', output, 1
-      assert_xpath '//*[@id="header"]//*[@id="toc"]//ol', output, 2
-      assert_xpath '//*[@id="header"]//*[@id="toc"]//ol[@type="none"]', output, 2
-      assert_xpath '//*[@id="header"]//*[@id="toc"]/ol/li', output, 4
-      assert_xpath '//*[@id="header"]//*[@id="toc"]/ol/li[1]/a[@href="#_section_one"][text()="1. Section One"]', output, 1
-      assert_xpath '//*[@id="header"]//*[@id="toc"]/ol/li/ol/li', output, 1
-      assert_xpath '//*[@id="header"]//*[@id="toc"]/ol/li/ol/li/a[@href="#_interlude"][text()="2.1. Interlude"]', output, 1
-      assert_xpath '((//*[@id="header"]//*[@id="toc"]/ol)[1]/li)[4]/a[@href="#_section_three"][text()="3. Section Three"]', output, 1
+      assert_xpath '//*[@id="header"]//*[@id="toc"]/ul', output, 1
+      assert_xpath '//*[@id="header"]//*[@id="toc"]//ul', output, 2
+      assert_xpath '//*[@id="header"]//*[@id="toc"]/ul/li', output, 4
+      assert_xpath '//*[@id="header"]//*[@id="toc"]/ul/li[1]/a[@href="#_section_one"][text()="1. Section One"]', output, 1
+      assert_xpath '//*[@id="header"]//*[@id="toc"]/ul/li/ul/li', output, 1
+      assert_xpath '//*[@id="header"]//*[@id="toc"]/ul/li/ul/li/a[@href="#_interlude"][text()="2.1. Interlude"]', output, 1
+      assert_xpath '((//*[@id="header"]//*[@id="toc"]/ul)[1]/li)[4]/a[@href="#_section_three"][text()="3. Section Three"]', output, 1
     end
 
     test 'should render a table of contents that honors numbered setting at position of section in document' do
@@ -1385,13 +1381,11 @@ That's all she wrote!
       output = render_string input
       assert_xpath '//*[@id="header"]//*[@id="toc"][@class="toc"]', output, 1
       assert_xpath '//*[@id="header"]//*[@id="toc"]/*[@id="toctitle"][text()="Table of Contents"]', output, 1
-      assert_xpath '//*[@id="header"]//*[@id="toc"]/ol', output, 1
-      assert_xpath '//*[@id="header"]//*[@id="toc"]/ol[@type="none"]', output, 1
-      assert_xpath '//*[@id="header"]//*[@id="toc"]//ol', output, 2
-      assert_xpath '//*[@id="header"]//*[@id="toc"]//ol[@type="none"]', output, 2
-      assert_xpath '//*[@id="header"]//*[@id="toc"]/ol/li', output, 4
-      assert_xpath '//*[@id="header"]//*[@id="toc"]/ol/li[1]/a[@href="#_section_one"][text()="1. Section One"]', output, 1
-      assert_xpath '((//*[@id="header"]//*[@id="toc"]/ol)[1]/li)[4]/a[@href="#_section_three"][text()="Section Three"]', output, 1
+      assert_xpath '//*[@id="header"]//*[@id="toc"]/ul', output, 1
+      assert_xpath '//*[@id="header"]//*[@id="toc"]//ul', output, 2
+      assert_xpath '//*[@id="header"]//*[@id="toc"]/ul/li', output, 4
+      assert_xpath '//*[@id="header"]//*[@id="toc"]/ul/li[1]/a[@href="#_section_one"][text()="1. Section One"]', output, 1
+      assert_xpath '((//*[@id="header"]//*[@id="toc"]/ul)[1]/li)[4]/a[@href="#_section_three"][text()="Section Three"]', output, 1
     end
 
     test 'should not number parts in table of contents for book doctype when numbered attribute is set' do
@@ -1420,15 +1414,15 @@ blah
 
       output = render_string input
       assert_xpath '//*[@id="toc"]', output, 1
-      assert_xpath '//*[@id="toc"]/ol', output, 1
-      assert_xpath '//*[@id="toc"]/ol[@type="none"][@class="sectlevel0"]', output, 1
-      assert_xpath '//*[@id="toc"]/ol[@type="none"][@class="sectlevel0"]/li', output, 4
-      assert_xpath '(//*[@id="toc"]/ol[@type="none"][@class="sectlevel0"]/li)[1]/a[text()="Part 1"]', output, 1
-      assert_xpath '(//*[@id="toc"]/ol[@type="none"][@class="sectlevel0"]/li)[3]/a[text()="Part 2"]', output, 1
-      assert_xpath '(//*[@id="toc"]/ol[@type="none"][@class="sectlevel0"]/li)[2]/ol', output, 1
-      assert_xpath '(//*[@id="toc"]/ol[@type="none"][@class="sectlevel0"]/li)[2]/ol[@type="none"][@class="sectlevel1"]', output, 1
-      assert_xpath '(//*[@id="toc"]/ol[@type="none"][@class="sectlevel0"]/li)[2]/ol/li', output, 2
-      assert_xpath '((//*[@id="toc"]/ol[@type="none"][@class="sectlevel0"]/li)[2]/ol/li)[1]/a[text()="1. First Section of Part 1"]', output, 1
+      assert_xpath '//*[@id="toc"]/ul', output, 1
+      assert_xpath '//*[@id="toc"]/ul[@class="sectlevel0"]', output, 1
+      assert_xpath '//*[@id="toc"]/ul[@class="sectlevel0"]/li', output, 4
+      assert_xpath '(//*[@id="toc"]/ul[@class="sectlevel0"]/li)[1]/a[text()="Part 1"]', output, 1
+      assert_xpath '(//*[@id="toc"]/ul[@class="sectlevel0"]/li)[3]/a[text()="Part 2"]', output, 1
+      assert_xpath '(//*[@id="toc"]/ul[@class="sectlevel0"]/li)[2]/ul', output, 1
+      assert_xpath '(//*[@id="toc"]/ul[@class="sectlevel0"]/li)[2]/ul[@class="sectlevel1"]', output, 1
+      assert_xpath '(//*[@id="toc"]/ul[@class="sectlevel0"]/li)[2]/ul/li', output, 2
+      assert_xpath '((//*[@id="toc"]/ul[@class="sectlevel0"]/li)[2]/ul/li)[1]/a[text()="1. First Section of Part 1"]', output, 1
     end
 
     test 'should render table of contents in header if toc2 attribute is set' do
@@ -1449,7 +1443,7 @@ They couldn't believe their eyes when...
       output = render_string input
       assert_xpath '//body[@class="article toc2"]', output, 1
       assert_xpath '//*[@id="header"]//*[@id="toc"][@class="toc2"]', output, 1
-      assert_xpath '//*[@id="header"]//*[@id="toc"]/ol/li[1]/a[@href="#_section_one"][text()="1. Section One"]', output, 1
+      assert_xpath '//*[@id="header"]//*[@id="toc"]/ul/li[1]/a[@href="#_section_one"][text()="1. Section One"]', output, 1
     end
 
     test 'should use document attributes toc-class, toc-title and toclevels to create toc' do


### PR DESCRIPTION
- remove use of invalid type="none" attribute
- default stylesheet provides styling for TOCs using either ol or ul
