### PR TITLE
resolves #706 output and style macro toc correctly

### DIFF
--- a/lib/asciidoctor/converter/html5.rb
+++ b/lib/asciidoctor/converter/html5.rb
@@ -135,7 +135,7 @@ MathJax.Hub.Config({
         body_attrs << %(id="#{node.id}")
       end
       if (node.attr? 'toc-class') && (node.attr? 'toc') && (node.attr? 'toc-placement', 'auto')
-        body_attrs << %(class="#{node.doctype} #{node.attr 'toc-class'} toc-#{node.attr 'toc-position', 'left'}")
+        body_attrs << %(class="#{node.doctype} #{node.attr 'toc-class'} toc-#{node.attr 'toc-position', 'header'}")
       else
         body_attrs << %(class="#{node.doctype}")
       end
@@ -801,17 +801,14 @@ Your browser does not support the audio tag.
     end
 
     def toc node
-      return '<!-- toc disabled -->' unless (doc = node.document).attr? 'toc'
+      return '<!-- toc disabled -->' unless (doc = node.document).attr?('toc-placement', 'macro') && doc.attr?('toc')
 
       if node.id
         id_attr = %( id="#{node.id}")
-        title_id_attr = ''
-      elsif doc.embedded? || !(doc.attr? 'toc-placement')
+        title_id_attr = %( id="#{node.id}title")
+      else
         id_attr = ' id="toc"'
         title_id_attr = ' id="toctitle"'
-      else
-        id_attr = nil
-        title_id_attr = nil
       end
       title = node.title? ? node.title : (doc.attr 'toc-title')
       levels = (node.attr? 'levels') ? (node.attr 'levels').to_i : nil

--- a/test/attributes_test.rb
+++ b/test/attributes_test.rb
@@ -283,6 +283,37 @@ content
       node.set_attr 'foo', 'baz'
       assert_equal 'baz', (node.attr 'foo')
     end
+
+    test 'verify toc attribute matrix' do
+      expected_data = <<-EOS
+#attributes                               |toc|toc-position|toc-placement|toc-class
+toc                                       |   |nil         |auto         |nil
+toc=header                                |   |nil         |auto         |nil
+toc=beeboo                                |   |nil         |auto         |nil
+toc=left                                  |   |left        |auto         |toc2
+toc2                                      |   |left        |auto         |toc2
+toc=right                                 |   |right       |auto         |toc2
+toc=preamble                              |   |content     |preamble     |nil
+toc=macro                                 |   |content     |macro        |nil
+toc toc-placement=macro toc-position=left |   |content     |macro        |nil
+toc toc-placement!                        |   |content     |macro        |nil
+      EOS
+
+      expected = expected_data.strip.lines.map {|l|
+        next if l.start_with? '#'
+        l.split('|').map {|e| (e = e.strip) == 'nil' ? nil : e }
+      }.compact
+
+      expected.each do |expect|
+        raw_attrs, toc, toc_position, toc_placement, toc_class = expect
+        attrs = Hash[*(raw_attrs.split ' ').map {|e| e.include?('=') ? e.split('=') : [e, ''] }.flatten]
+        doc = document_from_string '', :attributes => attrs
+        toc ? (assert doc.attr?('toc', toc)) : (assert !doc.attr?('toc')) 
+        toc_position ? (assert doc.attr?('toc-position', toc_position)) : (assert !doc.attr?('toc-position')) 
+        toc_placement ? (assert doc.attr?('toc-placement', toc_placement)) : (assert !doc.attr?('toc-placement')) 
+        toc_class ? (assert doc.attr?('toc-class', toc_class)) : (assert !doc.attr?('toc-class')) 
+      end
+    end
   end
 
   context 'Interpolation' do

--- a/test/sections_test.rb
+++ b/test/sections_test.rb
@@ -1860,10 +1860,10 @@ They couldn't believe their eyes when...
       assert_xpath '//*[@id="header"]//*[@id="toc"]/ul/li[1]/a[@href="#_section_one"][text()="1. Section One"]', output, 1
     end
 
-    test 'should set toc position if toc2 attribute is set to position' do
+    test 'should set toc position if toc attribute is set to position' do
       input = <<-EOS
 = Article
-:toc2: >
+:toc: >
 :numbered:
 
 == Section One
@@ -2020,7 +2020,7 @@ They couldn't believe their eyes when...
       input = <<-EOS
 = Article
 :toc:
-:toc-placement!:
+:toc-placement: macro
 
 Once upon a time...
 
@@ -2044,7 +2044,7 @@ They couldn't believe their eyes when...
       input = <<-EOS
 = Article
 :toc:
-:toc-placement!:
+:toc-placement: macro
 
 Once upon a time...
 
@@ -2064,7 +2064,7 @@ They couldn't believe their eyes when...
       assert_css '#preamble:root .paragraph + #toc', output, 1
     end
 
-    test 'should not assign toc id to more than one toc' do
+    test 'should not activate toc macro if toc-placement is not set' do
       input = <<-EOS
 = Article
 :toc:
@@ -2086,15 +2086,41 @@ They couldn't believe their eyes when...
 
       assert_css '#toc', output, 1
       assert_css '#toctitle', output, 1
-      assert_xpath '(//*[@class="toc"])[2][not(@id)]', output, 1
-      assert_xpath '(//*[@class="toc"])[2]/*[@class="title"][not(@id)]', output, 1
+      assert_css '.toc', output, 1
+      assert_css '#content .toc', output, 0
+    end
+
+    test 'should only output toc at toc macro if toc is macro' do
+      input = <<-EOS
+= Article
+:toc: macro
+
+Once upon a time...
+
+toc::[]
+
+== Section One
+
+It was a dark and stormy night...
+
+== Section Two
+
+They couldn't believe their eyes when...
+      EOS
+
+      output = render_string input
+
+      assert_css '#toc', output, 1
+      assert_css '#toctitle', output, 1
+      assert_css '.toc', output, 1
+      assert_css '#content .toc', output, 1
     end
 
     test 'should use global attributes for toc-title, toc-class and toclevels for toc macro' do
       input = <<-EOS
 = Article
 :toc:
-:toc-placement!:
+:toc-placement: macro
 :toc-title: Contents
 :toc-class: contents
 :toclevels: 1
@@ -2133,7 +2159,7 @@ Fin.
       input = <<-EOS
 = Article
 :toc:
-:toc-placement!:
+:toc-placement: macro
 :toc-title: Ignored
 :toc-class: ignored
 :toclevels: 5


### PR DESCRIPTION
- alias toc2 attribute as toc=left
- deprecate all other uses of toc2 attribute
- allow toc placement to be specified using toc attribute
- only emit macro toc if toc-placement attribute has the value "macro"
- fix tests
- add matrix test for toc-related attribute values
