### PR TITLE
resolves #888 resolve fallback source language from source-language attribute

### DIFF
--- a/lib/asciidoctor.rb
+++ b/lib/asciidoctor.rb
@@ -279,8 +279,7 @@ module Asciidoctor
     ':===' => [:table, ::Set.new],
     '!===' => [:table, ::Set.new],
     '////' => [:comment, ::Set.new],
-    '```'  => [:fenced_code, ::Set.new],
-    '~~~'  => [:fenced_code, ::Set.new]
+    '```'  => [:fenced_code, ::Set.new]
   }
 
   DELIMITED_BLOCK_LEADERS = DELIMITED_BLOCKS.keys.map {|key| key[0..1] }.to_set

--- a/lib/asciidoctor/converter/docbook5.rb
+++ b/lib/asciidoctor/converter/docbook5.rb
@@ -184,7 +184,7 @@ module Asciidoctor
       listing_attributes = (common_attributes node.id, node.role, node.reftext)
       if node.style == 'source' && (node.attr? 'language')
         numbering = (node.attr? 'linenums') ? 'numbered' : 'unnumbered'
-        listing_content = %(<programlisting#{informal ? listing_attributes : nil} language="#{node.attr 'language'}" linenumbering="#{numbering}">#{node.content}</programlisting>)
+        listing_content = %(<programlisting#{informal ? listing_attributes : nil} language="#{node.attr 'language', nil, false}" linenumbering="#{numbering}">#{node.content}</programlisting>)
       else
         listing_content = %(<screen#{informal ? listing_attributes : nil}>#{node.content}</screen>)
       end

--- a/lib/asciidoctor/converter/html5.rb
+++ b/lib/asciidoctor/converter/html5.rb
@@ -527,9 +527,9 @@ Your browser does not support the audio tag.
     def listing node
       nowrap = !(node.document.attr? 'prewrap') || (node.option? 'nowrap')
       if node.style == 'source'
-        language = node.attr 'language'
+        language = node.attr 'language', nil, false
         language_classes = language ? %(#{language} language-#{language}) : nil
-        case node.attr 'source-highlighter'
+        case node.document.attr 'source-highlighter'
         when 'coderay'
           pre_class = nowrap ? ' class="CodeRay nowrap"' : ' class="CodeRay"'
           code_class = language ? %( class="#{language_classes}") : nil

--- a/lib/asciidoctor/document.rb
+++ b/lib/asciidoctor/document.rb
@@ -664,7 +664,12 @@ class Document < AbstractBlock
       @attributes['toc-position'] ||= default_toc_position if default_toc_position
     end
 
-    @compat_mode = (@attributes['compat-mode'] == 'legacy' ? :legacy : :default)
+    @compat_mode = if @attributes['compat-mode'] == 'legacy'
+      @attributes['source-language'] = @attributes['language'] if @attributes.has_key? 'language'
+      :legacy
+    else
+      :default
+    end
 
     @original_attributes = @attributes.dup
 

--- a/lib/asciidoctor/parser.rb
+++ b/lib/asciidoctor/parser.rb
@@ -820,10 +820,17 @@ class Parser
             if language && !(language = language.strip).empty?
               attributes['language'] = language
               attributes['linenums'] = '' if linenums && !linenums.strip.empty?
+            elsif (default_language = document.attributes['source-language'])
+              attributes['language'] = default_language
             end
             terminator = terminator[0..2]
           elsif block_context == :source
             AttributeList.rekey(attributes, [nil, 'language', 'linenums'])
+            unless attributes.has_key? 'language'
+              if (default_language = document.attributes['source-language'])
+                attributes['language'] = default_language
+              end
+            end
           end
           block = build_block(:listing, :verbatim, terminator, parent, reader, attributes)
 
@@ -962,13 +969,6 @@ class Parser
         tip_3 = (tl == 4 ? tip.chop : tip)
         if tip_3 == '```'
           if tl == 4 && tip.end_with?('`')
-            return
-          end
-          tip = tip_3
-          tl = 3
-          fenced_code = true
-        elsif tip_3 == '~~~'
-          if tl == 4 && tip.end_with?('~')
             return
           end
           tip = tip_3

--- a/lib/asciidoctor/substitutors.rb
+++ b/lib/asciidoctor/substitutors.rb
@@ -1322,12 +1322,12 @@ module Substitutors
 
     case highlighter
     when 'coderay'
-      result = ::CodeRay::Duo[attr('language', :text).to_sym, :html, {
+      result = ::CodeRay::Duo[attr('language', :text, false).to_sym, :html, {
           :css => (@document.attributes['coderay-css'] || :class).to_sym,
           :line_numbers => (linenums_mode = ((attr? 'linenums') ? (@document.attributes['coderay-linenums-mode'] || :table).to_sym : nil)),
           :line_number_anchors => false}].highlight source
     when 'pygments'
-      lexer = ::Pygments::Lexer[attr('language')] || ::Pygments::Lexer['text']
+      lexer = ::Pygments::Lexer[attr('language', nil, false)] || ::Pygments::Lexer['text']
       opts = { :cssclass => 'pyhl', :classprefix => 'tok-', :nobackground => true }
       unless (@document.attributes['pygments-css'] || 'class') == 'class'
         opts[:noclasses] = true

--- a/test/blocks_test.rb
+++ b/test/blocks_test.rb
@@ -1955,19 +1955,6 @@ puts "Hello, World!"
       assert_css '.listingblock pre code', output, 1
       assert_css '.listingblock pre code:not([class])', output, 1
     end
-
-    test 'should support fenced code block using tildes' do
-      input = <<-EOS
-~~~
-puts "Hello, World!"
-~~~
-      EOS
-
-      output = render_embedded_string input
-      assert_css '.listingblock', output, 1
-      assert_css '.listingblock pre code', output, 1
-      assert_css '.listingblock pre code:not([class])', output, 1
-    end
  
     test 'should not recognize fenced code blocks with more than three delimiters' do
       input = <<-EOS
@@ -1990,9 +1977,9 @@ alert("Hello, World!")
 puts "Hello, World!"
 ```
 
-~~~ javascript
+``` javascript
 alert("Hello, World!")
-~~~
+```
       EOS
 
       output = render_embedded_string input
@@ -2007,9 +1994,9 @@ alert("Hello, World!")
 puts "Hello, World!"
 ```
 
-~~~ javascript, numbered
+``` javascript, numbered
 alert("Hello, World!")
-~~~
+```
       EOS
 
       output = render_embedded_string input
@@ -2032,6 +2019,40 @@ html = CodeRay.scan("puts 'Hello, world!'", :ruby).div(:line_numbers => :table)
       output = render_string input, :safe => Asciidoctor::SafeMode::SAFE, :linkcss_default => true
       assert_xpath '//pre[@class="CodeRay"]/code[@class="ruby language-ruby"]//span[@class = "constant"][text() = "CodeRay"]', output, 1
       assert_match(/\.CodeRay \{/, output)
+    end
+
+    test 'should read source language from source-language document attribute if not specified on source block' do
+      input = <<-EOS
+:source-highlighter: coderay
+:source-language: ruby
+
+[source]
+----
+require 'coderay'
+
+html = CodeRay.scan("puts 'Hello, world!'", :ruby).div(:line_numbers => :table)
+----
+      EOS
+      output = render_string input, :safe => Asciidoctor::SafeMode::SAFE, :linkcss_default => true
+      assert_xpath '//pre[@class="CodeRay"]/code[@class="ruby language-ruby"]//span[@class = "constant"][text() = "CodeRay"]', output, 1
+    end
+
+    test 'should rename document attribute named language to source-language when compat-mode is legacy' do
+      input = <<-EOS
+:language: ruby
+
+{source-language}
+      EOS
+
+      assert_equal 'ruby', render_string(input, :doctype => :inline, :attributes => {'compat-mode' => 'legacy'})
+
+      input = <<-EOS
+:language: ruby
+
+{source-language}
+      EOS
+
+      assert_equal '{source-language}', render_string(input, :doctype => :inline)
     end
 
     test 'should replace callout marks but not highlight them if source-highlighter attribute is coderay' do


### PR DESCRIPTION
- resolve fallback source language from source-language document attribute
- map language attribute to source-language in legacy mode
- remove ~~~ form of fenced code block
