### PR TITLE
Use badges from shields.io in README

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -63,7 +63,7 @@ Asciidoctor.js is used to power the AsciiDoc preview extensions for Chrome, Atom
 ====
 
 ifdef::env-github[]
-*Project health:* http://img.shields.io/travis/asciidoctor/asciidoctor/master.svg[Build Status, link="https://travis-ci.org/asciidoctor/asciidoctor"] image:http://img.shields.io/coveralls/asciidoctor/asciidoctor/master.svg["Coverage Status", link="https://coveralls.io/r/asciidoctor/asciidoctor"]
+*Project health:* image:http://img.shields.io/travis/asciidoctor/asciidoctor/master.svg[Build Status, link="https://travis-ci.org/asciidoctor/asciidoctor"] image:http://img.shields.io/coveralls/asciidoctor/asciidoctor/master.svg["Coverage Status", link="https://coveralls.io/r/asciidoctor/asciidoctor"]
 endif::env-github[]
 
 == The Big Picture


### PR DESCRIPTION
I've found that the badges provided by shields.io look much better than the default ones provided by Travis, Coveralls and other services.
A badge for Coveralls was also added.
