### PR TITLE
resolves #579 specialchars subs alias, shorthand subs

### DIFF
--- a/lib/asciidoctor/substituters.rb
+++ b/lib/asciidoctor/substituters.rb
@@ -16,7 +16,19 @@ module Substituters
   COMPOSITE_SUBS = {
     :none => [],
     :normal => SUBS[:normal],
-    :verbatim => SUBS[:verbatim]
+    :verbatim => SUBS[:verbatim],
+    :specialchars => :specialcharacters
+  }
+
+  SUB_SYMBOLS = {
+    :a => :attributes,
+    :m => :macros,
+    :n => :normal,
+    :p => :post_replacements,
+    :q => :quotes,
+    :r => :replacements,
+    :c => :specialcharacters,
+    :v => :verbatim
   }
 
   SUB_OPTIONS = {
@@ -1014,10 +1026,17 @@ module Substituters
     subs.split(',').each do |val|
       key = val.strip.to_sym
       # special case to disable callouts for inline subs
-      if key == :verbatim && type == :inline
+      if type == :inline && (key == :verbatim || key == :v)
         candidates << :specialcharacters
       elsif COMPOSITE_SUBS.has_key? key
         candidates.push(*COMPOSITE_SUBS[key])
+      elsif type == :inline && key.to_s.length == 1 && (SUB_SYMBOLS.has_key? key)
+        resolved_key = SUB_SYMBOLS[key]
+        if COMPOSITE_SUBS.has_key? resolved_key
+          candidates.push(*COMPOSITE_SUBS[resolved_key])
+        else
+          candidates << resolved_key
+        end
       else
         candidates << key
       end

--- a/test/paragraphs_test.rb
+++ b/test/paragraphs_test.rb
@@ -186,11 +186,21 @@ Note that multi-entry terms generate separate index entries.
     test 'normal paragraph should honor explicit subs list' do
       input = <<-EOS
 [subs="specialcharacters"]
-*Hey Jude*
+*<Hey Jude>*
       EOS
 
       output = render_embedded_string input
-      assert output.include?('*Hey Jude*')
+      assert output.include?('*&lt;Hey Jude&gt;*')
+    end
+
+    test 'normal paragraph should honor specialchars shorthand' do
+      input = <<-EOS
+[subs="specialchars"]
+*<Hey Jude>*
+      EOS
+
+      output = render_embedded_string input
+      assert output.include?('*&lt;Hey Jude&gt;*')
     end
 
     test 'should add a hardbreak at end of each line when hardbreaks option is set' do

--- a/test/substitutions_test.rb
+++ b/test/substitutions_test.rb
@@ -983,6 +983,15 @@ EOS
       assert_equal [:specialcharacters, :quotes], para.passthroughs.first[:subs]
     end
 
+    test 'resolves sub shorthands on inline pass macro' do
+      para = block_from_string 'pass:q,a[*<{backend}>*]'
+      result = para.extract_passthroughs para.source
+      assert_equal 1, para.passthroughs.size
+      assert_equal [:quotes, :attributes], para.passthroughs.first[:subs]
+      result = para.restore_passthroughs result
+      assert_equal '<strong><html5></strong>', result
+    end
+
     # NOTE placeholder is surrounded by text to prevent reader from stripping trailing boundary char (unique to test scenario)
     test 'restore inline passthroughs without subs' do
       para = block_from_string("some \e" + '0' + "\e to study")


### PR DESCRIPTION
- add specialchars as an alias for the subs key specialcharacters
- resolve single-letter subs for inline usages such as pass:[]
