### PR TITLE
resolves #684 alias sectnums attribute to numbered attribute

### DIFF
--- a/lib/asciidoctor.rb
+++ b/lib/asciidoctor.rb
@@ -329,8 +329,8 @@ module Asciidoctor
   }
 
   # attributes which be changed within the content of the document (but not
-  # header) because it has semantic meaning; ex. numbered
-  FLEXIBLE_ATTRIBUTES = %w(numbered)
+  # header) because it has semantic meaning; ex. sectnums
+  FLEXIBLE_ATTRIBUTES = %w(sectnums)
 
   # A collection of regular expressions used by the parser.
   #
@@ -476,7 +476,7 @@ module Asciidoctor
     #
     #   :foo: bar
     #   :First Name: Dan
-    #   :numbered!:
+    #   :sectnums!:
     #   :!toc:
     #   :long-entry: Attribute value lines ending in ' +'
     #                are joined together as a single value,

--- a/lib/asciidoctor/cli/options.rb
+++ b/lib/asciidoctor/cli/options.rb
@@ -67,7 +67,7 @@ Example: asciidoctor -b html5 source.asciidoc
             self[:header_footer] = false
           end
           opts.on('-n', '--section-numbers', 'auto-number section titles in the HTML backend; disabled by default') do
-            self[:attributes]['numbered'] = ''
+            self[:attributes]['sectnums'] = ''
           end
           opts.on('-e', '--eruby ERUBY', ['erb', 'erubis'],
                   'specify eRuby implementation to use when rendering custom ERB templates: [erb, erubis] (default: erb)') do |eruby|

--- a/lib/asciidoctor/converter/docbook5.rb
+++ b/lib/asciidoctor/converter/docbook5.rb
@@ -11,7 +11,7 @@ module Asciidoctor
         result << doctype_line
       end
       result << '<?asciidoc-toc?>' if node.attr? 'toc'
