### PR TITLE
resolves #1144 fix includes that reference absolute Windows paths

### DIFF
--- a/lib/asciidoctor.rb
+++ b/lib/asciidoctor.rb
@@ -1078,7 +1078,9 @@ module Asciidoctor
     #   https://domain
     #   data:info
     #
-    UriSniffRx = %r{^#{CG_ALPHA}[#{CC_ALNUM}.+-]*:/{0,2}}
+    #   not c:/sample.adoc or c:\sample.adoc
+    #
+    UriSniffRx = %r{^#{CG_ALPHA}[#{CC_ALNUM}.+-]+:/{0,2}}
 
     # Detects the end of an implicit URI in the text
     #

--- a/test/paths_test.rb
+++ b/test/paths_test.rb
@@ -227,5 +227,16 @@ context 'Path Resolver' do
       assert_equal 'master', Asciidoctor::Helpers.rootname('master')
       assert_equal 'docs/master', Asciidoctor::Helpers.rootname('docs/master')
     end
+
+    test 'UriSniffRx should detect URIs' do
+      assert Asciidoctor::UriSniffRx =~ 'http://example.com'
+      assert Asciidoctor::UriSniffRx =~ 'https://example.com'
+      assert Asciidoctor::UriSniffRx =~ 'data:image/gif;base64,R0lGODlhAQABAIAAAAUEBAAAACwAAAAAAQABAAACAkQBADs='
+    end
+
+    test 'UriSniffRx should not detect an absolute Windows path as a URI' do
+      assert Asciidoctor::UriSniffRx !~ 'c:/sample.adoc'
+      assert Asciidoctor::UriSniffRx !~ 'c:\\sample.adoc'
+    end
   end
 end

--- a/test/reader_test.rb
+++ b/test/reader_test.rb
@@ -613,6 +613,19 @@ include::fixtures/no-such-file.adoc[]
           flunk 'include directive should not raise exception on missing file'
         end
       end
+
+      # IMPORTANT this test needs to be run on Windows to verify proper behavior in Windows
+      test 'can resolve include directive with absolute path' do
+        include_path = ::File.join DIRNAME, 'fixtures', 'chapter-a.adoc'
+        input = <<-EOS
+include::#{include_path}[]
+        EOS
+        result = document_from_string input, :safe => :safe
+        assert_equal 'Chapter A', result.doctitle
+
+        result = document_from_string input, :safe => :unsafe, :base_dir => ::Dir.tmpdir
+        assert_equal 'Chapter A', result.doctitle
+      end
   
       test 'include directive can retrieve data from uri' do
         #url = 'http://echo.jsontest.com/name/asciidoctor'

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -10,6 +10,7 @@ require File.join(ASCIIDOCTOR_PROJECT_DIR, 'lib', 'asciidoctor')
 require 'minitest/autorun'
 require 'socket'
 require 'nokogiri'
+require 'tmpdir'
 
 autoload :FileUtils, 'fileutils'
 autoload :Pathname,  'pathname'


### PR DESCRIPTION
- fix support for absolute Windows path as target of include directive
- add test for include directive with absolute path target
- add tests for UriSniffRx
