### PR TITLE
Adds support for ?list= in YouTube URLs

### DIFF
--- a/lib/asciidoctor/converter/html5.rb
+++ b/lib/asciidoctor/converter/html5.rb
@@ -915,9 +915,10 @@ Your browser does not support the audio tag.
         autoplay_param = (node.option? 'autoplay') ? '&amp;autoplay=1' : nil
         loop_param = (node.option? 'loop') ? '&amp;loop=1' : nil
         controls_param = (node.option? 'nocontrols') ? '&amp;controls=0' : nil
+        list_param = (node.attr? 'list') ? "&amp;list=#{node.attr 'list'}" : nil
         %(<div#{id_attribute}#{class_attribute}>#{title_element}
 <div class="content">
-<iframe#{width_attribute}#{height_attribute} src="//www.youtube.com/embed/#{node.attr 'target'}?rel=0#{start_param}#{end_param}#{autoplay_param}#{loop_param}#{controls_param}" frameborder="0"#{(node.option? 'nofullscreen') ? nil : (append_boolean_attribute 'allowfullscreen', xml)}></iframe>
+<iframe#{width_attribute}#{height_attribute} src="//www.youtube.com/embed/#{node.attr 'target'}?rel=0#{start_param}#{end_param}#{autoplay_param}#{loop_param}#{controls_param}#{list_param}" frameborder="0"#{(node.option? 'nofullscreen') ? nil : (append_boolean_attribute 'allowfullscreen', xml)}></iframe>
 </div>
 </div>)
       else 


### PR DESCRIPTION
Adds support for YouTube URLs of the form **//www.youtube.com/embed/foo?list=bar**, where **bar** is a playlist and **foo** is the first video in that playlist to be played. Usage is thus:

```
video::foo[youtube,list=bar]
```

For example, https://www.youtube.com/watch?v=79gAss0K1TI&list=PLhQjrBD2T382Lqs7bsMl6WRDA9anaEzBe could thus be embedded with:

```
video::79gAss0K1TI[youtube,height=315,list=PLhQjrBD2T382Lqs7bsMl6WRDA9anaEzBe,width=560]
```

which would yield:

```
<iframe width="560" height="315" src="//www.youtube.com/embed/79gAss0K1TI?rel=0&list=PLhQjrBD2T382Lqs7bsMl6WRDA9anaEzBe" frameborder="0" allowfullscreen></iframe>
```
