### PR TITLE
Expose Document to extension point IncludeProcessor

### DIFF
--- a/lib/asciidoctor/extensions.rb
+++ b/lib/asciidoctor/extensions.rb
@@ -232,7 +232,7 @@ module Extensions
   #--
   # TODO add file extension or regexp to shortcut handles?
   class IncludeProcessor < Processor
-    def process reader, target, attributes
+    def process document, reader, target, attributes
       raise ::NotImplementedError
     end
 

--- a/lib/asciidoctor/reader.rb
+++ b/lib/asciidoctor/reader.rb
@@ -816,7 +816,7 @@ class PreprocessorReader < Reader
         (extension = @include_processor_extensions.find {|candidate| candidate.instance.handles? target })
       advance
       # FIXME parse attributes if requested by extension
-      extension.process_method[self, target, AttributeList.new(raw_attributes).parse]
+      extension.process_method[@document, self, target, AttributeList.new(raw_attributes).parse]
       true
     # if running in SafeMode::SECURE or greater, don't process this directive
     # however, be friendly and at least make it a link to the source document

--- a/test/extensions_test.rb
+++ b/test/extensions_test.rb
@@ -47,7 +47,7 @@ class BoilerplateTextIncludeProcessor < Asciidoctor::Extensions::IncludeProcesso
     target.end_with? '.txt'
   end
 
-  def process reader, target, attributes
+  def process document, reader, target, attributes
     case target
     when 'lorem-ipsum.txt'
       content = ["Lorem ipsum dolor sit amet...\n"]
@@ -415,7 +415,7 @@ last line
       # Safe Mode is not required here
       document = empty_document :base_dir => File.expand_path(File.dirname(__FILE__))
       document.extensions.include_processor do
-        process do |reader, target, attributes|
+        process do |document, reader, target, attributes|
           # demonstrate that push_include normalizes endlines
           content = ["include target:: #{target}\n", "\n", "middle line\n"]
           reader.push_include content, target, target, 1, attributes


### PR DESCRIPTION
IncludeProcessor should be allowed to read Document
e.g. attributes.
