### PR TITLE
tests: switch to minitest

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -24,9 +24,6 @@ begin
     test.pattern = 'test/**/*_test.rb'
     test.verbose = true
     test.warning = true
-    if RUBY_VERSION >= '2'
-      test.options = '--tty=no'
-    end
   end
   task :default => :test
 rescue LoadError

--- a/asciidoctor.gemspec
+++ b/asciidoctor.gemspec
@@ -46,8 +46,8 @@ A fast, open source text processor and publishing toolchain, written in Ruby, fo
   s.add_development_dependency 'tilt', '~> 2.0.0'
   s.add_development_dependency 'yard', '~> 0.8.7'
   s.add_development_dependency 'yard-tomdoc', '~> 0.7.0'
+  s.add_development_dependency 'minitest', '> 0'
   if RUBY_VERSION == '2.1.0' && RUBY_ENGINE == 'rbx'
-    s.add_development_dependency 'rubysl-test-unit', '~> 2.0.1'
     s.add_development_dependency 'racc', '~> 1.4.10'
   end
 end

--- a/test/attributes_test.rb
+++ b/test/attributes_test.rb
@@ -314,7 +314,7 @@ all there is.
       EOS
       html = render_embedded_string input
       result = Nokogiri::HTML(html)
-      assert_no_match(/blah blah/m, result.css("p").first.content.strip)
+      refute_match(/blah blah/m, result.css("p").first.content.strip)
     end
 
     test "attribute value gets interpretted when rendering" do
@@ -334,7 +334,7 @@ Line 2: Oh no, a {bogus-attribute}! This line should not appear in the output.
 
       output = render_embedded_string input
       assert_match(/Line 1/, output)
-      assert_no_match(/Line 2/, output)
+      refute_match(/Line 2/, output)
     end
 
     test 'should not drop line with reference to missing attribute by default' do
@@ -359,7 +359,7 @@ Line 2: {set:a!}This line should not appear in the output.
 
       output = render_embedded_string input
       assert_match(/Line 1/, output)
-      assert_no_match(/Line 2/, output)
+      refute_match(/Line 2/, output)
     end
 
     test 'should not drop line with attribute unassignment if attribute-undefined is drop' do
@@ -374,7 +374,7 @@ Line 2: {set:a!}This line should not appear in the output.
       output = render_embedded_string input
       assert_match(/Line 1/, output)
       assert_match(/Line 2/, output)
-      assert_no_match(/\{set:a!\}/, output)
+      refute_match(/\{set:a!\}/, output)
     end
 
     test "substitutes inside unordered list items" do
@@ -962,7 +962,7 @@ content
 
       doc = document_from_string input, :backend => 'docbook45'
       section = doc.blocks[0]
-      assert_not_nil section
+      refute_nil section
       assert_equal :section, section.context
       assert !section.special
       output = doc.convert

--- a/test/blocks_test.rb
+++ b/test/blocks_test.rb
@@ -37,7 +37,7 @@ first paragraph
 second paragraph
       EOS
       output = render_embedded_string input
-      assert_no_match(/line comment/, output)
+      refute_match(/line comment/, output)
       assert_xpath '//p', output, 2
     end
 
@@ -48,7 +48,7 @@ first line
 second line
       EOS
       output = render_embedded_string input
-      assert_no_match(/line comment/, output)
+      refute_match(/line comment/, output)
       assert_xpath '//p', output, 1
       assert_xpath "//p[1][text()='first line\nsecond line']", output, 1
     end
@@ -64,7 +64,7 @@ block comment
 second paragraph
       EOS
       output = render_embedded_string input
-      assert_no_match(/block comment/, output)
+      refute_match(/block comment/, output)
       assert_xpath '//p', output, 2
     end
 
@@ -77,7 +77,7 @@ block comment
 second paragraph
       EOS
       output = render_embedded_string input
