### PR TITLE
Include Slim helpers in the template's execution scope

### DIFF
--- a/lib/asciidoctor/converter/template.rb
+++ b/lib/asciidoctor/converter/template.rb
@@ -173,6 +173,13 @@ module Asciidoctor
       unless (template = @templates[template_name])
         raise %(Could not find a custom template to handle transform: #{template_name})
       end
+
+      # Slim doesn't include helpers in the template's execution scope such as
+      # HAML, so we must do it ourselves.
+      if defined?(::Slim::Helpers) && template.is_a?(::Slim::Template)
+        node.extend ::Slim::Helpers
+      end
+
       if template_name == 'document'
         (template.render node).strip
       else


### PR DESCRIPTION
Slim doesn’t include helpers in the template’s execution scope such as HAML, so we must do it ourselves. The approach used in this PR is similar to HAML (see [there](https://github.com/haml/haml/blob/4.0.5/lib/haml/engine.rb#L124-L127)), but simpler and way more efficient.

This patch allows to:
- use helper methods in Slim templates without inconvenient `Helpers.` prefix,
- access node’s variables and methods inside helper methods.

For example it allows to write helpers like:

``` ruby
module Asciidoctor::SlimHelpers

  def section_level
    (@level == 0 && @special) ? 1 : @level
  end

  def section_numbered?
    sectnumlevels = (@document.attr :sectnumlevels, 3).to_i
    @numbered && @caption.nil? && section_level <= sectnumlevels
  end
end
```
