### PR TITLE
Remove Struct in favor of Class

### DIFF
--- a/lib/asciidoctor/document.rb
+++ b/lib/asciidoctor/document.rb
@@ -18,19 +18,29 @@ module Asciidoctor
 # noheader - The header block (h1 heading, author, revision info) should not be shown
 class Document < AbstractBlock
 
-  Footnote = Struct.new(:index, :id, :text)
-  AttributeEntry = Struct.new(:name, :value, :negate) do
+  class Footnote
+    attr_reader :index, :id, :text
+
+    def initialize(index, id, text)
+      @index = index
+      @id = id
+      @text = text
+    end
+  end
+
+  class AttributeEntry
+    attr_reader :name, :value, :negate
+
     def initialize(name, value, negate = nil)
-      super(name, value, negate.nil? ? value.nil? : false)
+      @name = name
+      @value = value
+      @negate = negate.nil? ? value.nil? : false
     end
 
     def save_to(block_attributes)
-      (block_attributes[:attribute_entries] ||= []) << self
+      block_attributes[:attribute_entries] ||= []
+      block_attributes[:attribute_entries] << self
     end
-
-    #def save_to_next_block(document)
-    #  (document.attributes[:pending_attribute_entries] ||= []) << self
-    #end
   end
 
   # Public A read-only integer value indicating the level of security that

--- a/lib/asciidoctor/lexer.rb
+++ b/lib/asciidoctor/lexer.rb
@@ -1,4 +1,5 @@
 module Asciidoctor
+
 # Public: Methods to parse lines of AsciiDoc into an object hierarchy
 # representing the structure of the document. All methods are class methods and
 # should be invoked from the Lexer class. The main entry point is ::next_block.
@@ -23,7 +24,16 @@ module Asciidoctor
 #   # => Asciidoctor::Block
 class Lexer
 
-  BlockMatchData = Struct.new(:context, :masq, :tip, :terminator)
+  class BlockMatchData
+    attr_reader :context, :masq, :tip, :terminator
+
+    def initialize(context, masq, tip, terminator)
+      @context = context
+      @masq = masq
+      @tip = tip
+      @terminator = terminator
+    end
+  end
 
   # Public: Make sure the Lexer object doesn't get initialized.
   #


### PR DESCRIPTION
One Struct remains in `table.rb` `Table::Rows`.
The method `[]` is used: 

``` ruby
NoMethodError: undefined method `[]' for #<Asciidoctor::Table::Rows:0x00000005d81030>
    (erb):19:in `block in get_binding'
    (erb):19:in `select'
    (erb):19:in `get_binding'
```
