### PR TITLE
resolves #883 map null character to constant for Opal compatibility

### DIFF
--- a/lib/asciidoctor.rb
+++ b/lib/asciidoctor.rb
@@ -212,6 +212,9 @@ module Asciidoctor
   # The endline character to use when rendering output
   EOL = "\n"
 
+  # The null character to use for splitting attribute values
+  NULL = ::RUBY_ENGINE_OPAL ? 0.chr : "\0"
+
   # String for matching tab character
   TAB = "\t"
 
@@ -337,19 +340,6 @@ module Asciidoctor
   # attributes which be changed within the content of the document (but not
   # header) because it has semantic meaning; ex. numbered
   FLEXIBLE_ATTRIBUTES = %w(numbered)
-
-  # Delimiters and matchers for the passthrough placeholder
-  # See http://www.aivosto.com/vbtips/control-characters.html#listabout for characters to use
-  PASS_PLACEHOLDER = {
-    # SPA, start of guarded protected area
-    :start  => ::RUBY_ENGINE_OPAL ? 150.chr : "\u0096",
-    # EPA, end of guarded protected area
-    :end    => ::RUBY_ENGINE_OPAL ? 151.chr : "\u0097",
-    # match placeholder record
-    :match  => /\u0096(\d+)\u0097/,
-    # fix placeholder record after syntax highlighting
-    :match_hi => /<span[^>]*>\u0096<\/span>[^\d]*(\d+)[^\d]*<span[^>]*>\u0097<\/span>/
-  }
 
   # A collection of regular expressions used by the parser.
   #
@@ -1196,9 +1186,10 @@ module Asciidoctor
     elsif attrs.is_a? ::String
       # convert non-escaped spaces into null character, so we split on the
       # correct spaces chars, and restore escaped spaces
