### PR TITLE
resolves #836 and #846

### DIFF
--- a/lib/asciidoctor.rb
+++ b/lib/asciidoctor.rb
@@ -5,13 +5,16 @@ RUBY_MIN_VERSION_1_9 = (RUBY_VERSION >= '1.9')
 
 require 'set'
 
-if RUBY_ENGINE_OPAL
+# NOTE "RUBY_ENGINE == 'opal'" conditional blocks are filtered by the Opal preprocessor
+if RUBY_ENGINE == 'opal'
   require 'encoding' # needed for String.bytes method
   require 'strscan'
-  require 'asciidoctor/opal_ext/comparable'
-  require 'asciidoctor/opal_ext/dir'
-  require 'asciidoctor/opal_ext/error'
-  require 'asciidoctor/opal_ext/file'
+  require 'asciidoctor/opal_ext'
+else
+  autoload :Base64, 'base64'
+  autoload :FileUtils, 'fileutils'
+  autoload :OpenURI, 'open-uri'
+  autoload :StringScanner, 'strscan'
 end
 
 # ideally we should use require_relative instead of modifying the LOAD_PATH
@@ -47,15 +50,6 @@ $:.unshift File.dirname __FILE__
 #   Asciidoctor.convert_file 'sample.adoc', :template_dir => 'path/to/templates'
 #
 module Asciidoctor
-
-  unless ::RUBY_ENGINE_OPAL
-    # .chomp keeps Opal from trying to load the library
-    ::Object.autoload :Base64,        'base64'.chomp
-    ::Object.autoload :FileUtils,     'fileutils'.chomp
-    ::Object.autoload :OpenURI,       'open-uri'.chomp
-    #::Object.autoload :Set,           'set'.chomp
-    ::Object.autoload :StringScanner, 'strscan'.chomp
-  end
 
   module SafeMode
 
@@ -200,7 +194,7 @@ module Asciidoctor
   EOL = "\n"
 
   # The null character to use for splitting attribute values
-  NULL = ::RUBY_ENGINE_OPAL ? 0.chr : "\0"
+  NULL = "\0"
 
   # String for matching tab character
   TAB = "\t"
@@ -343,7 +337,7 @@ module Asciidoctor
 
     # character classes for JavaScript Regexp engine
     # NOTE use of double quotes are intentional to work around Opal issue
-    if ::RUBY_ENGINE_OPAL
+    if RUBY_ENGINE == 'opal'
       CC_ALPHA = 'a-zA-Z'
       CC_ALNUM = 'a-zA-Z0-9'
       CC_BLANK = "[ \\t]"
@@ -1449,8 +1443,11 @@ module Asciidoctor
 
   end
 
-  # autoload
-  unless ::RUBY_ENGINE_OPAL
+  if RUBY_ENGINE == 'opal'
+    require 'asciidoctor/debug'
+    require 'asciidoctor/version'
+    require 'asciidoctor/timings'
+  else
     autoload :Debug,   'asciidoctor/debug'
     autoload :VERSION, 'asciidoctor/version'
     autoload :Timings, 'asciidoctor/timings'

--- a/lib/asciidoctor/abstract_node.rb
+++ b/lib/asciidoctor/abstract_node.rb
@@ -323,7 +323,7 @@ class AbstractNode
   #
   # Returns A String data URI containing the content of the target image
   def generate_data_uri(target_image, asset_dir_key = nil)
-    ext = File.extname(target_image)[1..-1]
+    ext = ::File.extname(target_image)[1..-1]
     mimetype = 'image/' + ext
     mimetype = "#{mimetype}+xml" if ext == 'svg'
     if asset_dir_key
@@ -334,7 +334,7 @@ class AbstractNode
       image_path = normalize_system_path(target_image)
     end
 
-    if !File.readable? image_path
+    unless ::File.readable? image_path
       warn "asciidoctor: WARNING: image to embed not found or not readable: #{image_path}"
       return "data:#{mimetype}:base64,"
       # uncomment to return 1 pixel white dot instead
@@ -342,12 +342,12 @@ class AbstractNode
     end
 
     bindata = nil
-    if IO.respond_to? :binread
-      bindata = IO.binread(image_path)
+    if ::IO.respond_to? :binread
+      bindata = ::IO.binread(image_path)
     else
-      bindata = File.open(image_path, 'rb') {|file| file.read }
+      bindata = ::File.open(image_path, 'rb') {|file| file.read }
     end
-    "data:#{mimetype};base64,#{Base64.encode64(bindata).delete EOL}"
+    "data:#{mimetype};base64,#{::Base64.encode64(bindata).delete EOL}"
   end
 
   # Public: Read the contents of the file at the specified path.
@@ -361,9 +361,9 @@ class AbstractNode
   # Returns the [String] content of the file at the specified path, or nil
   # if the file does not exist.
   def read_asset(path, warn_on_failure = false)
-    if File.readable? path
+    if ::File.readable? path
       # QUESTION should we use strip or rstrip instead of chomp here?
-      File.read(path).chomp
+      ::File.read(path).chomp
     else
       warn "asciidoctor: WARNING: file does not exist or cannot be read: #{path}" if warn_on_failure
       nil

--- a/lib/asciidoctor/core_ext.rb
+++ b/lib/asciidoctor/core_ext.rb
@@ -1,7 +1,7 @@
 require 'asciidoctor/core_ext/object/nil_or_empty'
-# Opal barfs here if we use ::RUBY_VERSION_MIN_1_9
-unless RUBY_VERSION >= '1.9'
-  require 'asciidoctor/core_ext/string/chr'
-  # we append .to_s to keep Opal from processing the next require
-  require 'asciidoctor/core_ext/symbol/length'.to_s
+unless RUBY_ENGINE == 'opal'
+  unless RUBY_MIN_VERSION_1_9
+    require 'asciidoctor/core_ext/string/chr'
+    require 'asciidoctor/core_ext/symbol/length'
+  end
 end

--- a/lib/asciidoctor/opal_ext.rb
+++ b/lib/asciidoctor/opal_ext.rb
@@ -1,0 +1,4 @@
+require 'asciidoctor/opal_ext/comparable'
+require 'asciidoctor/opal_ext/dir'
+require 'asciidoctor/opal_ext/error'
+require 'asciidoctor/opal_ext/file'

--- a/test/document_test.rb
+++ b/test/document_test.rb
@@ -1301,7 +1301,6 @@ two
 content
       EOS
       result = render_string input, :safe => :safe, :backend => :xhtml, :keep_namespaces => true
-      doc = xmldoc_from_string(result)
       assert_xpath '//*[not(namespace-uri() = "http://www.w3.org/1999/xhtml")]', result, 0
     end
 


### PR DESCRIPTION
- use new Opal preprocessor guards (i.e., unless RUBY_ENGINE == 'opal')
- use unicode escape sequence for passthrough placeholders and null character
- fix several checks where a value is empty string instead of null in JavaScript
- consolidate opal_ext require to a single line
- move autoload declarations outside of Asciidoctor module block
- use qualified name for top-level classes in AbstractNode
