### PR TITLE
Fix "sh [: unexpected operator" when running run-tests.sh

### DIFF
--- a/run-tests.sh
+++ b/run-tests.sh
@@ -3,7 +3,7 @@
 # A convenience script to run tests without delays caused by incrementally writing to the terminal buffer.
 # This script will execute against all supported Ruby versions if "all" is the first argument to the script.
 
-if [ "$1" == "all" ]; then
+if [ "$1" = "all" ]; then
   rvm 1.8@asciidoctor-dev,jruby@asciidoctor-dev,rbx@asciidoctor-dev,1.9@asciidoctor-dev,2.0@asciidoctor-dev,2.1@asciidoctor-dev "do" ./run-tests.sh
 else
   rake > /tmp/asciidoctor-test-results.txt 2>&1; cat /tmp/asciidoctor-test-results.txt


### PR DESCRIPTION
POSIX sh doesn't understand == for string equality, as that is a bash-ism. Use = instead.
http://stackoverflow.com/questions/3411048/unexpected-operator-in-shell-programming
