### PR TITLE
resolves #498 permit !name syntax for undefining attribute

### DIFF
--- a/lib/asciidoctor.rb
+++ b/lib/asciidoctor.rb
@@ -267,20 +267,11 @@ module Asciidoctor
     # :foo: bar
     # :Author: Dan
     # :numbered!:
-    :attr_entry       => /^:(\w.*?):(?:[[:blank:]]+(.*))?$/,
-
-    # {name?value}
-    :attr_conditional => /^\s*\{([^\?]+)\?\s*([^\}]+)\s*\}/,
-
-    # +   Attribute values treat lines ending with ' +' as a continuation,
-    #     not a line-break as elsewhere in the document, where this is
-    #     a forced line break. This should be the same regexp as :line_break,
-    #     below, but it gets its own entry because readability ftw, even
-    #     though repeating regexps ftl.
-    :attr_continue    => /^[[:blank:]]*(.*)[[:blank:]]\+[[:blank:]]*$/,
-
-    # :foo!:
-    :attr_delete      => /^:([^:]+)!:$/,
+    # :long-entry: Attribute value lines ending in ' +'
+    #              are joined together as a single value,
+    #              collapsing the line breaks and indentation to
+    #              a single space.
+    :attr_entry       => /^:(!?\w.*?):(?:[[:blank:]]+(.*))?$/,
 
     # An attribute list above a block element
     #
@@ -298,6 +289,8 @@ module Asciidoctor
     # attribute reference
     # {foo}
     # {counter:pcount:1}
+    # {set:foo:bar}
+    # {set:name!}
     :attr_ref         => /(\\)?\{((set|counter2?):.+?|\w+(?:[\-]\w+)*)(\\)?\}/,
 
     # The author info line the appears immediately following the document title

--- a/lib/asciidoctor/cli/options.rb
+++ b/lib/asciidoctor/cli/options.rb
@@ -85,6 +85,10 @@ Example: asciidoctor -b html5 source.asciidoc
                   'defined in the source document') do |attribs|
             attribs.each do |attrib|
               key, val = attrib.split '=', 2
+              # move leading ! to end for internal processing
+              #if val.nil? && key.start_with?('!')
+              #  key = "#{key[1..-1]}!"
+              #end
               self[:attributes][key] = val || ''
             end
           end

--- a/lib/asciidoctor/lexer.rb
+++ b/lib/asciidoctor/lexer.rb
@@ -1778,6 +1778,10 @@ class Lexer
       # a nil value signals the attribute should be deleted (undefined)
       value = nil
       name = name.chop
+    elsif name.start_with?('!')
+      # a nil value signals the attribute should be deleted (undefined)
+      value = nil
+      name = name[1..-1]
     end
 
     name = sanitize_attribute_name(name)

--- a/test/attributes_test.rb
+++ b/test/attributes_test.rb
@@ -22,8 +22,28 @@ context 'Attributes' do
       assert_equal 'This is the first Ruby implementation of AsciiDoc.', doc.attributes['description']
     end
 
-    test 'deletes an attribute' do
+    test 'should delete an attribute that ends with !' do
       doc = document_from_string(":frog: Tanglefoot\n:frog!:")
+      assert_equal nil, doc.attributes['frog']
+    end
+
+    test 'should delete an attribute that ends with ! set via API' do
+      doc = document_from_string(":frog: Tanglefoot", :attributes => {'frog!' => ''})
+      assert_equal nil, doc.attributes['frog']
+    end
+
+    test 'should delete an attribute that begins with !' do
+      doc = document_from_string(":frog: Tanglefoot\n:!frog:")
+      assert_equal nil, doc.attributes['frog']
+    end
+
+    test 'should delete an attribute that begins with ! set via API' do
+      doc = document_from_string(":frog: Tanglefoot", :attributes => {'!frog' => ''})
+      assert_equal nil, doc.attributes['frog']
+    end
+
+    test 'should delete an attribute set via API to nil value' do
+      doc = document_from_string(":frog: Tanglefoot", :attributes => {'frog' => nil})
       assert_equal nil, doc.attributes['frog']
     end
 


### PR DESCRIPTION
- remove unused attribute matching regular expressions
- normalize negated attributes before processing other assignments
- improved attribute tests
