### PR TITLE
refactor how libraries are required

### DIFF
--- a/lib/asciidoctor/abstract_node.rb
+++ b/lib/asciidoctor/abstract_node.rb
@@ -326,8 +326,6 @@ class AbstractNode
   #
   # Returns A String data URI containing the content of the target image
   def generate_data_uri(target_image, asset_dir_key = nil)
-    Helpers.require_library 'base64'
-
     ext = File.extname(target_image)[1..-1]
     mimetype = 'image/' + ext
     mimetype = "#{mimetype}+xml" if ext == 'svg'
@@ -342,6 +340,7 @@ class AbstractNode
     if !File.readable? image_path
       warn "asciidoctor: WARNING: image to embed not found or not readable: #{image_path}"
       return "data:#{mimetype}:base64,"
+      # uncomment to return 1 pixel white dot instead
       #return 'data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw=='
     end
 

--- a/lib/asciidoctor/backends/_stylesheets.rb
+++ b/lib/asciidoctor/backends/_stylesheets.rb
@@ -4,7 +4,8 @@ module HTML5
   #
   # returns the default CodeRay stylesheet as a String
   def self.default_coderay_stylesheet
-    #::Asciidoctor::Helpers.require_library 'coderay', true
+    # use the following two lines to load a built-in theme instead
+    #::Asciidoctor::Helpers.require_library 'coderay'
     #::CodeRay::Encoders[:html]::CSS.new(:default).stylesheet
     <<'DEFAULT_CODERAY_STYLESHEET'
 /* Foundation stylesheet for CodeRay (to match GitHub theme) | MIT License | http://foundation.zurb.com */

--- a/lib/asciidoctor/helpers.rb
+++ b/lib/asciidoctor/helpers.rb
@@ -1,30 +1,28 @@
 module Asciidoctor
 module Helpers
-  # Internal: Prior to invoking Kernel#require, issues a warning urging a
-  # manual require if running in a threaded environment.
+  # Internal: Require the specified library using Kernel#require.
+  #
+  # Attempts to load the library specified in the first argument using the
+  # Kernel#require. Rescues the LoadError if the library is not available and
+  # passes a message to Kernel#fail to communicate to the user that processing
+  # is being aborted. If a gem_name is specified, the failure message
+  # communicates that a required gem is not installed.
   #
   # name  - the String name of the library to require.
+  # gem   - a Boolean that indicates whether this library is provided by a RubyGem,
+  #         or the String name of the RubyGem if it differs from the library name
+  #         (default: true)
   #
-  # returns false if the library is detected on the load path or the return
-  # value of delegating to Kernel#require
-  def self.require_library(name, gem_name = nil)
-    if Thread.list.size > 1
-      main_script = "#{name}.rb"
-      main_script_path_segment = "/#{name}.rb"
-      if !$LOADED_FEATURES.detect {|p| p == main_script || p.end_with?(main_script_path_segment) }.nil?
-        return false
-      else
-        warn "WARN: asciidoctor is autoloading '#{name}' in threaded environment. " +
-           "The use of an explicit require '#{name}' statement is recommended."
-      end
-    end
+  # returns the return value of Kernel#require if the library is available,
+  # otherwise Kernel#fail is called with an appropriate message.
+  def self.require_library(name, gem = true)
     begin
       require name
     rescue LoadError => e
-      if gem_name
-        fail "asciidoctor: FAILED: required gem '#{gem_name === true ? name : gem_name}' is not installed. Processing aborted."
+      if gem
+        fail "asciidoctor: FAILED: required gem '#{gem === true ? name : gem}' is not installed. Processing aborted."
       else
-        fail "asciidoctor: FAILED: #{e.chomp '.'}. Processing aborted."
+        fail "asciidoctor: FAILED: #{e.message.chomp '.'}. Processing aborted."
       end
     end
   end

--- a/lib/asciidoctor/reader.rb
+++ b/lib/asciidoctor/reader.rb
@@ -831,7 +831,8 @@ class PreprocessorReader < Reader
           # processing will be automatically aborted if these libraries can't be opened
           Helpers.require_library 'open-uri/cached', 'open-uri-cached'
         else
-          Helpers.require_library 'open-uri'
+          # autoload open-uri
+          ::OpenURI
         end
       else
         target_type = :file

--- a/lib/asciidoctor/renderer.rb
+++ b/lib/asciidoctor/renderer.rb
@@ -25,8 +25,8 @@ class Renderer
     case backend
     when 'html5', 'docbook45', 'docbook5'
       eruby = load_eruby options[:eruby]
-      #Helpers.require_library 'asciidoctor/backends/' + backend
-      require 'asciidoctor/backends/' + backend
+      require 'asciidoctor/backends/base_template'
+      require "asciidoctor/backends/#{backend}"
       # Load up all the template classes that we know how to render for this backend
       BaseTemplate.template_classes.each do |tc|
         if tc.to_s.downcase.include?('::' + backend + '::') # optimization
@@ -42,7 +42,7 @@ class Renderer
 
     # If user passed in a template dir, let them override our base templates
     if (template_dirs = options.delete(:template_dirs))
-      Helpers.require_library 'tilt', true
+      Helpers.require_library 'tilt'
 
       if (template_cache = options[:template_cache]) === true
         # FIXME probably want to use our own cache object for more control
@@ -105,7 +105,7 @@ class Renderer
           ext_name = name_parts.last
           if ext_name == 'slim' && !slim_loaded
             # slim doesn't get loaded by Tilt
-            Helpers.require_library 'slim', true
+            Helpers.require_library 'slim'
           end
           next unless Tilt.registered? ext_name
           opts = view_opts[ext_name.to_sym]
@@ -159,10 +159,10 @@ class Renderer
     end
 
     if name == 'erb'
-      Helpers.require_library 'erb'
+      # autoload erb and return constant
       ::ERB
     elsif name == 'erubis'
-      Helpers.require_library 'erubis', true
+      Helpers.require_library 'erubis'
       ::Erubis::FastEruby
     end
   end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,25 +1,16 @@
 if RUBY_VERSION < '1.9'
   require 'rubygems'
 end
-require 'fileutils'
-require 'pathname'
+
+require "#{File.dirname __FILE__}/../lib/asciidoctor"
+# or
+#require 'asciidoctor'
+
 require 'test/unit'
-
-require "#{File.expand_path(File.dirname(__FILE__))}/../lib/asciidoctor.rb"
-
 require 'nokogiri'
 
-if RUBY_ENGINE == 'rbx'
-  # TODO we'll need to think about a way in the future to load these
-  # dependencies in a thread-safe manner within Asciidoctor itself
-  # something like a "preload" libraries option
-  require 'erb'
-  require 'coderay'
-  require 'open-uri'
-  require 'haml'
-  require 'slim'
-  require 'base64'
-end
+autoload :FileUtils, 'fileutils'
+autoload :Pathname,  'pathname'
 
 ENV['SUPPRESS_DEBUG'] ||= 'true'
 


### PR DESCRIPTION
- use autoload for loading stdlib classes
- remove thread safety warning in Helpers#require_library
- add LIB_PATH constant
- remove require statements for rbx in test suite
- use absolute constant path to non-Asciidoctor classes
