### PR TITLE
Test for email address inside a link

### DIFF
--- a/test/links_test.rb
+++ b/test/links_test.rb
@@ -63,6 +63,10 @@ context 'Links' do
     assert_xpath '//a', render_string('\http://asciidoc.org is the project page for AsciiDoc.'), 0
   end
 
+  test 'url with at (@) sign should not create mailto link' do
+    assert_xpath '//a[@href="http://xircles.codehause.org/lists/dev@geb.codehaus.org"]', render_string('http://xircles.codehaus.org/lists/dev@geb.codehaus.org[here]')
+  end
+
   test 'escaped inline qualified url using macro syntax should not create link' do
     assert_xpath '//a', render_string('\http://asciidoc.org[AsciiDoc] is the key to good docs.'), 0
   end


### PR DESCRIPTION
Links containing an embedded '@' should not create an email link.

I don't have working code for this, but a test is better than nothing, right?
