### PR TITLE
resolves #720 fixed broken passthroughs caused by source highlighting

### DIFF
--- a/lib/asciidoctor.rb
+++ b/lib/asciidoctor.rb
@@ -290,6 +290,19 @@ module Asciidoctor
     :attribute_undefined => 'drop-line',
   }
 
+  # Delimiters and matchers for the passthrough placeholder
+  # See http://www.aivosto.com/vbtips/control-characters.html#listabout for characters to use
+  PASS_PLACEHOLDER = {
+    # SPA, start of guarded protected area
+    :start  => "\u0096",
+    # EPA, end of guarded protected area
+    :end    => "\u0097",
+    # match placeholder record
+    :match  => /\u0096(\d+)\u0097/,
+    # fix placeholder record after syntax highlighting
+    :match_syn => /<span[^>]*>\u0096<\/span>[^\d]*(\d+)[^\d]*<span[^>]*>\u0097<\/span>/
+  }
+
   # The following pattern, which appears frequently, captures the contents between square brackets,
   # ignoring escaped closing brackets (closing brackets prefixed with a backslash '\' character)
   #
@@ -519,9 +532,6 @@ module Asciidoctor
     # inline literal passthrough macro
     # `text`
     :pass_lit         => /(^|[^`\w])(?:\[([^\]]+?)\])?(\\?`([^`\s]|[^`\s].*?\S)`)(?![`\w])/m,
-
-    # placeholder for extracted passthrough text
-    :pass_placeholder => /\e(\d+)\e/,
 
     # The document revision info line the appears immediately following the
     # document title author info line, if present

--- a/test/blocks_test.rb
+++ b/test/blocks_test.rb
@@ -1744,6 +1744,27 @@ exit 0 # <5><6>
       assert_match(/exit.* <b>\(5\)<\/b> <b>\(6\)<\/b><\/pre>/, output)
     end
 
+    test 'should preserve passthrough placeholders when highlighting source using coderay' do
+      input = <<-EOS
+:source-highlighter: coderay
+
+[source,java]
+[subs="specialcharacters,macros,callouts"]
+----
+public class Printer {
+  public static void main(String[] args) {
+    System.pass:quotes[_out_].println("*asterisks* make text pass:quotes[*bold*]");
+  }
+}
+----
+      EOS
+      output = render_string input, :safe => Asciidoctor::SafeMode::SAFE
+      assert_match(/\.<em>out<\/em>\./, output, 1)
+      assert_match(/\*asterisks\*/, output, 1)
+      assert_match(/<strong>bold<\/strong>/, output, 1)
+      assert !output.include?(Asciidoctor::PASS_PLACEHOLDER[:start])
+    end
+
     test 'should link to CodeRay stylesheet if source-highlighter is coderay and linkcss is set' do
       input = <<-EOS
 :source-highlighter: coderay

--- a/test/links_test.rb
+++ b/test/links_test.rb
@@ -173,7 +173,7 @@ context 'Links' do
 
   test 'xref with escaped text' do
     # when \x0 was used as boundary character for passthrough, it was getting stripped
