### PR TITLE
use https scheme for assets by default

### DIFF
--- a/lib/asciidoctor/converter/html5.rb
+++ b/lib/asciidoctor/converter/html5.rb
@@ -28,6 +28,9 @@ module Asciidoctor
       result = []
       slash = @void_element_slash
       br = %(<br#{slash}>)
+      asset_uri_scheme = (node.attr 'asset-uri-scheme', 'https')
+      asset_uri_scheme = %(#{asset_uri_scheme}:) unless asset_uri_scheme == ''
+      cdn_base = %(#{asset_uri_scheme}//cdnjs.cloudflare.com/ajax/libs)
       linkcss = node.safe >= SafeMode::SECURE || (node.attr? 'linkcss')
       result << '<!DOCTYPE html>'
       lang_attribute = (node.attr? 'nolang') ? nil : %( lang="#{node.attr 'lang', 'en'}")
@@ -63,7 +66,7 @@ module Asciidoctor
 
       if node.attr? 'icons', 'font'
         if node.attr? 'iconfont-remote'
-          result << %(<link rel="stylesheet" href="#{node.attr 'iconfont-cdn', 'http://netdna.bootstrapcdn.com/font-awesome/4.1.0/css/font-awesome.min.css'}"#{slash}>)
+          result << %(<link rel="stylesheet" href="#{node.attr 'iconfont-cdn', %[#{cdn_base}/font-awesome/4.1.0/css/font-awesome.min.css]}"#{slash}>)
         else
           iconfont_stylesheet = %(#{node.attr 'iconfont-name', 'font-awesome'}.css)
           result << %(<link rel="stylesheet" href="#{node.normalize_web_path iconfont_stylesheet, (node.attr 'stylesdir', '')}"#{slash}>)
@@ -89,13 +92,14 @@ module Asciidoctor
           end
         end
       when 'highlightjs', 'highlight.js'
-        result << %(<link rel="stylesheet" href="#{node.attr 'highlightjsdir', 'http://cdnjs.cloudflare.com/ajax/libs/highlight.js/7.4'}/styles/#{node.attr 'highlightjs-theme', 'googlecode'}.min.css"#{slash}>
-<script src="#{node.attr 'highlightjsdir', 'http://cdnjs.cloudflare.com/ajax/libs/highlight.js/7.4'}/highlight.min.js"></script>
-<script src="#{node.attr 'highlightjsdir', 'http://cdnjs.cloudflare.com/ajax/libs/highlight.js/7.4'}/lang/common.min.js"></script>
+        highlightjs_path = node.attr 'highlightjsdir', %(#{cdn_base}/highlight.js/8.0)
+        result << %(<link rel="stylesheet" href="#{highlightjs_path}/styles/#{node.attr 'highlightjs-theme', 'googlecode'}.min.css"#{slash}>
+<script src="#{highlightjs_path}/highlight.min.js"></script>
 <script>hljs.initHighlightingOnLoad()</script>)
       when 'prettify'
-        result << %(<link rel="stylesheet" href="#{node.attr 'prettifydir', 'http://cdnjs.cloudflare.com/ajax/libs/prettify/r298'}/#{node.attr 'prettify-theme', 'prettify'}.min.css"#{slash}>
-<script src="#{node.attr 'prettifydir', 'http://cdnjs.cloudflare.com/ajax/libs/prettify/r298'}/prettify.min.js"></script>
+        prettify_path = node.attr 'prettifydir', %(#{cdn_base}/prettify/r298)
+        result << %(<link rel="stylesheet" href="#{prettify_path}/#{node.attr 'prettify-theme', 'prettify'}.min.css"#{slash}>
+<script src="#{prettify_path}/prettify.min.js"></script>
 <script>document.addEventListener('DOMContentLoaded', prettyPrint)</script>)
       end
 
@@ -113,7 +117,7 @@ MathJax.Hub.Config({
   }
 });
 </script>
-<script type="text/javascript" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-MML-AM_HTMLorMML"></script>
+<script type="text/javascript" src="#{cdn_base}/mathjax/2.4.0/MathJax.js?config=TeX-MML-AM_HTMLorMML"></script>
 <script>document.addEventListener('DOMContentLoaded', MathJax.Hub.TypeSet)</script>)
       end
 

--- a/test/blocks_test.rb
+++ b/test/blocks_test.rb
@@ -1870,8 +1870,42 @@ You can use icons for admonitions by setting the 'icons' attribute.
       EOS
 
       output = render_string input, :safe => Asciidoctor::SafeMode::SERVER
-      assert_css 'html > head > link[rel="stylesheet"][href="http://netdna.bootstrapcdn.com/font-awesome/4.1.0/css/font-awesome.min.css"]', output, 1
+      assert_css 'html > head > link[rel="stylesheet"][href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.1.0/css/font-awesome.min.css"]', output, 1
       assert_xpath '//*[@class="admonitionblock tip"]//*[@class="icon"]/i[@class="fa fa-tip"]', output, 1
+    end
+
+    test 'should use http uri scheme for assets when asset-uri-scheme is http' do
+      input = <<-EOS
+:asset-uri-scheme: http
+:icons: font
+:source-highlighter: highlightjs
+
+TIP: You can control the URI scheme used for assets with the asset-uri-scheme attribute
+
+[source,ruby]
+puts "AsciiDoc, FTW!"
+      EOS
+
+      output = render_string input, :safe => Asciidoctor::SafeMode::SAFE
+      assert_css 'html > head > link[rel="stylesheet"][href="http://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.1.0/css/font-awesome.min.css"]', output, 1
+      assert_css 'html > head > script[src="http://cdnjs.cloudflare.com/ajax/libs/highlight.js/8.0/highlight.min.js"]', output, 1
+    end
+
+    test 'should use no uri scheme for assets when asset-uri-scheme is blank' do
+      input = <<-EOS
+:asset-uri-scheme:
+:icons: font
+:source-highlighter: highlightjs
+
+TIP: You can control the URI scheme used for assets with the asset-uri-scheme attribute
+
+[source,ruby]
+puts "AsciiDoc, FTW!"
+      EOS
+
+      output = render_string input, :safe => Asciidoctor::SafeMode::SAFE
+      assert_css 'html > head > link[rel="stylesheet"][href="//cdnjs.cloudflare.com/ajax/libs/font-awesome/4.1.0/css/font-awesome.min.css"]', output, 1
+      assert_css 'html > head > script[src="//cdnjs.cloudflare.com/ajax/libs/highlight.js/8.0/highlight.min.js"]', output, 1
     end
   end
 


### PR DESCRIPTION
- use https scheme for assets by default
- allow URI scheme for assets to be controlled by asset-uri-scheme
- upgrade highlightjs to 8.0, remove unnecessary JavaScript resource
- load MathJax 2.4.0 from cdnjs
- load FontAwesome 4.1.0 from cdnjs
- add tests for asset-uri-scheme
