### PR TITLE
Reader should only process lines in AsciiDoc files

### DIFF
--- a/lib/asciidoctor.rb
+++ b/lib/asciidoctor.rb
@@ -132,6 +132,15 @@ module Asciidoctor
     'markdown' => '.md'
   }
 
+  # Set of file extensions recognized as AsciiDoc documents (stored as a truth hash)
+  ASCIIDOC_EXTENSIONS = {
+    '.asciidoc' => true,
+    '.adoc' => true,
+    '.ad' => true,
+    '.asc' => true,
+    '.txt' => true
+  }
+
   SECTION_LEVELS = {
     '=' => 0,
     '-' => 1,


### PR DESCRIPTION
additionally:
- small optimization for matching line comments
- decrement look_ahead if line restored w/ processing off
