### PR TITLE
DocBook manpage improvements

### DIFF
--- a/lib/asciidoctor/converter/docbook5.rb
+++ b/lib/asciidoctor/converter/docbook5.rb
@@ -47,8 +47,12 @@ module Asciidoctor
       else
         doctype == 'book' && node.level <= 1 ? (node.level == 0 ? 'part' : 'chapter') : 'section'
       end
-      if doctype == 'manpage' && tag_name.start_with?('sect')
-        tag_name = 'ref' + tag_name
+      if doctype == 'manpage'
+        if tag_name.start_with?('sect')
+          tag_name = 'ref' + tag_name
+        elsif tag_name == 'synopsis'
+          tag_name = 'refsynopsisdiv'
+        end
       end
       %(<#{tag_name}#{common_attributes node.id, node.role, node.reftext}>
 <title>#{node.title}</title>

--- a/test/document_test.rb
+++ b/test/document_test.rb
@@ -1455,6 +1455,10 @@ section body
 
 asciidoctor(1) - Process text
 
+== SYNOPSIS
+
+some text
+
 == First Section
 
 section body
@@ -1466,6 +1470,8 @@ section body
       assert_xpath '/refentry/refmeta/manvolnum[text() = "1"]', result, 1
       assert_xpath '/refentry/refnamediv/refname[text() = "asciidoctor"]', result, 1
       assert_xpath '/refentry/refnamediv/refpurpose[text() = "Process text"]', result, 1
+      assert_xpath '/refentry/refsynopsisdiv', result, 1
+      assert_xpath '/refentry/refsynopsisdiv/simpara[text() = "some text"]', result, 1
       assert_xpath '/refentry/refsection', result, 1
       assert_xpath '/refentry/refsection[@id = "_first_section"]/title[text() = "First Section"]', result, 1
       assert_xpath '/refentry/refsection[@id = "_first_section"]/simpara[text() = "section body"]', result, 1
@@ -1553,6 +1559,10 @@ section body
 
 asciidoctor(1) - Process text
 
+== SYNOPSIS
+
+some text
+
 == First Section
 
 section body
@@ -1568,6 +1578,8 @@ section body
       assert_xpath '/xmlns:refentry/xmlns:refmeta/xmlns:manvolnum[text() = "1"]', result, 1
       assert_xpath '/xmlns:refentry/xmlns:refnamediv/xmlns:refname[text() = "asciidoctor"]', result, 1
       assert_xpath '/xmlns:refentry/xmlns:refnamediv/xmlns:refpurpose[text() = "Process text"]', result, 1
+      assert_xpath '/xmlns:refentry/xmlns:refsynopsisdiv', result, 1
+      assert_xpath '/xmlns:refentry/xmlns:refsynopsisdiv/xmlns:simpara[text() = "some text"]', result, 1
       assert_xpath '/xmlns:refentry/xmlns:refsection', result, 1
       section = xmlnodes_at_xpath('/xmlns:refentry/xmlns:refsection', result, 1).first
       # nokogiri can't make up its mind


### PR DESCRIPTION
The DocBook code for generating manpages contained a few bugs. Probably for historical reasons, DocBook requires manpages (refentry documents) to use `refsection` instead of `section` (and `refsect1` instead of `sect1`, etc.). Also, the block element holding the synopsis section should be `refsynopsisdiv`.

Finally, man pages require some additional metadata in the `refmeta` and `refnamediv` elements immediately after the main document's `info` block. Without these, the DocBook stylesheets won't be able to determine the manpage name and section, and will try to output to a file called `.1`.

This is the minimal amount of changes required on the Asciidoctor side to build Git using Asciidoctor instead of AsciiDoc. I will be sending a patch series to the Git list to fix up the Git side of things.