-      result << '<?asciidoc-numbered?>' if node.attr? 'numbered'
+      result << '<?asciidoc-numbered?>' if node.attr? 'sectnums'
       lang_attribute = (node.attr? 'nolang') ? nil : %( lang="#{node.attr 'lang', 'en'}")
       result << %(<#{root_tag_name}#{document_ns_attributes node}#{lang_attribute}>)
       result << (document_info_element node, root_tag_name)

--- a/lib/asciidoctor/document.rb
+++ b/lib/asciidoctor/document.rb
@@ -285,6 +285,9 @@ class Document < AbstractBlock
 
     attr_overrides['user-home'] = USER_HOME
 
+    # legacy support for numbered attribute
+    attr_overrides['sectnums'] = attr_overrides.delete 'numbered' if attr_overrides.key? 'numbered'
+
     # if the base_dir option is specified, it overrides docdir as the root for relative paths
     # otherwise, the base_dir is the directory of the source file (docdir) or the current
     # directory of the input is a string
@@ -675,11 +678,11 @@ class Document < AbstractBlock
   # Internal: Branch the attributes so that the original state can be restored
   # at a future time.
   def save_attributes
-    # enable toc and numbered by default in DocBook backend
+    # enable toc and sectnums (i.e., numbered) by default in DocBook backend
     # NOTE the attributes_modified should go away once we have a proper attribute storage & tracking facility
     if @attributes['basebackend'] == 'docbook'
       @attributes['toc'] = '' unless attribute_locked?('toc') || @attributes_modified.include?('toc')
-      @attributes['numbered'] = '' unless attribute_locked?('numbered') || @attributes_modified.include?('numbered')
+      @attributes['sectnums'] = '' unless attribute_locked?('sectnums') || @attributes_modified.include?('sectnums')
     end
 
     unless @attributes.key?('doctitle') || !(val = doctitle)
@@ -736,7 +739,7 @@ class Document < AbstractBlock
       FLEXIBLE_ATTRIBUTES.each do |name|
         # turning a flexible attribute off should be permanent
         # (we may need more config if that's not always the case)
-        if @attribute_overrides.key?(name) && !@attribute_overrides[name].nil?
+        if @attribute_overrides.key?(name) && @attribute_overrides[name]
           @attribute_overrides.delete(name)
         end
       end

--- a/lib/asciidoctor/parser.rb
+++ b/lib/asciidoctor/parser.rb
@@ -1556,7 +1556,7 @@ class Parser
     source_location = reader.cursor if document.sourcemap
     sect_id, sect_reftext, sect_title, sect_level, _ = parse_section_title(reader, document)
     attributes['reftext'] = sect_reftext if sect_reftext
-    section = Section.new parent, sect_level, document.attributes.has_key?('numbered')
+    section = Section.new parent, sect_level, document.attributes.has_key?('sectnums')
     section.source_location = source_location if source_location
     section.id = sect_id
     section.title = sect_title
@@ -2096,16 +2096,21 @@ class Parser
     name = sanitize_attribute_name(name)
     accessible = true
     if doc
+      # alias numbered attribute to sectnums
+      if name == 'numbered'
+        name = 'sectnums'
       # support relative leveloffset values
-      if name == 'leveloffset' && value
-        case value[0..0]
-        when '+'
-          value = ((doc.attr 'leveloffset', 0).to_i + (value[1..-1] || 0).to_i).to_s
-        when '-'
-          value = ((doc.attr 'leveloffset', 0).to_i - (value[1..-1] || 0).to_i).to_s
+      elsif name == 'leveloffset'
+        if value
+          case value[0..0]
+          when '+'
+            value = ((doc.attr 'leveloffset', 0).to_i + (value[1..-1] || 0).to_i).to_s
+          when '-'
+            value = ((doc.attr 'leveloffset', 0).to_i - (value[1..-1] || 0).to_i).to_s
+          end
         end
       end
-      accessible = value.nil? ? doc.delete_attribute(name) : doc.set_attribute(name, value)
+      accessible = value ? doc.set_attribute(name, value) : doc.delete_attribute(name)
     end
 
     if accessible && attrs

--- a/test/document_test.rb
+++ b/test/document_test.rb
@@ -73,21 +73,30 @@ context 'Document' do
       end
     end
 
-    test 'toc and numbered should be enabled by default for DocBook backend' do
+    test 'toc and sectnums should be enabled by default for DocBook backend' do
       doc = empty_document :backend => 'docbook', :parse => true
       assert doc.attr?('toc')
-      assert doc.attr?('numbered')
+      assert doc.attr?('sectnums')
     end
 
-    test 'should be able to disable toc and numbered in document header for DocBook backend' do
+    test 'should be able to disable toc and sectnums in document header for DocBook backend' do
       input = <<-EOS
 = Document Title
 :toc!:
-:numbered!:
+:sectnums!:
       EOS
       doc = document_from_string input, :backend => 'docbook'
       assert !doc.attr?('toc')
-      assert !doc.attr?('numbered')
+      assert !doc.attr?('sectnums')
+    end
+
+    test 'should be able to disable section numbering using numbered attribute in document header for DocBook backend' do
+      input = <<-EOS
+= Document Title
+:numbered!:
+      EOS
+      doc = document_from_string input, :backend => 'docbook'
+      assert !doc.attr?('sectnums')
     end
   end
 
@@ -149,12 +158,12 @@ preamble
 
     test 'should accept attributes as array' do
 	  # NOTE there's a tab character before idseparator
-      doc = Asciidoctor.load('text', :attributes => %w(toc numbered   source-highlighter=coderay idprefix	idseparator=-))
+      doc = Asciidoctor.load('text', :attributes => %w(toc sectnums   source-highlighter=coderay idprefix	idseparator=-))
       assert doc.attributes.is_a?(Hash)
       assert doc.attr?('toc')
       assert_equal '', doc.attr('toc')
-      assert doc.attr?('numbered')
-      assert_equal '', doc.attr('numbered')
+      assert doc.attr?('sectnums')
+      assert_equal '', doc.attr('sectnums')
       assert doc.attr?('source-highlighter')
       assert_equal 'coderay', doc.attr('source-highlighter')
       assert doc.attr?('idprefix')
@@ -170,12 +179,12 @@ preamble
 
     test 'should accept attributes as string' do
 	  # NOTE there's a tab character before idseparator
-      doc = Asciidoctor.load('text', :attributes => 'toc numbered  source-highlighter=coderay idprefix	idseparator=-')
+      doc = Asciidoctor.load('text', :attributes => 'toc sectnums  source-highlighter=coderay idprefix	idseparator=-')
       assert doc.attributes.is_a?(Hash)
       assert doc.attr?('toc')
       assert_equal '', doc.attr('toc')
-      assert doc.attr?('numbered')
-      assert_equal '', doc.attr('numbered')
+      assert doc.attr?('sectnums')
+      assert_equal '', doc.attr('sectnums')
       assert doc.attr?('source-highlighter')
       assert_equal 'coderay', doc.attr('source-highlighter')
       assert doc.attr?('idprefix')
@@ -333,13 +342,13 @@ paragraph
 
     test 'should accept attributes as array' do
       sample_input_path = fixture_path('sample.asciidoc')
-      output = Asciidoctor.convert_file sample_input_path, :attributes => %w(numbered idprefix idseparator=-), :to_file => false
+      output = Asciidoctor.convert_file sample_input_path, :attributes => %w(sectnums idprefix idseparator=-), :to_file => false
       assert_css '#section-a', output, 1
     end
 
     test 'should accept attributes as string' do
       sample_input_path = fixture_path('sample.asciidoc')
-      output = Asciidoctor.convert_file sample_input_path, :attributes => 'numbered idprefix idseparator=-', :to_file => false
+      output = Asciidoctor.convert_file sample_input_path, :attributes => 'sectnums idprefix idseparator=-', :to_file => false
       assert_css '#section-a', output, 1
     end
 

--- a/test/sections_test.rb
+++ b/test/sections_test.rb
@@ -735,6 +735,45 @@ content
       assert_equal '1:1:1', sect1_1_1.sectnum(':', false)
     end
 
+    test 'should render section numbers when sectnums attribute is set' do
+      input = <<-EOS
+= Title
+:sectnums:
+
+== Section_1 
+
+text
+
+=== Section_1_1
+
+text
+
+==== Section_1_1_1
+
+text
+
+== Section_2
+
+text
+
+=== Section_2_1
+
+text
+
+=== Section_2_2
+
+text
+      EOS
+    
+      output = render_string input
+      assert_xpath '//h2[@id="_section_1"][starts-with(text(), "1. ")]', output, 1
+      assert_xpath '//h3[@id="_section_1_1"][starts-with(text(), "1.1. ")]', output, 1
+      assert_xpath '//h4[@id="_section_1_1_1"][starts-with(text(), "1.1.1. ")]', output, 1
+      assert_xpath '//h2[@id="_section_2"][starts-with(text(), "2. ")]', output, 1
+      assert_xpath '//h3[@id="_section_2_1"][starts-with(text(), "2.1. ")]', output, 1
+      assert_xpath '//h3[@id="_section_2_2"][starts-with(text(), "2.2. ")]', output, 1
+    end
+
     test 'should render section numbers when numbered attribute is set' do
       input = <<-EOS
 = Title


### PR DESCRIPTION
- interpret numbered attribute as sectnums
- don't set numbered attribute on document (requires change to backends)