-      attrs = attrs.gsub(SpaceDelimiterRx, "\\1\0").gsub(EscapedSpaceRx, '\1')
+      capture_1 = ::RUBY_ENGINE_OPAL ? '$' : '\1'
+      attrs = attrs.gsub(SpaceDelimiterRx, %(#{capture_1}#{NULL})).gsub(EscapedSpaceRx, capture_1)
 
-      attrs = options[:attributes] = attrs.split("\0").inject({}) do |accum, entry|
+      attrs = options[:attributes] = attrs.split(NULL).inject({}) do |accum, entry|
         k, v = entry.split '=', 2
         accum[k] = v || ''
         accum

--- a/lib/asciidoctor/core_ext.rb
+++ b/lib/asciidoctor/core_ext.rb
@@ -1,5 +1,7 @@
 require 'asciidoctor/core_ext/object/nil_or_empty'
-unless RUBY_MIN_VERSION_1_9
+# Opal barfs here if we use ::RUBY_VERSION_MIN_1_9
+unless ::RUBY_VERSION >= '1.9'
   require 'asciidoctor/core_ext/string/chr'
-  require 'asciidoctor/core_ext/symbol/length'
+  # we append .to_s to keep Opal from processing the next require
+  require 'asciidoctor/core_ext/symbol/length'.to_s
 end

--- a/lib/asciidoctor/substitutors.rb
+++ b/lib/asciidoctor/substitutors.rb
@@ -45,11 +45,21 @@ module Substitutors
     :inline => COMPOSITE_SUBS.keys + SUBS[:normal]
   }
 
-  # dereference these constants closer and out of map as performance optimization
-  PASS_START = PASS_PLACEHOLDER[:start]
-  PASS_END = PASS_PLACEHOLDER[:end]
-  PASS_MATCH = PASS_PLACEHOLDER[:match]
-  PASS_MATCH_HI = PASS_PLACEHOLDER[:match_hi]
+  # Delimiters and matchers for the passthrough placeholder
+  # See http://www.aivosto.com/vbtips/control-characters.html#listabout for characters to use
+  # Opal hasn't yet defined the constant ::RUBY_ENGINE_OPAL at this point
+
+  # SPA, start of guarded protected area (\u0096)
+  PASS_START = ::RUBY_ENGINE == 'opal' ? 150.chr : "\u0096"
+
+  # EPA, end of guarded protected area (\u0097)
+  PASS_END = ::RUBY_ENGINE == 'opal' ? 151.chr : "\u0097"
+
+  # match placeholder record
+  PASS_MATCH = /\u0096(\d+)\u0097/
+
+  # fix placeholder record after syntax highlighting
+  PASS_MATCH_HI = /<span[^>]*>\u0096<\/span>[^\d]*(\d+)[^\d]*<span[^>]*>\u0097<\/span>/
 
   # Internal: A String Array of passthough (unprocessed) text captured from this block
   attr_reader :passthroughs

--- a/test/blocks_test.rb
+++ b/test/blocks_test.rb
@@ -2049,7 +2049,7 @@ public class Printer {
       assert_match(/\.<em>out<\/em>\./, output, 1)
       assert_match(/\*asterisks\*/, output, 1)
       assert_match(/<strong>bold<\/strong>/, output, 1)
-      assert !output.include?(Asciidoctor::PASS_PLACEHOLDER[:start])
+      assert !output.include?(Asciidoctor::Substitutors::PASS_START)
     end
 
     test 'should link to CodeRay stylesheet if source-highlighter is coderay and linkcss is set' do

--- a/test/substitutions_test.rb
+++ b/test/substitutions_test.rb
@@ -983,7 +983,7 @@ EOS
     test 'collect inline triple plus passthroughs' do
       para = block_from_string('+++<code>inline code</code>+++')
       result = para.extract_passthroughs(para.source)
-      assert_equal Asciidoctor::PASS_PLACEHOLDER[:start] + '0' + Asciidoctor::PASS_PLACEHOLDER[:end], result
+      assert_equal Asciidoctor::Substitutors::PASS_START + '0' + Asciidoctor::Substitutors::PASS_END, result
       assert_equal 1, para.passthroughs.size
       assert_equal '<code>inline code</code>', para.passthroughs.first[:text]
       assert para.passthroughs.first[:subs].empty?
@@ -992,7 +992,7 @@ EOS
     test 'collect multi-line inline triple plus passthroughs' do
       para = block_from_string("+++<code>inline\ncode</code>+++")
       result = para.extract_passthroughs(para.source)
-      assert_equal Asciidoctor::PASS_PLACEHOLDER[:start] + '0' + Asciidoctor::PASS_PLACEHOLDER[:end], result
+      assert_equal Asciidoctor::Substitutors::PASS_START + '0' + Asciidoctor::Substitutors::PASS_END, result
       assert_equal 1, para.passthroughs.size
       assert_equal "<code>inline\ncode</code>", para.passthroughs.first[:text]
       assert para.passthroughs.first[:subs].empty?
@@ -1001,7 +1001,7 @@ EOS
     test 'collect inline double dollar passthroughs' do
       para = block_from_string('$$<code>{code}</code>$$')
       result = para.extract_passthroughs(para.source)
-      assert_equal Asciidoctor::PASS_PLACEHOLDER[:start] + '0' + Asciidoctor::PASS_PLACEHOLDER[:end], result
+      assert_equal Asciidoctor::Substitutors::PASS_START + '0' + Asciidoctor::Substitutors::PASS_END, result
       assert_equal 1, para.passthroughs.size
       assert_equal '<code>{code}</code>', para.passthroughs.first[:text]
       assert_equal [:specialcharacters], para.passthroughs.first[:subs]
@@ -1010,7 +1010,7 @@ EOS
     test 'collect multi-line inline double dollar passthroughs' do
       para = block_from_string("$$<code>\n{code}\n</code>$$")
       result = para.extract_passthroughs(para.source)
-      assert_equal Asciidoctor::PASS_PLACEHOLDER[:start] + '0' + Asciidoctor::PASS_PLACEHOLDER[:end], result
+      assert_equal Asciidoctor::Substitutors::PASS_START + '0' + Asciidoctor::Substitutors::PASS_END, result
       assert_equal 1, para.passthroughs.size
       assert_equal "<code>\n{code}\n</code>", para.passthroughs.first[:text]
       assert_equal [:specialcharacters], para.passthroughs.first[:subs]
@@ -1019,7 +1019,7 @@ EOS
     test 'collect passthroughs from inline pass macro' do
       para = block_from_string(%Q{pass:specialcharacters,quotes[<code>['code'\\]</code>]})
       result = para.extract_passthroughs(para.source)
-      assert_equal Asciidoctor::PASS_PLACEHOLDER[:start] + '0' + Asciidoctor::PASS_PLACEHOLDER[:end], result
+      assert_equal Asciidoctor::Substitutors::PASS_START + '0' + Asciidoctor::Substitutors::PASS_END, result
       assert_equal 1, para.passthroughs.size
       assert_equal %q{<code>['code']</code>}, para.passthroughs.first[:text]
       assert_equal [:specialcharacters, :quotes], para.passthroughs.first[:subs]
@@ -1028,7 +1028,7 @@ EOS
     test 'collect multi-line passthroughs from inline pass macro' do
       para = block_from_string(%Q{pass:specialcharacters,quotes[<code>['more\ncode'\\]</code>]})
       result = para.extract_passthroughs(para.source)
-      assert_equal Asciidoctor::PASS_PLACEHOLDER[:start] + '0' + Asciidoctor::PASS_PLACEHOLDER[:end], result
+      assert_equal Asciidoctor::Substitutors::PASS_START + '0' + Asciidoctor::Substitutors::PASS_END, result
       assert_equal 1, para.passthroughs.size
       assert_equal %Q{<code>['more\ncode']</code>}, para.passthroughs.first[:text]
       assert_equal [:specialcharacters, :quotes], para.passthroughs.first[:subs]
@@ -1045,7 +1045,7 @@ EOS
 
     # NOTE placeholder is surrounded by text to prevent reader from stripping trailing boundary char (unique to test scenario)
     test 'restore inline passthroughs without subs' do
-      para = block_from_string("some #{Asciidoctor::PASS_PLACEHOLDER[:start]}" + '0' + "#{Asciidoctor::PASS_PLACEHOLDER[:end]} to study")
+      para = block_from_string("some #{Asciidoctor::Substitutors::PASS_START}" + '0' + "#{Asciidoctor::Substitutors::PASS_END} to study")
       para.passthroughs << {:text => '<code>inline code</code>', :subs => []}
       result = para.restore_passthroughs(para.source)
       assert_equal "some <code>inline code</code> to study", result
@@ -1053,7 +1053,7 @@ EOS
 
     # NOTE placeholder is surrounded by text to prevent reader from stripping trailing boundary char (unique to test scenario)
     test 'restore inline passthroughs with subs' do
-      para = block_from_string("some #{Asciidoctor::PASS_PLACEHOLDER[:start]}" + '0' + "#{Asciidoctor::PASS_PLACEHOLDER[:end]} to study in the #{Asciidoctor::PASS_PLACEHOLDER[:start]}" + '1' + "#{Asciidoctor::PASS_PLACEHOLDER[:end]} programming language")
+      para = block_from_string("some #{Asciidoctor::Substitutors::PASS_START}" + '0' + "#{Asciidoctor::Substitutors::PASS_END} to study in the #{Asciidoctor::Substitutors::PASS_START}" + '1' + "#{Asciidoctor::Substitutors::PASS_END} programming language")
       para.passthroughs << {:text => '<code>{code}</code>', :subs => [:specialcharacters]}
       para.passthroughs << {:text => '{language}', :subs => [:specialcharacters]}
       result = para.restore_passthroughs(para.source)


### PR DESCRIPTION
- also move the declaration of the pass placeholder constants to Substitutors
