### PR TITLE
resolves #1127 add key documentation links to README

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -42,12 +42,11 @@ endif::[]
 :uri-freesoftware: https://www.gnu.org/philosophy/free-sw.html
 :uri-foundation: http://foundation.zurb.com
 :uri-tilt: https://github.com/rtomayko/tilt
-:uri-ruby: https://ruby-lang.org
 // images:
 :image-uri-screenshot: https://raw.githubusercontent.com/asciidoctor/asciidoctor/master/screenshot.png
 
 {uri-project}[Asciidoctor] is a _fast_ text processor and publishing toolchain for converting {uri-what-is-asciidoc}[AsciiDoc] content to HTML5, DocBook 5 (or 4.5) and other formats.
-Asciidoctor is written in {uri-ruby}[Ruby], packaged as a RubyGem and published to {uri-rubygem}[RubyGems.org].
+Asciidoctor is written in Ruby, packaged as a RubyGem and published to {uri-rubygem}[RubyGems.org].
 The gem is also included in several Linux distributions, including Fedora, Debian and Ubuntu.
 Asciidoctor is open source, {uri-repo}[hosted on GitHub] and released under the MIT license.
 
@@ -62,8 +61,16 @@ We use http://opalrb.org[Opal] to transcompile the Ruby source to JavaScript to 
 Asciidoctor.js is used to power the AsciiDoc preview extensions for Chrome, Atom, Brackets and other web-based tooling.
 ====
 
+.Key documentation
+[square]
+* {uri-docs}/what-is-asciidoc[What is Asciidoc?]
+* {uri-docs}/asciidoc-writers-guide[AsciiDoc Writer's Guide]
+* {uri-docs}/asciidoc-syntax-quick-reference[AsciiDoc Syntax Reference]
+* {uri-docs}/user-manual[Asciidoctor User Manual]
+
 ifdef::env-github[]
-*Project health:* image:http://img.shields.io/travis/asciidoctor/asciidoctor/master.svg[Build Status, link="https://travis-ci.org/asciidoctor/asciidoctor"] image:http://img.shields.io/coveralls/asciidoctor/asciidoctor/master.svg["Coverage Status", link="https://coveralls.io/r/asciidoctor/asciidoctor"]
+.*Project Health*
+image:http://img.shields.io/travis/asciidoctor/asciidoctor/master.svg[Build Status, link=https://travis-ci.org/asciidoctor/asciidoctor] image:http://img.shields.io/coveralls/asciidoctor/asciidoctor/master.svg[Coverage Status, link=https://coveralls.io/r/asciidoctor/asciidoctor]
 endif::env-github[]
 
 == The Big Picture


### PR DESCRIPTION
- also adds them to asciidoctor.org home page
