### PR TITLE
resolves #907 write to file by default if input is file

### DIFF
--- a/lib/asciidoctor/cli/invoker.rb
+++ b/lib/asciidoctor/cli/invoker.rb
@@ -79,15 +79,14 @@ module Asciidoctor
           tofile = outfile
           opts[:mkdirs] = true
         else
+          # automatically calculate outfile based on infile unless to_dir is set
           tofile = nil
-          # automatically calculate outfile based on infile
-          opts[:in_place] = true unless opts.has_key? :to_dir
           opts[:mkdirs] = true
         end
 
         inputs.each do |input|
           # NOTE processor will dup options and attributes internally
-          input_opts = tofile ? opts.merge(:to_file => tofile) : opts
+          input_opts = tofile.nil? ? opts : opts.merge(:to_file => tofile)
           if show_timings
             timings = Timings.new
             @documents << ::Asciidoctor.convert(input, input_opts.merge(:timings => timings))

--- a/lib/asciidoctor/cli/options.rb
+++ b/lib/asciidoctor/cli/options.rb
@@ -162,7 +162,7 @@ Example: asciidoctor -b html5 source.asciidoc
                   file = file.tr '\\', '/'
                 end
                 if (matches = ::Dir.glob file).empty?
-                  $stderr.puts "asciidoctor: FAILED: input file #{file} missing or cannot be read"
+                  $stderr.puts %(asciidoctor: FAILED: input file #{file} missing or cannot be read)
                   return 1
                 end
               end
@@ -174,12 +174,14 @@ Example: asciidoctor -b html5 source.asciidoc
 
         infiles.each do |file|
           unless file == '-' || (::File.readable? file)
-            $stderr.puts "asciidoctor: FAILED: input file #{file} missing or cannot be read"
+            $stderr.puts %(asciidoctor: FAILED: input file #{file} missing or cannot be read)
             return 1
           end
         end
 
         self[:input_files] = infiles
+
+        self.delete(:attributes) if self[:attributes].empty?
 
         if self[:template_dirs]
           begin

--- a/lib/asciidoctor/document.rb
+++ b/lib/asciidoctor/document.rb
@@ -845,6 +845,7 @@ class Document < AbstractBlock
     end
   end
 
+  # TODO document me
   def create_converter
     converter_opts = {}
     converter_opts[:htmlsyntax] = @attributes['htmlsyntax']


### PR DESCRIPTION
- write to file by default if input is file
- use to_file option to control whether file is written instead of in_place
- prevent input file from being overwritten
