### PR TITLE
Make Reader#push_include work without path info.

### DIFF
--- a/lib/asciidoctor/reader.rb
+++ b/lib/asciidoctor/reader.rb
@@ -961,7 +961,7 @@ class PreprocessorReader < Reader
     end
   end
 
-  def push_include data, file = nil, path = nil, lineno = 1, attributes = {}
+  def push_include data, file = '', path = '', lineno = 1, attributes = {}
     @include_stack << [@lines, @file, @dir, @path, @lineno, @maxdepth, @process_lines]
     @includes << Helpers.rootname(path)
     @file = file

--- a/test/reader_test.rb
+++ b/test/reader_test.rb
@@ -469,6 +469,16 @@ preamble
         assert_equal 1, reader.include_stack.size
         assert_equal 'one', reader.read_line.rstrip
       end
+
+      test 'PreprocessorReader#push_include method should gracefully handle file and path' do
+        doc = empty_document
+        lines = %(a b c)
+        reader = Asciidoctor::PreprocessorReader.new doc, lines
+        append_lines = %w(one two three)
+        assert_nothing_raised do
+          reader.push_include append_lines
+        end
+      end
     end
 
     context 'Include Directive' do


### PR DESCRIPTION
As requested in issue #743, this makes Reader#push_include work without path information.

I considered leaving the items in the include stack as nil as a sort of documentation
