### PR TITLE
resolves #824 BOM in file confuses parser

### DIFF
--- a/test/reader_test.rb
+++ b/test/reader_test.rb
@@ -346,6 +346,33 @@ This is a paragraph outside the block.
         assert_equal SAMPLE_DATA, reader.lines
       end
 
+      test 'should strip BOM from beginning of data' do
+        doc = Asciidoctor::Document.new
+        input = <<-EOS
+= Title =
+
+Some source text.
+      EOS
+        data = input.split "\n"
+        expected = data.dup
+        data[0] = "\u{feff}#{data[0]}"
+        reader = Asciidoctor::PreprocessorReader.new doc, data
+        assert_equal expected, reader.lines
+      end
+
+      test 'should not strip U+FEFF from middle of data' do
+        doc = Asciidoctor::Document.new
+        input = <<-EOS
+= Title =
+
+Some source text.
+      EOS
+        data = input.split "\n"
+        data[1] = "\u{feff}#{data[1]}"
+        reader = Asciidoctor::PreprocessorReader.new doc, data
+        assert_equal data, reader.lines
+      end
+
       test 'should clean CRLF from end of lines' do
         input = <<-EOS
 source\r


### PR DESCRIPTION
This commit modifies Reader to strip a leading byte order mark. Instances of U+FEFF that are not the first character are not modified, since they are not byte order marks.

I added tests for both cases, even though the second test passed initially, since it preserves the existing behavior. I've tested this in an actual document as well and it appears to work correctly.

This resolves issue #824.
