### PR TITLE
resolves #695 allow spaces in reftext defined in block anchor

### DIFF
--- a/lib/asciidoctor.rb
+++ b/lib/asciidoctor.rb
@@ -305,13 +305,17 @@ module Asciidoctor
 
     # [[idname]]
     # [[idname,Reference Text]]
-    :anchor           => /^\[\[(#{CC_ALPHA}[\w:.-]*(?:,#{CC_BLANK}*\S.*)?)\]\]$/,
+    :anchor           => /^\[\[(|#{CC_ALPHA}[\w:.-]*(?:,#{CC_BLANK}*\S.*)?)\]\]$/,
 
-    # Foowhatevs [[Bar]]
-    :anchor_embedded  => /^(.*?)\s*\[\[([^\[\]]+)\]\]$/,
+    # Section Title [[idname]]
+    # Section Title [[idname,Reference Text]]
+    # Section Title [["idname","Reference Text"]]
+    :anchor_embedded  => /^(.*?)#{CC_BLANK}+(\\)?\[\[("?)(#{CC_ALPHA}[\w:.-]*)\3(?:,#{CC_BLANK}*("?)(\S.*?)\5)?\]\]$/,
 
-    # [[ref]] (anywhere inline)
-    :anchor_macro     => /\\?\[\[([\w":].*?)\]\]/,
+    # [[idname]] (anywhere inline)
+    # [[idname,Reference Text]] (anywhere inline)
+    # [["idname","Reference Text"]] (anywhere inline)
+    :anchor_macro     => /\\?\[\[(("?)#{CC_ALPHA}[\w:.-]*\2(?:,#{CC_BLANK}*\S.*?)?)\]\]/,
 
     # matches any unbounded block delimiter:
     #   listing, literal, example, sidebar, quote, passthrough, table, fenced code
@@ -341,8 +345,8 @@ module Asciidoctor
     # [{lead}]
     :blk_attr_list    => /^\[(|#{CC_BLANK}*[\w\{,.#"'%].*)\]$/,
 
-    # block attribute list or block id (bulk query)
-    :attr_line        => /^\[(|#{CC_BLANK}*[\w\{,.#"'%].*|\[[^\[\]]*\])\]$/,
+    # block attribute list or block anchor (bulk query)
+    :attr_line        => /^\[(|#{CC_BLANK}*[\w\{,.#"'%].*|\[(?:|#{CC_ALPHA}[\w:.-]*(?:,#{CC_BLANK}*\S.*)?)\])\]$/,
 
     # attribute reference
     # {foo}
@@ -572,8 +576,9 @@ module Asciidoctor
     # match[1] is the delimiter, whose length determines the level
     # match[2] is the title itself
     # match[3] is an inline anchor, which becomes the section id
-    :section_title     => /^((?:=|#){1,6})\s+(\S.*?)(?:\s*\[\[([^\[]+)\]\])?(?:\s+\1)?$/,
+    :section_title     => /^((?:=|#){1,6})#{CC_BLANK}+(\S.*?)(?:#{CC_BLANK}+\1)?$/,
 
+    # restricted section name for two-line section title
     # does not begin with a dot and has at least one alphanumeric character
     :section_name      => /^((?=.*\w+.*)[^.].*?)$/,
 

--- a/test/blocks_test.rb
+++ b/test/blocks_test.rb
@@ -2101,7 +2101,6 @@ content
       assert_nil block.id
       assert_nil (block.attr 'reftext')
       assert !doc.references[:ids].has_key?('illegal$id')
-      puts doc.render
     end
 
     test 'should use specified id and reftext when registering block reference' do

--- a/test/sections_test.rb
+++ b/test/sections_test.rb
@@ -64,6 +64,24 @@ context 'Sections' do
       assert_equal 'Section One', sec.title
     end
 
+    test 'explicit id can be defined using an inline anchor with reftext' do
+      sec = block_from_string("== Section One [[one,Section Uno]] ==")
+      assert_equal 'one', sec.id
+      assert_equal 'Section One', sec.title
+    end
+
+    test 'id and reftext in inline anchor can be quoted' do
+      sec = block_from_string(%(== Section One [["one","Section Uno"]] ==))
+      assert_equal 'one', sec.id
+      assert_equal 'Section One', sec.title
+    end
+
+    test 'should unescape but not process inline anchor' do
+      sec = block_from_string(%(== Section One \\[[one]] ==))
+      assert_not_equal 'one', sec.id
+      assert_equal 'Section One [[one]]', sec.title
+    end
+
     test 'title substitutions are applied before generating id' do
       sec = block_from_string("== Section{sp}One\n")
       assert_equal '_section_one', sec.id


### PR DESCRIPTION
- also recognize only legal characters in id
