### PR TITLE
resolves #1022 \ as line continuation character in attribute value

### DIFF
--- a/lib/asciidoctor.rb
+++ b/lib/asciidoctor.rb
@@ -311,9 +311,12 @@ module Asciidoctor
 
   LIST_CONTINUATION = '+'
 
-  # FIXME technically a preceding TAB is allowed too
-  # alternatively, we can enforce everywhere it must be a space
+  # NOTE AsciiDoc Python recognizes both a preceding TAB and a space
   LINE_BREAK = ' +'
+
+  LINE_CONTINUATION = ' \\'
+
+  LINE_CONTINUATION_LEGACY = ' +'
 
   BLOCK_MATH_DELIMITERS = {
     :asciimath => ['\\$', '\\$'],

--- a/test/attributes_test.rb
+++ b/test/attributes_test.rb
@@ -16,7 +16,7 @@ context 'Attributes' do
       assert_equal nil, doc.attributes['foo']
     end
 
-    test 'creates an attribute by fusing a multi-line value' do
+    test 'creates an attribute by fusing a legacy multi-line value' do
       str = <<-EOS
 :description: This is the first      +
               Ruby implementation of +
@@ -24,6 +24,26 @@ context 'Attributes' do
       EOS
       doc = document_from_string(str)
       assert_equal 'This is the first Ruby implementation of AsciiDoc.', doc.attributes['description']
+    end
+
+    test 'creates an attribute by fusing a multi-line value' do
+      str = <<-EOS
+:description: This is the first \\
+              Ruby implementation of \\
+              AsciiDoc.
+      EOS
+      doc = document_from_string(str)
+      assert_equal 'This is the first Ruby implementation of AsciiDoc.', doc.attributes['description']
+    end
+
+    test 'honors line break characters in multi-line values' do
+      str = <<-EOS
+:signature: Linus Torvalds + \\
+Linux Hacker + \\
+linus.torvalds@example.com
+      EOS
+      doc = document_from_string(str)
+      assert_equal %(Linus Torvalds +\nLinux Hacker +\nlinus.torvalds@example.com), doc.attributes['signature']
     end
 
     test 'should delete an attribute that ends with !' do


### PR DESCRIPTION
- \ as line continuation character in attribute value
- join lines on endline char if preceding line ends with line break sequence
- optimize line continuation parse logic
