### PR TITLE
resolves #469, #364, #472 list improvements

### DIFF
--- a/lib/asciidoctor.rb
+++ b/lib/asciidoctor.rb
@@ -169,14 +169,16 @@ module Asciidoctor
 
   NESTABLE_LIST_CONTEXTS = [:ulist, :olist, :dlist]
 
-  ORDERED_LIST_STYLES = [:arabic, :loweralpha, :lowerroman, :upperalpha, :upperroman]
+  # TODO validate use of explicit style name above ordered list (this list is for selecting an implicit style)
+  ORDERED_LIST_STYLES = [:arabic, :loweralpha, :lowerroman, :upperalpha, :upperroman] #, :lowergreek]
 
   ORDERED_LIST_MARKER_PATTERNS = {
     :arabic => /\d+[.>]/,
     :loweralpha => /[a-z]\./,
-    :upperalpha => /[A-Z]\./,
     :lowerroman => /[ivx]+\)/,
+    :upperalpha => /[A-Z]\./,
     :upperroman => /[IVX]+\)/
+    #:lowergreek => /[a-z]\]/
   }
 
   ORDERED_LIST_KEYWORDS = {
@@ -184,6 +186,9 @@ module Asciidoctor
     'lowerroman' => 'i',
     'upperalpha' => 'A',
     'upperroman' => 'I'
+    #'lowergreek' => 'a'
+    #'arabic'     => '1'
+    #'decimal'    => '1'
   }
 
   LIST_CONTINUATION = '+'

--- a/lib/asciidoctor/abstract_node.rb
+++ b/lib/asciidoctor/abstract_node.rb
@@ -391,5 +391,16 @@ class AbstractNode
         :target_name => asset_name, :recover => autocorrect)
   end
 
+  # Public: Retrieve the list marker keyword for the specified list type.
+  #
+  # For use in the HTML type attribute.
+  #
+  # list_type - the type of list; default to the @style if not specified
+  #
+  # returns the single-character String keyword that represents the marker for the specified list type
+  def list_marker_keyword(list_type = nil)
+    ORDERED_LIST_KEYWORDS[list_type || @style]
+  end
+
 end
 end

--- a/lib/asciidoctor/backends/_stylesheets.rb
+++ b/lib/asciidoctor/backends/_stylesheets.rb
@@ -253,10 +253,12 @@ dl dd:last-child, dl dd:last-child > :last-child { margin-bottom: 0; }
 ol > li p, ul > li p, ul dd, ol dd, .olist .olist, .ulist .olist, .olist .ulist { margin-bottom: 0.625em; }
 ul.unstyled, ol.unnumbered, ul.checklist { list-style-type: none; margin-left: 0.625em; }
 ol.arabic { list-style-type: decimal; }
+ol.decimal { list-style-type: decimal-leading-zero; }
 ol.loweralpha { list-style-type: lower-alpha; }
 ol.upperalpha { list-style-type: upper-alpha; }
 ol.lowerroman { list-style-type: lower-roman; }
 ol.upperroman { list-style-type: upper-roman; }
+ol.lowergreek { list-style-type: lower-greek; }
 .hdlist > table, .colist > table { border: 0; background: none; }
 .hdlist > table > tbody > tr, .colist > table > tbody > tr { background: none; }
 .literalblock + .colist, .listingblock + .colist { margin-top: -0.5em; }

--- a/lib/asciidoctor/backends/html5.rb
+++ b/lib/asciidoctor/backends/html5.rb
@@ -634,7 +634,7 @@ class BlockUlistTemplate < BaseTemplate
     @template ||= @eruby.new <<-EOS
 <%#encoding:UTF-8%><div#{id} class="ulist<%= (checklist = (option? 'checklist')) ? ' checklist' : nil %>#{style_class}#{role_class}"><%= title? ? %(
 <div class="title">\#{title}</div>) : nil %>
-<ul<%= checklist ? ' class="checklist"' : nil %>><%
+<ul<%= checklist ? ' class="checklist"' : (!@style.nil? ? %( class="\#{@style}") : nil) %>><%
 if checklist
   # could use &#9745 (checked ballot) and &#9744 (ballot) w/o font instead
   marker_checked = (@document.attr? 'icons', 'font') ? '<i class="icon-check"></i> ' : '<input type="checkbox" data-item-complete="1" checked disabled> '
