### PR TITLE
Rename default to defaultValue for Opal

### DIFF
--- a/lib/asciidoctor/abstract_node.rb
+++ b/lib/asciidoctor/abstract_node.rb
@@ -54,20 +54,20 @@ class AbstractNode
   # Document node and return the value of the attribute if found. Otherwise,
   # return the default value, which defaults to nil.
   #
-  # name    - the String or Symbol name of the attribute to lookup
-  # default - the Object value to return if the attribute is not found (default: nil)
-  # inherit - a Boolean indicating whether to check for the attribute on the
-  #           AsciiDoctor::Document if not found on this node (default: false)
+  # name          - the String or Symbol name of the attribute to lookup
+  # default_value - the Object value to return if the attribute is not found (default: nil)
+  # inherit       - a Boolean indicating whether to check for the attribute on the
+  #                 AsciiDoctor::Document if not found on this node (default: false)
   #
   # return the value of the attribute or the default value if the attribute
   # is not found in the attributes of this node or the document node
-  def attr(name, default = nil, inherit = true)
+  def attr(name, default_value = nil, inherit = true)
     name = name.to_s if name.is_a?(Symbol)
     inherit = false if self == @document
     if inherit
-      @attributes[name] || @document.attributes[name] || default
+      @attributes[name] || @document.attributes[name] || default_value
     else
-      @attributes[name] || default
+      @attributes[name] || default_value
     end
   end
 


### PR DESCRIPTION
This should be unnecessary but I still have error when running with Opal master

> - The missing `$` from `default$` is now fixed on master. 

http://discuss.asciidoctor.org/Upgrading-Asciidoctor-js-to-the-latest-version-of-Asciidoctor-tp636p646.html

I'm assuming I'm doing something wrong but I don't know what ? :smile: 
