### PR TITLE
resolves #478 make callout bullets non-selectable

### DIFF
--- a/lib/asciidoctor.rb
+++ b/lib/asciidoctor.rb
@@ -308,11 +308,11 @@ module Asciidoctor
     :biblio_macro     => /\\?\[\[\[([\w:][\w:.-]*?)\]\]\]/,
 
     # callout reference inside literal text
-    # <1>
+    # <1> (optionally prefixed by // or # line comment character)
     # special characters will already be replaced, hence their use in the regex
-    :callout_render   => /\\?&lt;(\d+)&gt;/,
+    :callout_render   => /(?:\/\/ ?|# ?)?(\\)?&lt;(\d+)&gt;$/,
     # ...but not while scanning
-    :callout_scan     => /\\?<(\d+)>/,
+    :callout_scan     => /\\?<(\d+)>$/,
 
     # <1> Foo
     :colist           => /^<?(\d+)>[[:blank:]]+(.*)/,

--- a/lib/asciidoctor/backends/_stylesheets.rb
+++ b/lib/asciidoctor/backends/_stylesheets.rb
@@ -331,8 +331,9 @@ div.unbreakable { page-break-inside: avoid; }
 .admonitionblock td.icon .icon-important:before { content: "\f06a"; color: #bf0000; }
 .conum { display: inline-block; color: white !important; background-color: #222222; -webkit-border-radius: 100px; border-radius: 100px; text-align: center; width: 20px; height: 20px; font-size: 12px; font-weight: bold; line-height: 20px; font-family: Arial, sans-serif; font-style: normal; position: relative; top: -2px; letter-spacing: -1px; }
 .conum * { color: white !important; }
-.conum:empty { display: none; }
-pre .comment .conum { left: -20px; }
+.conum + b { display: none; }
+.conum:after { content: attr(data-value); }
+.conum:not([data-value]):empty { display: none; }
 .literalblock > .content > pre, .listingblock > .content > pre { -webkit-border-radius: 0; border-radius: 0; }
 DEFAULT_ASCIIDOCTOR_STYLESHEET
   end

--- a/lib/asciidoctor/backends/html5.rb
+++ b/lib/asciidoctor/backends/html5.rb
@@ -685,7 +685,7 @@ if @document.attr? 'icons' %>
   content.each_with_index do |item, i| %>
 <tr>
 <td><%
-    if @document.attr? 'icons', 'font' %><i class="conum"><%= i + 1 %></i><%
+    if @document.attr? 'icons', 'font' %><%= %(<i class="conum" data-value="\#{i + 1}"></i><b>\#{i + 1}</b>) %><%
     else %><img src="<%= icon_uri("callouts/\#{i + 1}") %>" alt="<%= i + 1 %>"><%
     end %></td>
 <td><%= item.text %></td>
@@ -856,12 +856,12 @@ end
 class InlineCalloutTemplate < BaseTemplate
   def result(node)
     if node.document.attr? 'icons', 'font'
-      %(<i class="conum">#{node.text}</i>)
+      %(<i class="conum" data-value="#{node.text}"></i><b>(#{node.text})</b>)
     elsif node.document.attr? 'icons'
       src = node.icon_uri("callouts/#{node.text}")
       %(<img src="#{src}" alt="#{node.text}">)
     else
-      "<b>&lt;#{node.text}&gt;</b>"
+      "<b>(#{node.text})</b>"
     end
   end
 

--- a/lib/asciidoctor/substituters.rb
+++ b/lib/asciidoctor/substituters.rb
@@ -716,10 +716,10 @@ module Substituters
       # alias match for Ruby 1.8.7 compat
       m = $~
       # honor the escape
-      if m[0].start_with? '\\'
-        next "&lt;#{m[1]}&gt;"
+      if m[1] == '\\'
+        next "&lt;#{m[2]}&gt;"
       end
-      Inline.new(self, :callout, m[1], :id => document.callouts.read_next_id).render
+      Inline.new(self, :callout, m[2], :id => document.callouts.read_next_id).render
     }
   end
 

--- a/test/lists_test.rb
+++ b/test/lists_test.rb
@@ -3746,8 +3746,8 @@ puts doc.render # <3>
 [source]
 ----
 require 'asciidoctor' # <1>
-doc = Asciidoctor::Document.new('Hello, World!') # <2>
-puts doc.render # <3>
+doc = Asciidoctor::Document.new('Hello, World!') #<2>
+puts doc.render #<3>
 ----
 <1> Describe the first line
 <2> Describe the second line
@@ -3756,11 +3756,15 @@ puts doc.render # <3>
     output = render_embedded_string input, :attributes => {'icons' => 'font'}
     assert_css '.listingblock code > i', output, 3
     (1..3).each do |i|
-      assert_xpath %((/div[@class="listingblock"]//code/i)[#{i}][@class="conum"][text() = "#{i}"]), output, 1
+      assert_xpath %((/div[@class="listingblock"]//code/i)[#{i}]), output, 1
+      assert_xpath %((/div[@class="listingblock"]//code/i)[#{i}][@class="conum"][@data-value="#{i}"]), output, 1
+      assert_xpath %((/div[@class="listingblock"]//code/i)[#{i}]/following-sibling::b[text()="(#{i})"]), output, 1
     end
     assert_css '.colist table td i', output, 3
     (1..3).each do |i|
-      assert_xpath %((/div[@class="colist arabic"]//td/i)[#{i}][@class="conum"][text() = "#{i}"]), output, 1
+      assert_xpath %((/div[@class="colist arabic"]//td/i)[#{i}]), output, 1
+      assert_xpath %((/div[@class="colist arabic"]//td/i)[#{i}][@class="conum"][@data-value = "#{i}"]), output, 1
+      assert_xpath %((/div[@class="colist arabic"]//td/i)[#{i}]/following-sibling::b[text() = "#{i}"]), output, 1
     end
   end
 end


### PR DESCRIPTION
- enforce that callout bullet is at end of the line
- consume line comment character immediately preceding callout number
- change layout of callouts in html output
