### PR TITLE
resolves #551 strip leading separator(s) on section id if idprefix is blank

### DIFF
--- a/lib/asciidoctor.rb
+++ b/lib/asciidoctor.rb
@@ -356,6 +356,8 @@ module Asciidoctor
                            ';;' => /^(?!\/\/)[[:blank:]]*(.*)(;;)(?:[[:blank:]]+(.*))?$/
                          },
 
+    :illegal_sectid_chars => /&(?:[[:alpha:]]+|#[[:digit:]]+|#x[[:alnum:]]+);|\W+?/,
+
     # footnote:[text]
     # footnoteref:[id,text]
     # footnoteref:[id]

--- a/lib/asciidoctor/section.rb
+++ b/lib/asciidoctor/section.rb
@@ -80,16 +80,26 @@ class Section < AbstractBlock
   #   another_section.title = "Foo"
   #   another_section.generate_id
   #   => "_foo_1"
+  #
+  #   yet_another_section = Section.new(parent)
+  #   yet_another_section.title = "Ben & Jerry"
+  #   yet_another_section.generate_id
+  #   => "_ben_jerry"
   def generate_id
     if @document.attr? 'sectids'
       separator = @document.attr('idseparator', '_')
-      # FIXME define constants for these regexps
-      base_id = @document.attr('idprefix', '_') + title.downcase.gsub(/&#[0-9]+;/, separator).
-          gsub(/\W+/, separator).tr_s(separator, separator).chomp(separator)
+      idprefix = @document.attr('idprefix', '_')
+      base_id = idprefix + title.downcase.gsub(REGEXP[:illegal_sectid_chars], separator).
+          tr_s(separator, separator).chomp(separator)
+      # ensure id doesn't begin with idprefix if requested it doesn't
+      if idprefix.empty? && base_id.start_with?(separator)
+        base_id = base_id[1..-1]
+        base_id = base_id[1..-1] while base_id.start_with?(separator)
+      end
       gen_id = base_id
       cnt = 2
-      while @document.references[:ids].has_key? gen_id 
-        gen_id = "#{base_id}#{separator}#{cnt}" 
+      while @document.references[:ids].has_key? gen_id
+        gen_id = "#{base_id}#{separator}#{cnt}"
         cnt += 1
       end 
       gen_id

--- a/test/sections_test.rb
+++ b/test/sections_test.rb
@@ -18,6 +18,11 @@ context 'Sections' do
       assert_equal '_section_one', sec.id
     end
 
+    test 'synthetic id removes entities' do
+      sec = block_from_string('== Ben & Jerry &#34;Ice Cream Brothers&#34;')
+      assert_equal '_ben_jerry_ice_cream_brothers', sec.id
+    end
+
     test 'synthetic id prefix can be customized' do
       sec = block_from_string(":idprefix: id_\n\n== Section One")
       assert_equal 'id_section_one', sec.id
@@ -26,6 +31,11 @@ context 'Sections' do
     test 'synthetic id prefix can be set to blank' do
       sec = block_from_string(":idprefix:\n\n== Section One")
       assert_equal 'section_one', sec.id
+    end
+
+    test 'synthetic id prefix is stripped from beginning of id if set to blank' do
+      sec = block_from_string(":idprefix:\n\n== & More")
+      assert_equal 'more', sec.id
     end
 
     test 'synthetic id separator can be customized' do


### PR DESCRIPTION
- make section id sub regex a constant
- capture all entities, not just numeric ones
