### PR TITLE
resolves #717 disable single quotes as formatting marks for emphasized text

### DIFF
--- a/compat/asciidoc.conf
+++ b/compat/asciidoc.conf
@@ -21,16 +21,21 @@ space=" "
 tilde=~
 user-home={eval:os.path.expanduser('~')}
 vbar=|
+ifndef::compat-mode[]
+compat-mode=default
+endif::[]
 
 [replacements]
-# trailing apostrophe
-([a-zA-Z])'(?!')=\1&#8217;
-# (planned)
-#\B'([a-zA-Z])=&#8216;\1
+# right single quote
+(?<!\\)`'=&#8217;
+# escaped right single quote
+\\`'=`'
 
-#[quotes]
-# (planned)
-#'=
+[quotes]
+# disable single quotes as constrained formatting marks for emphasis
+ifeval::["{compat-mode}"!="legacy"]
+'=
+endif::[]
 
 # enables markdown-style headings
 [titles]

--- a/lib/asciidoctor.rb
+++ b/lib/asciidoctor.rb
@@ -1117,8 +1117,8 @@ module Asciidoctor
   # constrained quotes:: must be bordered by non-word characters
   # NOTE these substitutions are processed in the order they appear here and
   # the order in which they are replaced is important
-  QUOTE_SUBS = [
-
+  QUOTE_SUBS = { :default =>
+  [
     # **strong**
     [:strong, :unconstrained, /\\?(?:\[([^\]]+?)\])?\*\*(.+?)\*\*/m],
 
@@ -1127,9 +1127,6 @@ module Asciidoctor
 
     # ``double-quoted''
     [:double, :constrained, /(^|[^#{CC_WORD};:}])(?:\[([^\]]+?)\])?``(\S|\S.*?\S)''(?!#{CG_WORD})/m],
-
-    # 'emphasis'
-    [:emphasis, :constrained, /(^|[^#{CC_WORD};:}])(?:\[([^\]]+?)\])?'(\S|\S.*?\S)'(?!#{CG_WORD})/m],
 
     # `single-quoted'
     [:single, :constrained, /(^|[^#{CC_WORD};:}])(?:\[([^\]]+?)\])?`(\S|\S.*?\S)'(?!#{CG_WORD})/m],
@@ -1157,7 +1154,10 @@ module Asciidoctor
 
     # ~subscript~
     [:subscript, :unconstrained, /\\?(?:\[([^\]]+?)\])?~(\S*?)~/m]
-  ]
+  ]}
+
+  QUOTE_SUBS[:legacy] = QUOTE_SUBS[:default].dup.
+    insert(3, [:emphasis, :constrained, /(^|[^#{CC_WORD};:}])(?:\[([^\]]+?)\])?'(\S|\S.*?\S)'(?!#{CG_WORD})/m])
 
   # NOTE in Ruby 1.8.7, [^\\] does not match start of line,
   # so we need to match it explicitly
@@ -1175,10 +1175,10 @@ module Asciidoctor
     [/(#{CG_WORD})\\?--(?=#{CG_WORD})/, '&#8212;', :leading],
     # ellipsis
     [/\\?\.\.\./, '&#8230;', :leading],
-    # apostrophe or a closing single quote (planned)
-    [/(#{CG_ALPHA})\\?'(?!')/, '&#8217;', :leading],
-    # an opening single quote (planned)
-    #[/\B\\?'(?=#{CG_ALPHA})/, '&#8216;', :none],
+    # right single quote
+    [/\\?`'/, '&#8217;', :none],
+    # apostrophe (inside a word)
+    [/(#{CG_ALNUM})\\?'(?=#{CG_ALPHA})/, '&#8217;', :leading],
     # right arrow ->
     [/\\?-&gt;/, '&#8594;', :none],
     # right double arrow =>

--- a/lib/asciidoctor/substitutors.rb
+++ b/lib/asciidoctor/substitutors.rb
@@ -280,14 +280,14 @@ module Substitutors
   def sub_quotes(text)
     if ::RUBY_ENGINE_OPAL
       result = text
-      QUOTE_SUBS.each {|type, scope, pattern|
+      QUOTE_SUBS[@document.compat_mode].each {|type, scope, pattern|
         result = result.gsub(pattern) { convert_quoted_text $~, type, scope }
       }
     else
       # NOTE interpolation is faster than String#dup
       result = %(#{text})
-      # NOTE using gsub! as optimization
-      QUOTE_SUBS.each {|type, scope, pattern|
+      # NOTE using gsub! here as an MRI Ruby optimization
+      QUOTE_SUBS[@document.compat_mode].each {|type, scope, pattern|
         result.gsub!(pattern) { convert_quoted_text $~, type, scope }
       }
     end

--- a/test/blocks_test.rb
+++ b/test/blocks_test.rb
@@ -495,7 +495,7 @@ ____
       input = <<-EOS
 [verse]
 ____
-'GET /groups/link:#group-id[\{group-id\}]'
+_GET /groups/link:#group-id[\{group-id\}]_
 ____
       EOS
 
@@ -919,7 +919,7 @@ AssertionError
 
       assert_css '.listingblock pre', output, 1
       assert_css '.listingblock pre strong', output, 1
-      assert_css '.listingblock pre em', output, 1
+      assert_css '.listingblock pre em', output, 0
 
       input2 = <<-EOS
 [subs="specialcharacters,macros"]
@@ -1077,7 +1077,7 @@ image:tiger.png[]
 
 [subs="attributes,quotes,macros"]
 ++++
-This is a '{type}' block.
+This is a _{type}_ block.
 http://asciidoc.org
 ++++
       EOS

--- a/test/lists_test.rb
+++ b/test/lists_test.rb
@@ -626,7 +626,7 @@ List
 ====
 
 - I am *strong*.
-- I am 'stressed'.
+- I am _stressed_.
 - I am `flexible`.
       EOS
       output = render_string input
@@ -2795,7 +2795,7 @@ term1::
       output = render_embedded_string input
       assert_xpath '//*[@class="dlist"]/dl', output, 1
       assert_xpath '//*[@class="dlist"]//dd', output, 1
-      assert_xpath %(//*[@class="dlist"]//dd/p/em[text()="'"]), output, 1
+      assert_xpath %(//*[@class="dlist"]//dd/p[text()="'''"]), output, 1
     end
   
     test 'folds text that looks like ruler offset by blank line and line comment' do
@@ -2811,7 +2811,7 @@ term1::
       output = render_embedded_string input
       assert_xpath '//*[@class="dlist"]/dl', output, 1
       assert_xpath '//*[@class="dlist"]//dd', output, 1
-      assert_xpath %(//*[@class="dlist"]//dd/p/em[text()="'"]), output, 1
+      assert_xpath %(//*[@class="dlist"]//dd/p[text()="'''"]), output, 1
     end
   
     test 'folds text that looks like ruler and the line following it offset by blank line' do
@@ -2827,8 +2827,7 @@ continued
       output = render_embedded_string input
       assert_xpath '//*[@class="dlist"]/dl', output, 1
       assert_xpath '//*[@class="dlist"]//dd', output, 1
-      assert_xpath %(//*[@class="dlist"]//dd/p/em[text()="'"]), output, 1
-      assert_xpath %(//*[@class="dlist"]//dd/p[normalize-space(text())="continued"]), output, 1
+      assert_xpath %(//*[@class="dlist"]//dd/p[normalize-space(text())="''' continued"]), output, 1
     end
   
     test 'folds text that looks like title offset by blank line' do

--- a/test/paragraphs_test.rb
+++ b/test/paragraphs_test.rb
@@ -367,7 +367,7 @@ A famouse quote.
     test 'should perform normal subs on a verse paragraph' do
       input = <<-EOS
 [verse]
-'GET /groups/link:#group-id[\{group-id\}]'
+_GET /groups/link:#group-id[\{group-id\}]_
       EOS
 
       output = render_embedded_string input

--- a/test/tables_test.rb
+++ b/test/tables_test.rb
@@ -601,6 +601,20 @@ content
       assert_css 'table.tableblock .paragraph', result, 0
     end
 
+    test 'compat-mode can be set in asciidoc table cell' do
+      input = <<-EOS
+|===
+a|
+:compat-mode: legacy
+
+'italic'
+|===
+      EOS
+
+      result = render_embedded_string input
+      assert_css 'table.tableblock td em', result, 1
+    end
+
     test 'asciidoc content' do
       input = <<-EOS
 [cols="1e,1,5a",frame="topbot",options="header"]

--- a/test/text_test.rb
+++ b/test/text_test.rb
@@ -171,32 +171,43 @@ This line is separated something that is not a horizontal rule...
     end
   end
 
-  test "emphasized text" do
-    assert_xpath "//em", render_string("An 'emphatic' no")
+  test "emphasized text using underscore characters" do
+    assert_xpath "//em", render_string("An _emphatic_ no")
   end
 
-  test "emphasized text with single quote" do
-    assert_xpath "//em[text()=\"Johnny#{[8217].pack('U*')}s\"]", render_string("It's 'Johnny's' phone")
+  test 'emphasized text with single quote using apostrophe characters' do
+    rsquo = [8217].pack 'U*'
+    assert_xpath %(//em[text()="Johnny#{rsquo}s"]), render_string(%q(It's 'Johnny's' phone), :attributes => {'compat-mode' => 'legacy'})
+    assert_xpath %(//p[text()="It#{rsquo}s 'Johnny#{rsquo}s' phone"]), render_string(%q(It's 'Johnny's' phone))
   end
 
-  test "emphasized text with escaped single quote" do
-    assert_xpath "//em[text()=\"Johnny's\"]", render_string("It's 'Johnny\\'s' phone")
+  test 'emphasized text with escaped single quote using apostrophe characters' do
+    assert_xpath %(//em[text()="Johnny's"]), render_string(%q(It's 'Johnny\\'s' phone), :attributes => {'compat-mode' => 'legacy'})
+    assert_xpath %(//p[text()="It's 'Johnny's' phone"]), render_string(%q(It\\'s 'Johnny\\'s' phone))
   end
 
   test "escaped single quote is restored as single quote" do
     assert_xpath "//p[contains(text(), \"Let's do it!\")]", render_string("Let\\'s do it!")
   end
 
+  test 'unescape escaped single quote emphasis in legacy mode only' do
+    assert_xpath %(//p[text()="A 'single quoted string' example"]), render_embedded_string(%(A \\'single quoted string' example), :attributes => {'compat-mode' => 'legacy'})
+    assert_xpath %(//p[text()="'single quoted string'"]), render_embedded_string(%(\\'single quoted string'), :attributes => {'compat-mode' => 'legacy'})
+
+    assert_xpath %(//p[text()="A \\'single quoted string' example"]), render_embedded_string(%(A \\'single quoted string' example))
+    assert_xpath %(//p[text()="\\'single quoted string'"]), render_embedded_string(%(\\'single quoted string'))
+  end
+
   test "emphasized text at end of line" do
-    assert_xpath "//em", render_string("This library is 'awesome'")
+    assert_xpath "//em", render_string("This library is _awesome_")
   end
 
   test "emphasized text at beginning of line" do
-    assert_xpath "//em", render_string("'drop' it")
+    assert_xpath "//em", render_string("_drop_ it")
   end
 
   test "emphasized text across line" do
-    assert_xpath "//em", render_string("'check it'")
+    assert_xpath "//em", render_string("_check it_")
   end
 
   test "unquoted text" do


### PR DESCRIPTION
- disable single quotes as formatting marks for emphasized text
- add compliance method to reenable single quotes as formatting marks
- don't replace trailing single quote with right single smart quote
- introduce `' as the formatting mark to make a right single smart quote
- unescape escaped single quote explicitly
- update compat file for AsciiDoc Python
