### PR TITLE
Remove unsupported syntax to make Asciidoctor compatible with Opal

### DIFF
--- a/lib/asciidoctor/document.rb
+++ b/lib/asciidoctor/document.rb
@@ -122,7 +122,8 @@ class Document < AbstractBlock
       # attribute overrides are attributes that can only be set from the commandline
       # a direct assignment effectively makes the attribute a constant
       # a nil value or name with leading or trailing ! will result in the attribute being unassigned
-      @attribute_overrides = (options[:attributes] || {}).inject({}) do |collector,(key,value)|
+      @attribute_overrides = (options[:attributes] || {}).inject({}) do |collector,hash|
+        key, value = hash
         if key.start_with?('!')
           key = key[1..-1]
           value = nil


### PR DESCRIPTION
Full stack trace when running `rake dist` on Asciidoctor.js:

```
$ rake dist
Cannot handle dynamic require :asciidoctor:12
Cannot handle dynamic require :asciidoctor/helpers:23
rake aborted!
parse error on value "(" (PAREN_BEG) :asciidoctor/document:125
  (in /home/ggrossetie/workspaces/opensource/asciidoctor.js/asciidoctor/lib/asciidoctor/document.rb)
/var/lib/gems/1.9.1/gems/opal-0.4.4/lib/opal/lexer.rb:40:in `on_error'
(eval):3:in `_racc_do_parse_c'
(eval):3:in `do_parse'
/var/lib/gems/1.9.1/gems/opal-0.4.4/lib/opal/lexer.rb:33:in `parse'
/var/lib/gems/1.9.1/gems/opal-0.4.4/lib/opal/parser.rb:76:in `parse'
/var/lib/gems/1.9.1/gems/opal-0.4.4/lib/opal/require_parser.rb:17:in `parse'
/var/lib/gems/1.9.1/gems/opal-sprockets-0.2.0/lib/opal/sprockets/processor.rb:73:in `evaluate'
/var/lib/gems/1.9.1/gems/tilt-1.4.1/lib/tilt/template.rb:103:in `render'
/var/lib/gems/1.9.1/gems/sprockets-2.10.0/lib/sprockets/context.rb:197:in `block in evaluate'
/var/lib/gems/1.9.1/gems/sprockets-2.10.0/lib/sprockets/context.rb:194:in `each'
/var/lib/gems/1.9.1/gems/sprockets-2.10.0/lib/sprockets/context.rb:194:in `evaluate'
/var/lib/gems/1.9.1/gems/sprockets-2.10.0/lib/sprockets/processed_asset.rb:12:in `initialize'
/var/lib/gems/1.9.1/gems/sprockets-2.10.0/lib/sprockets/base.rb:374:in `new'
/var/lib/gems/1.9.1/gems/sprockets-2.10.0/lib/sprockets/base.rb:374:in `block in build_asset'
/var/lib/gems/1.9.1/gems/sprockets-2.10.0/lib/sprockets/base.rb:395:in `circular_call_protection'
/var/lib/gems/1.9.1/gems/sprockets-2.10.0/lib/sprockets/base.rb:373:in `build_asset'
/var/lib/gems/1.9.1/gems/sprockets-2.10.0/lib/sprockets/index.rb:94:in `block in build_asset'
/var/lib/gems/1.9.1/gems/sprockets-2.10.0/lib/sprockets/caching.rb:51:in `cache_asset'
/var/lib/gems/1.9.1/gems/sprockets-2.10.0/lib/sprockets/index.rb:93:in `build_asset'
/var/lib/gems/1.9.1/gems/sprockets-2.10.0/lib/sprockets/base.rb:287:in `find_asset'
/var/lib/gems/1.9.1/gems/sprockets-2.10.0/lib/sprockets/index.rb:61:in `find_asset'
/var/lib/gems/1.9.1/gems/sprockets-2.10.0/lib/sprockets/processed_asset.rb:111:in `block in resolve_dependencies'
/var/lib/gems/1.9.1/gems/sprockets-2.10.0/lib/sprockets/processed_asset.rb:105:in `each'
/var/lib/gems/1.9.1/gems/sprockets-2.10.0/lib/sprockets/processed_asset.rb:105:in `resolve_dependencies'
/var/lib/gems/1.9.1/gems/sprockets-2.10.0/lib/sprockets/processed_asset.rb:97:in `build_required_assets'
/var/lib/gems/1.9.1/gems/sprockets-2.10.0/lib/sprockets/processed_asset.rb:16:in `initialize'
/var/lib/gems/1.9.1/gems/sprockets-2.10.0/lib/sprockets/base.rb:374:in `new'
/var/lib/gems/1.9.1/gems/sprockets-2.10.0/lib/sprockets/base.rb:374:in `block in build_asset'
/var/lib/gems/1.9.1/gems/sprockets-2.10.0/lib/sprockets/base.rb:395:in `circular_call_protection'
/var/lib/gems/1.9.1/gems/sprockets-2.10.0/lib/sprockets/base.rb:373:in `build_asset'
/var/lib/gems/1.9.1/gems/sprockets-2.10.0/lib/sprockets/index.rb:94:in `block in build_asset'
/var/lib/gems/1.9.1/gems/sprockets-2.10.0/lib/sprockets/caching.rb:51:in `cache_asset'
/var/lib/gems/1.9.1/gems/sprockets-2.10.0/lib/sprockets/index.rb:93:in `build_asset'
/var/lib/gems/1.9.1/gems/sprockets-2.10.0/lib/sprockets/base.rb:287:in `find_asset'
/var/lib/gems/1.9.1/gems/sprockets-2.10.0/lib/sprockets/index.rb:61:in `find_asset'
/var/lib/gems/1.9.1/gems/sprockets-2.10.0/lib/sprockets/bundled_asset.rb:16:in `initialize'
/var/lib/gems/1.9.1/gems/sprockets-2.10.0/lib/sprockets/base.rb:377:in `new'
/var/lib/gems/1.9.1/gems/sprockets-2.10.0/lib/sprockets/base.rb:377:in `build_asset'
/var/lib/gems/1.9.1/gems/sprockets-2.10.0/lib/sprockets/index.rb:94:in `block in build_asset'
/var/lib/gems/1.9.1/gems/sprockets-2.10.0/lib/sprockets/caching.rb:51:in `cache_asset'
/var/lib/gems/1.9.1/gems/sprockets-2.10.0/lib/sprockets/index.rb:93:in `build_asset'
/var/lib/gems/1.9.1/gems/sprockets-2.10.0/lib/sprockets/base.rb:287:in `find_asset'
/var/lib/gems/1.9.1/gems/sprockets-2.10.0/lib/sprockets/index.rb:61:in `find_asset'
/var/lib/gems/1.9.1/gems/sprockets-2.10.0/lib/sprockets/environment.rb:75:in `find_asset'
/var/lib/gems/1.9.1/gems/sprockets-2.10.0/lib/sprockets/base.rb:295:in `[]'
/home/ggrossetie/workspaces/opensource/asciidoctor.js/Rakefile:20:in `block in <top (required)>'
Tasks: TOP => dist
(See full trace by running task with --trace)
```