@@ -660,7 +660,7 @@ class BlockOlistTemplate < BaseTemplate
     @template ||= @eruby.new <<-EOS
 <%#encoding:UTF-8%><div#{id} class="olist#{style_class}#{role_class}"><%= title? ? %(
 <div class="title">\#{title}</div>) : nil %>
-<ol class="<%= @style %>"<%= (type = ::Asciidoctor::ORDERED_LIST_KEYWORDS[@style]) ? %( type="\#{type}") : nil %>#{attribute('start', :start)}><%
+<ol class="<%= @style %>"<%= (keyword = list_marker_keyword) ? %( type="\#{keyword}") : nil %>#{attribute('start', :start)}><%
 content.each do |item| %>
 <li>
 <p><%= item.text %></p><%

--- a/lib/asciidoctor/lexer.rb
+++ b/lib/asciidoctor/lexer.rb
@@ -457,10 +457,10 @@ class Lexer
             reader.unshift_line this_line
             block = next_outline_list(reader, :olist, parent)
             # QUESTION move this logic to next_outline_list?
-            if !(attributes.has_key? 'style') && !(block.attributes.has_key? 'style')
+            if !attributes['style'] && !block.attributes['style']
               marker = block.buffer.first.marker
               if marker.start_with? '.'
-                # first one makes more sense, but second on is AsciiDoc-compliant
+                # first one makes more sense, but second one is AsciiDoc-compliant
                 #attributes['style'] = (ORDERED_LIST_STYLES[block.level - 1] || ORDERED_LIST_STYLES.first).to_s
                 attributes['style'] = (ORDERED_LIST_STYLES[marker.length - 1] || ORDERED_LIST_STYLES.first).to_s
               else
@@ -2152,6 +2152,12 @@ class Lexer
       else
         parsed_style = attributes['style'] = raw_style
       end
+
+      # don't leave an empty style
+      #if parsed_style.to_s.empty?
+      #  parsed_style = nil
+      #  attributes.delete('style')
+      #end
 
       [parsed_style, original_style]
     end

--- a/test/lists_test.rb
+++ b/test/lists_test.rb
@@ -460,6 +460,20 @@ List
       assert_xpath '//ul/li', output, 3
     end
 
+    test 'should represent block style as style class' do
+      ['disc', 'square', 'circle'].each do |style|
+        input = <<-EOS
+[#{style}]
+* a
+* b
+* c
+        EOS
+        output = render_embedded_string input
+        assert_css ".ulist.#{style}", output, 1
+        assert_css ".ulist.#{style} ul.#{style}", output, 1
+      end
+    end
+
     test "asterisk elements separated by blank lines should merge lists" do
       input = <<-EOS
 List
@@ -1451,6 +1465,58 @@ List
       output = render_string input
       assert_xpath '//ol', output, 1
       assert_xpath '//ol/li', output, 3
+    end
+
+    test 'should represent explicit role attribute as style class' do
+      input = <<-EOS
+[role="dry"]
+. Once
+. Again
+. Refactor!
+      EOS
+
+      output = render_embedded_string input 
+      assert_css '.olist.arabic.dry', output, 1
+      assert_css '.olist ol.arabic', output, 1
+    end
+
+    test 'should represent custom numbering and explicit role attribute as style classes' do
+      input = <<-EOS
+[loweralpha, role="dry"]
+. Once
+. Again
+. Refactor!
+      EOS
+
+      output = render_embedded_string input 
+      assert_css '.olist.loweralpha.dry', output, 1
+      assert_css '.olist ol.loweralpha', output, 1
+    end
+
+    test 'should represent implicit role attribute as style class' do
+      input = <<-EOS
+[.dry]
+. Once
+. Again
+. Refactor!
+      EOS
+
+      output = render_embedded_string input 
+      assert_css '.olist.arabic.dry', output, 1
+      assert_css '.olist ol.arabic', output, 1
+    end
+
+    test 'should represent custom numbering and implicit role attribute as style classes' do
+      input = <<-EOS
+[loweralpha.dry]
+. Once
+. Again
+. Refactor!
+      EOS
+
+      output = render_embedded_string input 
+      assert_css '.olist.loweralpha.dry', output, 1
+      assert_css '.olist ol.loweralpha', output, 1
     end
 
     test "dot elements separated by blank lines should merge lists" do


### PR DESCRIPTION
- support additional list numeration and markers
  - lowergreek and decimal for ordered lists
  - disc, square, circle for unordered lists
- fix missing style when role shorthand is used on ordered list
- convenience method for retrieving list marker keyword
