### PR TITLE
added Prism.js syntax highlighting option

### DIFF
--- a/lib/asciidoctor/converter/html5.rb
+++ b/lib/asciidoctor/converter/html5.rb
@@ -547,7 +547,7 @@ Your browser does not support the audio tag.
           pre_class = %( class="CodeRay highlight#{nowrap ? ' nowrap' : nil}")
         when 'pygments'
           pre_class = %( class="pygments highlight#{nowrap ? ' nowrap' : nil}")
-        when 'highlightjs', 'highlight.js'
+        when 'highlight.js', 'prism.js'
           pre_class = %( class="highlightjs highlight#{nowrap ? ' nowrap' : nil}")
           code_attrs = %( class="language-#{language}"#{code_attrs}) if language
         when 'prettify'


### PR DESCRIPTION
I'd like to add some test coverage for this but I couldn't find where the existing highlighting is tested other than a check of the JS / CSS includes for highlight.js in blocks_test.rb
