### PR TITLE
Add asciimath support for docbook5

### DIFF
--- a/asciidoctor.gemspec
+++ b/asciidoctor.gemspec
@@ -30,9 +30,11 @@ A fast, open source text processor and publishing toolchain, written in Ruby, fo
   #s.extra_rdoc_files  = %w(CHANGELOG.adoc LICENSE.adoc README.adoc)
   s.extra_rdoc_files  = %w(LICENSE.adoc)
 
+  # asciimath is needed for testing AsciiMath in DocBook backend
   # erubis is needed for testing use of alternative eRuby impls
   # tilt, slim and haml are needed for testing custom templates
   # coderay is needed for testing syntax highlighting
+  s.add_development_dependency 'asciimath', '~> 1.0.1'
   s.add_development_dependency 'coderay', '~> 1.1.0'
   s.add_development_dependency 'cucumber', '~> 1.3.1'
   s.add_development_dependency 'erubis', '~> 2.7.0'

--- a/lib/asciidoctor/converter/docbook5.rb
+++ b/lib/asciidoctor/converter/docbook5.rb
@@ -256,9 +256,11 @@ module Asciidoctor
       if node.style == 'latexmath'
         equation_data = %(<alt><![CDATA[#{equation}]]></alt>
 <mediaobject><textobject><phrase></phrase></textobject></mediaobject>)
-      # asciimath
+      elsif node.style == 'asciimath' && (!(defined? @asciimath_loaded) ?
+          (@asciimath_loaded = Helpers.require_library 'asciimath', true, :warn) : @asciimath_loaded)
+        equation_data = ::AsciiMath.parse(equation).to_mathml 'mml:', 'xmlns:mml' => 'http://www.w3.org/1998/Math/MathML'
       else
-        # DocBook backends can't handle AsciiMath, so output raw expression in text object
+        # Unsupported math style, so output raw expression in text object
         equation_data = %(<mediaobject><textobject><phrase><![CDATA[#{equation}]]></phrase></textobject></mediaobject>)
       end
       if node.title?

--- a/test/blocks_test.rb
+++ b/test/blocks_test.rb
@@ -1285,11 +1285,9 @@ x+b/(2a)<+-sqrt((b^2)/(4a^2)-c/a)
 ++++
       EOS
 
-      expect = <<-'EOS'
-<informalequation>
-<mediaobject><textobject><phrase><![CDATA[x+b/(2a)<+-sqrt((b^2)/(4a^2)-c/a)]]></phrase></textobject></mediaobject>
-</informalequation>
-      EOS
+      expect = %(<informalequation>
+<mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML"><mml:mi>x</mml:mi><mml:mo>+</mml:mo><mml:mfrac><mml:mi>b</mml:mi><mml:mrow><mml:mn>2</mml:mn><mml:mi>a</mml:mi></mml:mrow></mml:mfrac><mml:mo>&#x003C;</mml:mo><mml:mo>&#x00B1;</mml:mo><mml:msqrt><mml:mrow><mml:mfrac><mml:msup><mml:mi>b</mml:mi><mml:mn>2</mml:mn></mml:msup><mml:mrow><mml:mn>4</mml:mn><mml:msup><mml:mi>a</mml:mi><mml:mn>2</mml:mn></mml:msup></mml:mrow></mml:mfrac><mml:mo>&#x2212;</mml:mo><mml:mfrac><mml:mi>c</mml:mi><mml:mi>a</mml:mi></mml:mfrac></mml:mrow></mml:msqrt></mml:math>
+</informalequation>)
 
       output = render_embedded_string input, :backend => :docbook
       assert_equal expect.strip, output.strip


### PR DESCRIPTION
Add an Asciimath parser and MathML generator. This enables conversion of asciimath expressions to MathML in the docbook5 converter.