-      assert_no_match(/block comment/, output)
+      refute_match(/block comment/, output)
       assert_xpath '//p', output, 2
     end
 
@@ -92,7 +92,7 @@ block comment
 
       EOS
       output = render_embedded_string input
-      assert_no_match(/block comment/, output)
+      refute_match(/block comment/, output)
     end
 
     test "trailing endlines after block comment at end of document does not create paragraph" do
@@ -596,7 +596,7 @@ Just write.
       doc = document_from_string input
       assert_equal 'Look!', doc.blocks.first.caption
       output = doc.render
-      assert_no_match(/Look/, output)
+      refute_match(/Look/, output)
     end
 
     test 'automatic caption can be turned off and on and modified' do
@@ -790,7 +790,7 @@ source line 2\r
       EOS
 
       output = render_embedded_string input
-      assert_no_match(/\[source\]/, output)
+      refute_match(/\[source\]/, output)
       assert_xpath '/*[@class="listingblock"]//pre', output, 1
       assert_xpath '/*[@class="listingblock"]//pre/code', output, 1
       assert_xpath %(/*[@class="listingblock"]//pre/code[text()="source line 1\nsource line 2"]), output, 1
@@ -2086,7 +2086,7 @@ html = CodeRay.scan("puts 'Hello, world!'", :ruby).div(:line_numbers => :table)
       EOS
       output = render_string input, :safe => Asciidoctor::SafeMode::SAFE, :linkcss_default => true
       assert_xpath '//pre[@class="CodeRay"]/code[@class="ruby language-ruby"]//span[@style = "color:#036;font-weight:bold"][text() = "CodeRay"]', output, 1
-      assert_no_match(/\.CodeRay \{/, output)
+      refute_match(/\.CodeRay \{/, output)
     end
 
     test 'should include remote highlight.js assets if source-highlighter attribute is highlightjs' do
@@ -2226,7 +2226,7 @@ Abstract for book without title is invalid.
         warnings = stderr.string
       end
       assert_css '.abstract', output, 0
-      assert_not_nil warnings
+      refute_nil warnings
       assert_match(/WARNING:.*abstract block/, warnings)
     end
 
@@ -2292,7 +2292,7 @@ Abstract for book is invalid.
         warnings = stderr.string
       end
       assert_css 'abstract', output, 0
-      assert_not_nil warnings
+      refute_nil warnings
       assert_match(/WARNING:.*abstract block/, warnings)
     end
 
@@ -2537,7 +2537,7 @@ $ apt-get install asciidoctor
 
       doc = document_from_string input
       reftext = doc.references[:ids]['debian']
-      assert_not_nil reftext
+      refute_nil reftext
       assert_equal 'Debian Install', reftext
     end
 
@@ -2552,7 +2552,7 @@ $ apt-get install asciidoctor
 
       doc = document_from_string input
       reftext = doc.references[:ids]['debian']
-      assert_not_nil reftext
+      refute_nil reftext
       assert_equal '[Debian] Install', reftext
     end
 
@@ -2567,7 +2567,7 @@ $ apt-get install asciidoctor
 
       doc = document_from_string input
       reftext = doc.references[:ids]['debian']
-      assert_not_nil reftext
+      refute_nil reftext
       assert_equal 'Debian, Ubuntu', reftext
     end
 
@@ -2583,7 +2583,7 @@ $ apt-get install asciidoctor
 
       doc = document_from_string input
       reftext = doc.references[:ids]['debian']
-      assert_not_nil reftext
+      refute_nil reftext
       assert_equal 'Debian Install', reftext
     end
   end

--- a/test/document_test.rb
+++ b/test/document_test.rb
@@ -489,7 +489,7 @@ text
     test 'should raise exception if an attempt is made to overwrite input file' do
       sample_input_path = fixture_path('sample.asciidoc')
 
-      assert_raise IOError do
+      assert_raises IOError do
         Asciidoctor.convert_file sample_input_path, :attributes => { 'outfilesuffix' => '.asciidoc' }
       end
     end
@@ -1277,14 +1277,14 @@ two
       rescue => e
         flunk "xhtml5 backend did not generate well-formed XML: #{e.message}\n#{result}"
       end
-      #assert_no_match(/<meta [^>]+[^\/]>/, result)
-      #assert_no_match(/<link [^>]+[^\/]>/, result)
-      #assert_no_match(/<img [^>]+[^\/]>/, result)
-      #assert_no_match(/<input [^>]+[^\/]>/, result)
+      #refute_match(/<meta [^>]+[^\/]>/, result)
+      #refute_match(/<link [^>]+[^\/]>/, result)
+      #refute_match(/<img [^>]+[^\/]>/, result)
+      #refute_match(/<input [^>]+[^\/]>/, result)
       #assert_match(/<input [^>]+checked="checked"/, result)
       #assert_match(/<input [^>]+disabled="disabled"/, result)
-      #assert_no_match(/<col [^>]+[^\/]>/, result)
-      #assert_no_match(/<[bh]r>/, result)
+      #refute_match(/<col [^>]+[^\/]>/, result)
+      #refute_match(/<[bh]r>/, result)
       #assert_match(/video [^>]+loop="loop"/, result)
       #assert_match(/video [^>]+autoplay="autoplay"/, result)
       #assert_match(/video [^>]+controls="controls"/, result)
@@ -1333,7 +1333,7 @@ section body
 
     test 'docbook45 backend doctype article no xmlns' do
       result = render_string('text', :keep_namespaces => true, :attributes => {'backend' => 'docbook45', 'doctype' => 'article', 'noxmlns' => ''})
-      assert_no_match(RE_XMLNS_ATTRIBUTE, result)
+      refute_match(RE_XMLNS_ATTRIBUTE, result)
     end
 
     test 'docbook45 backend doctype book' do
@@ -1364,7 +1364,7 @@ chapter body
 
     test 'docbook45 backend doctype book no xmlns' do
       result = render_string('text', :keep_namespaces => true, :attributes => {'backend' => 'docbook45', 'doctype' => 'book', 'noxmlns' => ''})
-      assert_no_match(RE_XMLNS_ATTRIBUTE, result)
+      refute_match(RE_XMLNS_ATTRIBUTE, result)
     end
 
     test 'docbook45 backend parses out subtitle' do
@@ -1403,8 +1403,8 @@ section body
       section = xmlnodes_at_xpath('/xmlns:article/xmlns:section', result, 1).first
       # nokogiri can't make up its mind
       id_attr = section.attribute('id') || section.attribute('xml:id')
-      assert_not_nil id_attr
-      assert_not_nil id_attr.namespace
+      refute_nil id_attr
+      refute_nil id_attr.namespace
       assert_equal 'xml', id_attr.namespace.prefix
       assert_equal '_first_section', id_attr.value
     end
@@ -1432,8 +1432,8 @@ chapter body
       chapter = xmlnodes_at_xpath('/xmlns:book/xmlns:chapter', result, 1).first
       # nokogiri can't make up its mind
       id_attr = chapter.attribute('id') || chapter.attribute('xml:id')
-      assert_not_nil id_attr
-      assert_not_nil id_attr.namespace
+      refute_nil id_attr
+      refute_nil id_attr.namespace
       assert_equal 'xml', id_attr.namespace.prefix
       assert_equal '_first_chapter', id_attr.value
     end
@@ -1575,7 +1575,7 @@ asciidoctor - converts AsciiDoc source files to HTML, DocBook and other formats
 
        doc = document_from_string input
        synopsis_section = doc.blocks.first 
-       assert_not_nil synopsis_section
+       refute_nil synopsis_section
        assert_equal :section, synopsis_section.context
        assert synopsis_section.special
        assert_equal 'synopsis', synopsis_section.sectname

--- a/test/extensions_test.rb
+++ b/test/extensions_test.rb
@@ -115,7 +115,7 @@ context 'Extensions' do
     test 'should register extension group class' do
       begin
         Asciidoctor::Extensions.register :sample, SampleExtensionGroup
-        assert_not_nil Asciidoctor::Extensions.groups
+        refute_nil Asciidoctor::Extensions.groups
         assert_equal 1, Asciidoctor::Extensions.groups.size
         assert_equal SampleExtensionGroup, Asciidoctor::Extensions.groups[:sample]
       ensure
@@ -126,7 +126,7 @@ context 'Extensions' do
     test 'should self register extension group class' do
       begin
         SampleExtensionGroup.register :sample
-        assert_not_nil Asciidoctor::Extensions.groups
+        refute_nil Asciidoctor::Extensions.groups
         assert_equal 1, Asciidoctor::Extensions.groups.size
         assert_equal SampleExtensionGroup, Asciidoctor::Extensions.groups[:sample]
       ensure
@@ -137,7 +137,7 @@ context 'Extensions' do
     test 'should register extension group from class name' do
       begin
         Asciidoctor::Extensions.register :sample, 'SampleExtensionGroup'
-        assert_not_nil Asciidoctor::Extensions.groups
+        refute_nil Asciidoctor::Extensions.groups
         assert_equal 1, Asciidoctor::Extensions.groups.size
         assert_equal SampleExtensionGroup, Asciidoctor::Extensions.groups[:sample]
       ensure
@@ -148,7 +148,7 @@ context 'Extensions' do
     test 'should register extension group from instance' do
       begin
         Asciidoctor::Extensions.register :sample, SampleExtensionGroup.new
-        assert_not_nil Asciidoctor::Extensions.groups
+        refute_nil Asciidoctor::Extensions.groups
         assert_equal 1, Asciidoctor::Extensions.groups.size
         assert Asciidoctor::Extensions.groups[:sample].is_a? SampleExtensionGroup
       ensure
@@ -160,7 +160,7 @@ context 'Extensions' do
       begin
         Asciidoctor::Extensions.register(:sample) do
         end
-        assert_not_nil Asciidoctor::Extensions.groups
+        refute_nil Asciidoctor::Extensions.groups
         assert_equal 1, Asciidoctor::Extensions.groups.size
         assert Asciidoctor::Extensions.groups[:sample].is_a? Proc
       ensure
@@ -170,19 +170,19 @@ context 'Extensions' do
 
     test 'should get class for top-level class name' do
       clazz = Asciidoctor::Extensions.class_for_name('Asciidoctor')
-      assert_not_nil clazz
+      refute_nil clazz
       assert_equal Asciidoctor, clazz
     end
 
     test 'should get class for class name in module' do
       clazz = Asciidoctor::Extensions.class_for_name('Asciidoctor::Extensions')
-      assert_not_nil clazz
+      refute_nil clazz
       assert_equal Asciidoctor::Extensions, clazz
     end
 
     test 'should get class for class name resolved from root' do
       clazz = Asciidoctor::Extensions.class_for_name('::Asciidoctor::Extensions')
-      assert_not_nil clazz
+      refute_nil clazz
       assert_equal Asciidoctor::Extensions, clazz
     end
 
@@ -197,13 +197,13 @@ context 'Extensions' do
 
     test 'should resolve class if class is given' do
       clazz = Asciidoctor::Extensions.resolve_class(Asciidoctor::Extensions)
-      assert_not_nil clazz
+      refute_nil clazz
       assert_equal Asciidoctor::Extensions, clazz
     end
 
     test 'should resolve class if class from string' do
       clazz = Asciidoctor::Extensions.resolve_class('Asciidoctor::Extensions')
-      assert_not_nil clazz
+      refute_nil clazz
       assert_equal Asciidoctor::Extensions, clazz
     end
   end
@@ -469,7 +469,7 @@ content
         end
 
         output = render_string input
-        assert_no_match(/<div class="ulist">/, output)
+        refute_match(/<div class="ulist">/, output)
       ensure
         Asciidoctor::Extensions.unregister_all
       end

--- a/test/options_test.rb
+++ b/test/options_test.rb
@@ -127,7 +127,7 @@ context 'Options' do
     old_load_path = $LOAD_PATH.dup
     begin
       exitval = options.parse! %w(-I foobar -I foobaz test/fixtures/sample.asciidoc)
-      assert_not_equal 1, exitval
+      refute_equal 1, exitval
       assert_equal old_load_path.size + 2, $LOAD_PATH.size
       assert_equal File.expand_path('foobar'), $LOAD_PATH[0]
       assert_equal File.expand_path('foobaz'), $LOAD_PATH[1]

--- a/test/parser_test.rb
+++ b/test/parser_test.rb
@@ -482,7 +482,7 @@ Joe Cool
 :page-layout: post
     EOS
     metadata, = parse_header_metadata input
-    assert_not_equal 'page-layout: post', metadata['revremark']
+    refute_equal 'page-layout: post', metadata['revremark']
     assert !metadata.has_key?('revdate')
   end
 

--- a/test/reader_test.rb
+++ b/test/reader_test.rb
@@ -4,7 +4,7 @@ unless defined? ASCIIDOCTOR_PROJECT_DIR
   require 'test_helper'
 end
 
-class ReaderTest < Test::Unit::TestCase
+class ReaderTest < Minitest::Test
   DIRNAME = File.expand_path(File.dirname(__FILE__))
 
   SAMPLE_DATA = <<-EOS.chomp.split(::Asciidoctor::EOL)
@@ -477,9 +477,7 @@ preamble
         doc = Asciidoctor::Document.new lines
         reader = doc.reader
         append_lines = %w(one two three)
-        assert_nothing_raised do
-          reader.push_include append_lines
-        end
+        reader.push_include append_lines
         assert_equal 1, reader.include_stack.size
         assert_equal 'one', reader.read_line.rstrip
         assert_nil reader.file
@@ -629,7 +627,7 @@ include::#{url}[]
           render_embedded_string input, :safe => :safe, :attributes => {'allow-uri-read' => ''}
         end
 
-        assert_not_nil output
+        refute_nil output
         assert_match(expect, output)
       end
   
@@ -648,7 +646,7 @@ include::#{url}[]
         rescue
           flunk 'include directive should not raise exception on inaccessible uri'
         end
-        assert_not_nil output
+        refute_nil output
         assert_match(/Unresolved directive/, output)
       end
   
@@ -659,10 +657,10 @@ include::fixtures/include-file.asciidoc[lines=1;3..4;6..-1]
   
         output = render_string input, :safe => :safe, :header_footer => false, :base_dir => DIRNAME
         assert_match(/first line/, output)
-        assert_no_match(/second line/, output)
+        refute_match(/second line/, output)
         assert_match(/third line/, output)
         assert_match(/fourth line/, output)
-        assert_no_match(/fifth line/, output)
+        refute_match(/fifth line/, output)
         assert_match(/sixth line/, output)
         assert_match(/seventh line/, output)
         assert_match(/eighth line/, output)
@@ -676,10 +674,10 @@ include::fixtures/include-file.asciidoc[lines="1, 3..4 , 6 .. -1"]
   
         output = render_string input, :safe => :safe, :header_footer => false, :base_dir => DIRNAME
         assert_match(/first line/, output)
-        assert_no_match(/second line/, output)
+        refute_match(/second line/, output)
         assert_match(/third line/, output)
         assert_match(/fourth line/, output)
-        assert_no_match(/fifth line/, output)
+        refute_match(/fifth line/, output)
         assert_match(/sixth line/, output)
         assert_match(/seventh line/, output)
         assert_match(/eighth line/, output)
@@ -693,9 +691,9 @@ include::fixtures/include-file.asciidoc[tag=snippetA]
   
         output = render_string input, :safe => :safe, :header_footer => false, :base_dir => DIRNAME
         assert_match(/snippetA content/, output)
-        assert_no_match(/snippetB content/, output)
-        assert_no_match(/non-tagged content/, output)
-        assert_no_match(/included content/, output)
+        refute_match(/snippetB content/, output)
+        refute_match(/non-tagged content/, output)
+        refute_match(/included content/, output)
       end
   
       test 'include directive supports multiple tagged selection' do
@@ -706,8 +704,8 @@ include::fixtures/include-file.asciidoc[tags=snippetA;snippetB]
         output = render_string input, :safe => :safe, :header_footer => false, :base_dir => DIRNAME
         assert_match(/snippetA content/, output)
         assert_match(/snippetB content/, output)
-        assert_no_match(/non-tagged content/, output)
-        assert_no_match(/included content/, output)
+        refute_match(/non-tagged content/, output)
+        refute_match(/included content/, output)
       end
 
       test 'should warn if tag is not found in include file' do
@@ -720,7 +718,7 @@ include::fixtures/include-file.asciidoc[tag=snippetZ]
         begin
           render_string input, :safe => :safe, :header_footer => false, :base_dir => DIRNAME
           warning = $stderr.tap(&:rewind).read
-          assert_not_nil warning
+          refute_nil warning
           assert_match(/WARNING.*snippetZ/, warning)
         ensure
           $stderr = old_stderr
@@ -734,8 +732,8 @@ include::fixtures/include-file.asciidoc[lines=1, tags=snippetA;snippetB]
   
         output = render_string input, :safe => :safe, :header_footer => false, :base_dir => DIRNAME
         assert_match(/first line of included content/, output)
-        assert_no_match(/snippetA content/, output)
-        assert_no_match(/snippetB content/, output)
+        refute_match(/snippetA content/, output)
+        refute_match(/snippetB content/, output)
       end
   
       test 'indent of included file can be reset to size of indent attribute' do
@@ -961,7 +959,7 @@ endif::asciidoctor[]
   
         doc = Asciidoctor::Document.new input
         reader = doc.reader
-        assert_not_nil reader.process_line(reader.lines.first)
+        refute_nil reader.process_line(reader.lines.first)
       end
 
       test 'peek_line does not advance cursor when on a regular content line' do

--- a/test/sections_test.rb
+++ b/test/sections_test.rb
@@ -76,7 +76,7 @@ context 'Sections' do
 
     test 'id and reftext in embedded anchor cannot be quoted' do
       sec = block_from_string(%(== Section One [["one","Section Uno"]] ==))
-      assert_not_equal 'one', sec.id
+      refute_equal 'one', sec.id
       assert_equal 'Section One [["one","Section Uno"]]', sec.title
       assert_nil(sec.attr 'reftext')
     end
@@ -90,7 +90,7 @@ context 'Sections' do
 
     test 'should unescape but not process inline anchor' do
       sec = block_from_string(%(== Section One \\[[one]] ==))
-      assert_not_equal 'one', sec.id
+      refute_equal 'one', sec.id
       assert_equal 'Section One [[one]]', sec.title
     end
 
@@ -124,7 +124,7 @@ content
 
       doc = document_from_string input
       reftext = doc.references[:ids]['install']
-      assert_not_nil reftext
+      refute_nil reftext
       assert_equal 'Install Procedure', reftext
     end
 
@@ -138,7 +138,7 @@ content
 
       doc = document_from_string input
       reftext = doc.references[:ids]['_install']
-      assert_not_nil reftext
+      refute_nil reftext
       assert_equal 'Install Procedure', reftext
     end
   end
@@ -508,7 +508,7 @@ content
 
       doc = document_from_string input
       reftext = doc.references[:ids]['install']
-      assert_not_nil reftext
+      refute_nil reftext
       assert_equal 'Install Procedure', reftext
     end
 
@@ -523,7 +523,7 @@ content
 
       doc = document_from_string input
       reftext = doc.references[:ids]['_install']
-      assert_not_nil reftext
+      refute_nil reftext
       assert_equal 'Install Procedure', reftext
     end
   end
@@ -2243,7 +2243,7 @@ intro
         warnings = err.string
       end
 
-      assert_not_nil warnings
+      refute_nil warnings
       assert !warnings.empty?
       assert_match(/ERROR:.*section/, warnings)
     end

--- a/test/substitutions_test.rb
+++ b/test/substitutions_test.rb
@@ -698,9 +698,7 @@ context 'Substitutions' do
 
     test 'an unresolved footnoteref should not crash the processor' do
       para = block_from_string('Sentence text footnoteref:[ex1].')
-      assert_nothing_raised do
-        para.sub_macros para.source
-      end
+      para.sub_macros para.source
     end
 
     test 'a single-line index term macro with a primary term should be registered as an index reference' do

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -7,7 +7,7 @@ end
 
 require File.join(ASCIIDOCTOR_PROJECT_DIR, 'lib', 'asciidoctor')
 
-require 'test/unit'
+require 'minitest/autorun'
 require 'socket'
 require 'nokogiri'
 
@@ -19,7 +19,14 @@ ENV['SUPPRESS_DEBUG'] ||= 'true'
 RE_XMLNS_ATTRIBUTE = / xmlns="[^"]+"/
 RE_DOCTYPE = /\s*<!DOCTYPE (.*)/
 
-class Test::Unit::TestCase
+if Minitest.const_defined?('Test')
+  # We're on Minitest 5+. Nothing to do here.
+else
+  # Minitest 4 doesn't have Minitest::Test yet.
+  Minitest::Test = MiniTest::Unit::TestCase
+end
+
+class Minitest::Test
   def windows?
     RbConfig::CONFIG['host_os'] =~ /win|ming/
   end
@@ -316,22 +323,12 @@ end
 #
 ###
 
-# Test::Unit loads a default test if the suite is empty, whose purpose is to
-# fail. Since having empty contexts is a common practice, we decided to
-# overwrite TestSuite#empty? in order to allow them. Having a failure when no
-# tests have been defined seems counter-intuitive.
-class Test::Unit::TestSuite
-  def empty?
-    false
-  end
-end
-
 # Contest adds +teardown+, +test+ and +context+ as class methods, and the
 # instance methods +setup+ and +teardown+ now iterate on the corresponding
 # blocks. Note that all setup and teardown blocks must be defined with the
 # block syntax. Adding setup or teardown instance methods defeats the purpose
 # of this library.
-class Test::Unit::TestCase
+class Minitest::Test
   def self.setup(&block)
     define_method :setup do
       super(&block)
@@ -384,5 +381,5 @@ private
 end
 
 def context(*name, &block)
-  Test::Unit::TestCase.context(name, &block)
+  Minitest::Test.context(name, &block)
 end

--- a/test/text_test.rb
+++ b/test/text_test.rb
@@ -200,7 +200,7 @@ This line is separated something that is not a horizontal rule...
   end
 
   test "unquoted text" do
-    assert_no_match(/#/, render_string("An #unquoted# word"))
+    refute_match(/#/, render_string("An #unquoted# word"))
   end
 
   test "backtick-escaped text followed by single-quoted text" do


### PR DESCRIPTION
Ruby 1.9+ uses Minitest as the backend for Test::Unit. As of Minitest 5, the shim no longer supports Test::Unit::TestCase.

This pull request adjusts the test suite to support Minitest 5's syntax.

Minitest versions 4 and below do not support the newer Minitest::Test class that arrived in version 5. For that case, this pull request uses the MiniTest::Unit::TestCase class as a fallback.
