### PR TITLE
resolves #697 honor reftext defined in embedded section title anchor

### DIFF
--- a/lib/asciidoctor.rb
+++ b/lib/asciidoctor.rb
@@ -245,15 +245,13 @@ module Asciidoctor
 
   # Regular expression character classes (dependent on regexp engine)
   if RUBY_ENGINE_OPAL
-    CC_ALPHA = '[a-zA-Z]'
-    CC_ALNUM = '[a-zA-Z0-9]'
-    CC_ALNUM_BARE = 'a-zA-Z0-9'
+    CC_ALPHA = 'a-zA-Z'
+    CC_ALNUM = 'a-zA-Z0-9'
     CC_BLANK = '[ \t]'
     CC_GRAPH = '[\x21-\x7E]' # non-blank character
   else
-    CC_ALPHA = '[[:alpha:]]'
-    CC_ALNUM = '[[:alnum:]]'
-    CC_ALNUM_BARE = '[:alnum:]'
+    CC_ALPHA = '[:alpha:]'
+    CC_ALNUM = '[:alnum:]'
     CC_BLANK = '[[:blank:]]'
     CC_GRAPH = '[[:graph:]]' # non-blank character
   end
@@ -305,17 +303,15 @@ module Asciidoctor
 
     # [[idname]]
     # [[idname,Reference Text]]