-    # now using \e as boundary character, which resolves issue
+    # now using unicode marks as boundary characters, which resolves issue
     input = 'See the <<tigers , `[tigers]`>> section for data about tigers'
     output = render_embedded_string input
     assert_xpath %(//a[@href="#tigers"]/code[text()="[tigers]"]), output, 1

--- a/test/substitutions_test.rb
+++ b/test/substitutions_test.rb
@@ -940,7 +940,7 @@ EOS
     test 'collect inline triple plus passthroughs' do
       para = block_from_string('+++<code>inline code</code>+++')
       result = para.extract_passthroughs(para.source)
-      assert_equal "\e" + '0' + "\e", result
+      assert_equal Asciidoctor::PASS_PLACEHOLDER[:start] + '0' + Asciidoctor::PASS_PLACEHOLDER[:end], result
       assert_equal 1, para.passthroughs.size
       assert_equal '<code>inline code</code>', para.passthroughs.first[:text]
       assert para.passthroughs.first[:subs].empty?
@@ -949,7 +949,7 @@ EOS
     test 'collect multi-line inline triple plus passthroughs' do
       para = block_from_string("+++<code>inline\ncode</code>+++")
       result = para.extract_passthroughs(para.source)
-      assert_equal "\e" + '0' + "\e", result
+      assert_equal Asciidoctor::PASS_PLACEHOLDER[:start] + '0' + Asciidoctor::PASS_PLACEHOLDER[:end], result
       assert_equal 1, para.passthroughs.size
       assert_equal "<code>inline\ncode</code>", para.passthroughs.first[:text]
       assert para.passthroughs.first[:subs].empty?
@@ -958,7 +958,7 @@ EOS
     test 'collect inline double dollar passthroughs' do
       para = block_from_string('$$<code>{code}</code>$$')
       result = para.extract_passthroughs(para.source)
-      assert_equal "\e" + '0' + "\e", result
+      assert_equal Asciidoctor::PASS_PLACEHOLDER[:start] + '0' + Asciidoctor::PASS_PLACEHOLDER[:end], result
       assert_equal 1, para.passthroughs.size
       assert_equal '<code>{code}</code>', para.passthroughs.first[:text]
       assert_equal [:specialcharacters], para.passthroughs.first[:subs]
@@ -967,7 +967,7 @@ EOS
     test 'collect multi-line inline double dollar passthroughs' do
       para = block_from_string("$$<code>\n{code}\n</code>$$")
       result = para.extract_passthroughs(para.source)
-      assert_equal "\e" + '0' + "\e", result
+      assert_equal Asciidoctor::PASS_PLACEHOLDER[:start] + '0' + Asciidoctor::PASS_PLACEHOLDER[:end], result
       assert_equal 1, para.passthroughs.size
       assert_equal "<code>\n{code}\n</code>", para.passthroughs.first[:text]
       assert_equal [:specialcharacters], para.passthroughs.first[:subs]
@@ -976,7 +976,7 @@ EOS
     test 'collect passthroughs from inline pass macro' do
       para = block_from_string(%Q{pass:specialcharacters,quotes[<code>['code'\\]</code>]})
       result = para.extract_passthroughs(para.source)
-      assert_equal "\e" + '0' + "\e", result
+      assert_equal Asciidoctor::PASS_PLACEHOLDER[:start] + '0' + Asciidoctor::PASS_PLACEHOLDER[:end], result
       assert_equal 1, para.passthroughs.size
       assert_equal %q{<code>['code']</code>}, para.passthroughs.first[:text]
       assert_equal [:specialcharacters, :quotes], para.passthroughs.first[:subs]
@@ -985,7 +985,7 @@ EOS
     test 'collect multi-line passthroughs from inline pass macro' do
       para = block_from_string(%Q{pass:specialcharacters,quotes[<code>['more\ncode'\\]</code>]})
       result = para.extract_passthroughs(para.source)
-      assert_equal "\e" + '0' + "\e", result
+      assert_equal Asciidoctor::PASS_PLACEHOLDER[:start] + '0' + Asciidoctor::PASS_PLACEHOLDER[:end], result
       assert_equal 1, para.passthroughs.size
       assert_equal %Q{<code>['more\ncode']</code>}, para.passthroughs.first[:text]
       assert_equal [:specialcharacters, :quotes], para.passthroughs.first[:subs]
@@ -1002,7 +1002,7 @@ EOS
 
     # NOTE placeholder is surrounded by text to prevent reader from stripping trailing boundary char (unique to test scenario)
     test 'restore inline passthroughs without subs' do
-      para = block_from_string("some \e" + '0' + "\e to study")
+      para = block_from_string("some #{Asciidoctor::PASS_PLACEHOLDER[:start]}" + '0' + "#{Asciidoctor::PASS_PLACEHOLDER[:end]} to study")
       para.passthroughs << {:text => '<code>inline code</code>', :subs => []}
       result = para.restore_passthroughs(para.source)
       assert_equal "some <code>inline code</code> to study", result
@@ -1010,7 +1010,7 @@ EOS
 
     # NOTE placeholder is surrounded by text to prevent reader from stripping trailing boundary char (unique to test scenario)
     test 'restore inline passthroughs with subs' do
-      para = block_from_string("some \e" + '0' + "\e to study in the \e" + '1' + "\e programming language")
+      para = block_from_string("some #{Asciidoctor::PASS_PLACEHOLDER[:start]}" + '0' + "#{Asciidoctor::PASS_PLACEHOLDER[:end]} to study in the #{Asciidoctor::PASS_PLACEHOLDER[:start]}" + '1' + "#{Asciidoctor::PASS_PLACEHOLDER[:end]} programming language")
       para.passthroughs << {:text => '<code>{code}</code>', :subs => [:specialcharacters]}
       para.passthroughs << {:text => '{language}', :subs => [:specialcharacters]}
       result = para.restore_passthroughs(para.source)


### PR DESCRIPTION
- move passthrough placeholder characters and regexps to constant
