### PR TITLE
changes related to #679

### DIFF
--- a/lib/asciidoctor.rb
+++ b/lib/asciidoctor.rb
@@ -483,7 +483,7 @@ module Asciidoctor
     # +      (would not match because there's no space before +)
     #  +     (would match and capture '')
     # Foo +  (would and capture 'Foo')
-    :line_break       => /^(.*)#{CC_BLANK}\+$/,
+    :line_break       => /^(.*)#{CC_BLANK}\+(?=\n|$)/,
 
     # inline link and some inline link macro
     # FIXME revisit!
@@ -771,7 +771,7 @@ module Asciidoctor
   # returns the Asciidoctor::Document
   def self.load(input, options = {})
     if (monitor = options.fetch(:monitor, false))
-      start = Time.now
+      start = Time.now.to_f
     end
 
     attrs = (options[:attributes] ||= {})
@@ -828,13 +828,13 @@ module Asciidoctor
     end
 
     if monitor
-      read_time = Time.now - start
-      start = Time.now
+      read_time = Time.now.to_f - start
+      start = Time.now.to_f
     end
 
     doc = Document.new(lines, options) 
     if monitor
-      parse_time = Time.now - start
+      parse_time = Time.now.to_f - start
       monitor[:read] = read_time
       monitor[:parse] = parse_time
       monitor[:load] = read_time + parse_time
@@ -941,17 +941,17 @@ module Asciidoctor
       end
     end
 
-    start = Time.now if monitor
+    start = Time.now.to_f if monitor
     output = doc.render
 
     if monitor
-      render_time = Time.now - start
+      render_time = Time.now.to_f - start
       monitor[:render] = render_time
       monitor[:load_render] = monitor[:load] + render_time
     end
 
     if to_file
-      start = Time.now if monitor
+      start = Time.now.to_f if monitor
       if stream_output
         to_file.write output.rstrip
         # ensure there's a trailing endline
@@ -963,7 +963,7 @@ module Asciidoctor
         doc.attributes['outdir'] = File.dirname(outfile)
       end
       if monitor
-        write_time = Time.now - start
+        write_time = Time.now.to_f - start
         monitor[:write] = write_time
         monitor[:total] = monitor[:load_render] + write_time
       end

--- a/lib/asciidoctor/document.rb
+++ b/lib/asciidoctor/document.rb
@@ -136,7 +136,7 @@ class Document < AbstractBlock
       @safe = nil
       @renderer = nil
       initialize_extensions = Asciidoctor.const_defined?(:Extensions) &&
-          Asciidoctor.const_get(:Extensions) == Asciidoctor::Extensions
+          Asciidoctor.const_get(:Extensions) == ::Asciidoctor::Extensions
       @extensions = nil # initialize furthur down
     end
 

--- a/lib/asciidoctor/lexer.rb
+++ b/lib/asciidoctor/lexer.rb
@@ -1760,9 +1760,8 @@ class Lexer
   def self.process_authors(author_line, names_only = false, multiple = true)
     author_metadata = {}
     keys = ['author', 'authorinitials', 'firstname', 'middlename', 'lastname', 'email']
-    author_entries = multiple ? author_line.split(';').map(&:strip) : [author_line]
+    author_entries = multiple ? ((author_line.split ';').map &:strip) : [author_line]
     author_entries.each_with_index do |author_entry, idx|
-      author_entry.strip!
       next if author_entry.empty?
       key_map = {}
       if idx.zero?
@@ -1909,7 +1908,7 @@ class Lexer
       name = match[1]
       value = match[2].nil? ? '' : match[2]
       if value.end_with? LINE_BREAK
-        value.chop!.rstrip!
+        value = value.chop.rstrip
         while reader.advance
           next_line = reader.peek_line.strip
           break if next_line.empty?

--- a/lib/asciidoctor/substituters.rb
+++ b/lib/asciidoctor/substituters.rb
@@ -242,7 +242,7 @@ module Substituters
     return text if @passthroughs.nil? || @passthroughs.empty? || !text.include?(PASS_PLACEHOLDER[:start])
 
     text.gsub(PASS_PLACEHOLDER[:match]) {
-      pass = @passthroughs[$1.to_i]
+      pass = @passthroughs[$~[1].to_i]
       text = apply_subs(pass[:text], pass.fetch(:subs, []))
       pass[:literal] ? Inline.new(self, :quoted, text, :type => :monospaced, :attributes => pass.fetch(:attributes, {})).render : text
     }
@@ -289,8 +289,8 @@ module Substituters
     REPLACEMENTS.each {|pattern, replacement, restore|
       result.gsub!(pattern) {
         matched = $&
-        head = $1
-        tail = $2
+        head = $~[1]
+        tail = $~[2]
         if matched.include?('\\')
           matched.tr('\\', '')
         else
@@ -862,7 +862,7 @@ module Substituters
       last = lines.pop
       lines.map {|line| Inline.new(self, :break, line.chomp.chomp(LINE_BREAK), :type => :line).render }.push(last) * EOL
     else
-      text.gsub(REGEXP[:line_break]) { Inline.new(self, :break, $1, :type => :line).render }
+      text.gsub(REGEXP[:line_break]) { Inline.new(self, :break, $~[1], :type => :line).render }
     end
   end
 

--- a/lib/asciidoctor/table.rb
+++ b/lib/asciidoctor/table.rb
@@ -347,7 +347,7 @@ class Table::ParserContext
   # returns true if the buffer starts with a double quote (and not an escaped double quote),
   # false otherwise
   def buffer_quoted?
-    @buffer.lstrip!
+    @buffer = @buffer.lstrip
     @buffer.start_with?('"') && !@buffer.start_with?('""')
   end
 

--- a/test/blocks_test.rb
+++ b/test/blocks_test.rb
@@ -2120,7 +2120,7 @@ content
       doc = document_from_string input
       block = doc.blocks.first
       assert_nil block.id
-      assert_nil (block.attr 'reftext')
+      assert_nil(block.attr 'reftext')
       assert !doc.references[:ids].has_key?('illegal$id')
     end
 

--- a/test/sections_test.rb
+++ b/test/sections_test.rb
@@ -75,7 +75,7 @@ context 'Sections' do
       sec = block_from_string(%(== Section One [["one","Section Uno"]] ==))
       assert_not_equal 'one', sec.id
       assert_equal 'Section One [["one","Section Uno"]]', sec.title
-      assert_nil (sec.attr 'reftext')
+      assert_nil(sec.attr 'reftext')
     end
 
     test 'reftext in embedded anchor may contain comma' do


### PR DESCRIPTION
- remove use of mutable string operations: chop!, lstrip! and rstrip!
- calculate time elapsed using floats
- use $~ instead of numbered variables in regexp substitutions
- match endline in line break regexp