-    :anchor           => /^\[\[(|#{CC_ALPHA}[\w:.-]*(?:,#{CC_BLANK}*\S.*)?)\]\]$/,
+    :anchor           => /^\[\[(?:|([#{CC_ALPHA}:_][\w:.-]*)(?:,#{CC_BLANK}*(\S.*))?)\]\]$/,
 
     # Section Title [[idname]]
     # Section Title [[idname,Reference Text]]
-    # Section Title [["idname","Reference Text"]]
-    :anchor_embedded  => /^(.*?)#{CC_BLANK}+(\\)?\[\[("?)(#{CC_ALPHA}[\w:.-]*)\3(?:,#{CC_BLANK}*("?)(\S.*?)\5)?\]\]$/,
+    :anchor_embedded  => /^(.*?)#{CC_BLANK}+(\\)?\[\[([#{CC_ALPHA}:_][\w:.-]*)(?:,#{CC_BLANK}*(\S.*?))?\]\]$/,
 
     # [[idname]] (anywhere inline)
     # [[idname,Reference Text]] (anywhere inline)
-    # [["idname","Reference Text"]] (anywhere inline)
-    :anchor_macro     => /\\?\[\[(("?)#{CC_ALPHA}[\w:.-]*\2(?:,#{CC_BLANK}*\S.*?)?)\]\]/,
+    :anchor_macro     => /\\?\[\[([#{CC_ALPHA}:_][\w:.-]*)(?:,#{CC_BLANK}*(\S.*?))?\]\]/,
 
     # matches any unbounded block delimiter:
     #   listing, literal, example, sidebar, quote, passthrough, table, fenced code
@@ -346,7 +342,7 @@ module Asciidoctor
     :blk_attr_list    => /^\[(|#{CC_BLANK}*[\w\{,.#"'%].*)\]$/,
 
     # block attribute list or block anchor (bulk query)
-    :attr_line        => /^\[(|#{CC_BLANK}*[\w\{,.#"'%].*|\[(?:|#{CC_ALPHA}[\w:.-]*(?:,#{CC_BLANK}*\S.*)?)\])\]$/,
+    :attr_line        => /^\[(|#{CC_BLANK}*[\w\{,.#"'%].*|\[(?:|[#{CC_ALPHA}:_][\w:.-]*(?:,#{CC_BLANK}*\S.*)?)\])\]$/,
 
     # attribute reference
     # {foo}
@@ -486,7 +482,7 @@ module Asciidoctor
 
     # inline email address
     # doc.writer@asciidoc.org
-    :email_inline     => /[\\>:]?\w[\w.%+-]*@#{CC_ALNUM}[#{CC_ALNUM_BARE}.-]*\.#{CC_ALPHA}{2,4}\b/,
+    :email_inline     => /[\\>:]?\w[\w.%+-]*@[#{CC_ALNUM}][#{CC_ALNUM}.-]*\.[#{CC_ALPHA}]{2,4}\b/,
 
     # <TAB>Foo  or one-or-more-spaces-or-tabs then whatever
     :lit_par          => /^(#{CC_BLANK}+.*)$/,
@@ -621,7 +617,7 @@ module Asciidoctor
     # http://domain
     # https://domain
     # data:info
-    :uri_sniff        => %r{\A#{CC_ALPHA}[#{CC_ALNUM_BARE}.+-]*:/*},
+    :uri_sniff        => %r{\A[#{CC_ALPHA}][#{CC_ALNUM}.+-]*:/*},
 
     :uri_encode_chars => /[^\w\-.!~*';:@=+$,()\[\]]/,
 

--- a/lib/asciidoctor/lexer.rb
+++ b/lib/asciidoctor/lexer.rb
@@ -1076,11 +1076,13 @@ class Lexer
       # alias match for Ruby 1.8.7 compat
       m = $~
       next if m[0].start_with? '\\'
-      id, reftext = m[1].split(',', 2)
-      id.sub!(REGEXP[:dbl_quoted], '\2')
-      if !reftext.nil?
-        reftext.sub!(REGEXP[:m_dbl_quoted], '\2')
-      end
+      id = m[1]
+      reftext = m[2]
+      # enable if we want to allow double quoted values
+      #id.sub!(REGEXP[:dbl_quoted], '\2')
+      #if !reftext.nil?
+      #  reftext.sub!(REGEXP[:m_dbl_quoted], '\2')
+      #end
       document.register(:ids, [id, reftext])
     }
     nil
@@ -1598,8 +1600,8 @@ class Lexer
       if (sect_title.end_with? ']]') && (anchor_match = (sect_title.match REGEXP[:anchor_embedded]))
         if anchor_match[2].nil?
           sect_title = anchor_match[1]
-          sect_id = anchor_match[4]
-          sect_reftext = anchor_match[6]
+          sect_id = anchor_match[3]
+          sect_reftext = anchor_match[4]
         end
       end
     elsif Compliance.underline_style_section_titles
@@ -1612,8 +1614,8 @@ class Lexer
         if (sect_title.end_with? ']]') && (anchor_match = (sect_title.match REGEXP[:anchor_embedded]))
           if anchor_match[2].nil?
             sect_title = anchor_match[1]
-            sect_id = anchor_match[4]
-            sect_reftext = anchor_match[6]
+            sect_id = anchor_match[3]
+            sect_reftext = anchor_match[4]
           end
         end
         sect_level = section_level line2
@@ -1878,13 +1880,12 @@ class Lexer
     elsif !options[:text] && (match = next_line.match(REGEXP[:attr_entry]))
       process_attribute_entry(reader, parent, attributes, match)
     elsif match = next_line.match(REGEXP[:anchor])
-      unless (text = match[1]).empty?
-        id, reftext = text.split(',', 2)
-        attributes['id'] = id
+      unless match[1] == ''
+        attributes['id'] = match[1]
         # AsciiDoc always uses [id] as the reftext in HTML output,
         # but I'd like to do better in Asciidoctor
         # registration is deferred until the block or section is processed
-        attributes['reftext'] = reftext if reftext
+        attributes['reftext'] = match[2] unless match[2].nil?
       end
     elsif match = next_line.match(REGEXP[:blk_attr_list])
       parent.document.parse_attributes(match[1], [], :sub_input => true, :into => attributes)

--- a/lib/asciidoctor/substituters.rb
+++ b/lib/asciidoctor/substituters.rb
@@ -808,15 +808,21 @@ module Substituters
         if m[0].start_with? '\\'
           next m[0][1..-1]
         end
-        id, reftext = m[1].split(',').map(&:strip)
-        id.sub!(REGEXP[:dbl_quoted], '\2')
-        if reftext.nil?
-          reftext = "[#{id}]"
+        id = m[1]
+        reftext = m[2].nil? ? "[#{id}]" : m[2]
+        # enable if we want to allow double quoted values
+        #id.sub!(REGEXP[:dbl_quoted], '\2')
+        #if reftext.nil?
+        #  reftext = "[#{id}]"
+        #else
+        #  reftext.sub!(REGEXP[:m_dbl_quoted], '\2')
+        #end
+        if @document.references[:ids].has_key? id
+          # reftext may not match since inline substitutions have been applied
+          #if reftext != @document.references[:ids][id]
+          #  Debug.debug { "Mismatched reference for anchor #{id}" }
+          #end
         else
-          reftext.sub!(REGEXP[:m_dbl_quoted], '\2')
-        end
-        # NOTE the reftext should also match what's in our references dic
-        if !@document.references[:ids].has_key? id
           Debug.debug { "Missing reference for anchor #{id}" }
         end
         Inline.new(self, :anchor, reftext, :type => :ref, :target => id).render

--- a/test/blocks_test.rb
+++ b/test/blocks_test.rb
@@ -2135,7 +2135,7 @@ $ apt-get install asciidoctor
 
     test 'should allow comma in block reference text' do
       input = <<-EOS
-[[debian,Debian, Ubuntu]]
+[[debian, Debian, Ubuntu]]
 .Installation on Debian
 ----
 $ apt-get install asciidoctor

--- a/test/links_test.rb
+++ b/test/links_test.rb
@@ -236,13 +236,13 @@ context 'Links' do
     assert_equal({'tigers' => 'Tigers'}, doc.references[:ids])
   end
 
-  test 'anchor with quoted label creates reference' do
-    doc = document_from_string %([["tigers","Tigers roam here"]]Tigers roam here.)
-    assert_equal({'tigers' => "Tigers roam here"}, doc.references[:ids])
+  test 'anchor with quoted label creates reference with quoted label text' do
+    doc = document_from_string %([[tigers,"Tigers roam here"]]Tigers roam here.)
+    assert_equal({'tigers' => '"Tigers roam here"'}, doc.references[:ids])
   end
 
-  test 'anchor with quoted label containing a comma creates reference' do
-    doc = document_from_string %([["tigers","Tigers, scary tigers, roam here"]]Tigers roam here.)
-    assert_equal({'tigers' => "Tigers, scary tigers, roam here"}, doc.references[:ids])
+  test 'anchor with label containing a comma creates reference' do
+    doc = document_from_string %([[tigers,Tigers, scary tigers, roam here]]Tigers roam here.)
+    assert_equal({'tigers' => 'Tigers, scary tigers, roam here'}, doc.references[:ids])
   end
 end

--- a/test/sections_test.rb
+++ b/test/sections_test.rb
@@ -71,15 +71,15 @@ context 'Sections' do
       assert_equal 'Section Uno', (sec.attr 'reftext')
     end
 
-    test 'id and reftext in embedded anchor can be quoted' do
+    test 'id and reftext in embedded anchor cannot be quoted' do
       sec = block_from_string(%(== Section One [["one","Section Uno"]] ==))
-      assert_equal 'one', sec.id
-      assert_equal 'Section One', sec.title
-      assert_equal 'Section Uno', (sec.attr 'reftext')
+      assert_not_equal 'one', sec.id
+      assert_equal 'Section One [["one","Section Uno"]]', sec.title
+      assert_nil (sec.attr 'reftext')
     end
 
     test 'reftext in embedded anchor may contain comma' do
-      sec = block_from_string(%(== Section One [["one","Section,Uno"]] ==))
+      sec = block_from_string(%(== Section One [[one, Section,Uno]] ==))
       assert_equal 'one', sec.id
       assert_equal 'Section One', sec.title
       assert_equal 'Section,Uno', (sec.attr 'reftext')


### PR DESCRIPTION
- assign reftext defined in embedded anchor to section
- register id for block even if reftext and title are empty
- don't split on comma in reftext (only split on first comma)
- disallow quoted values in block and inline anchors
