### PR TITLE
resolves #1068 make line comment before callout number configurable

### DIFF
--- a/lib/asciidoctor.rb
+++ b/lib/asciidoctor.rb
@@ -735,15 +735,18 @@ module Asciidoctor
     # Matches a callout reference inside literal text.
     # 
     # Examples
-    #   <1> (optionally prefixed by //, # or ;; line comment chars)
+    #   <1> (optionally prefixed by //, #, -- or ;; line comment chars)
     #   <1> <2> (multiple callouts on one line)
     #   <!--1--> (for XML-based languages)
     #
-    # NOTE special characters are already be replaced at this point during conversion to an SGML format
-    CalloutConvertRx = /(?:(?:\/\/|#|;;) ?)?(\\)?&lt;!?(--|)(\d+)\2&gt;(?=(?: ?\\?&lt;!?\2\d+\2&gt;)*#{CC_EOL})/
-    # NOTE (con't) ...but not while scanning
+    # NOTE extract regexps are applied line-by-line, so we can use $ as end-of-line char
+    CalloutExtractRx = /(?:(?:\/\/|#|--|;;) ?)?(\\)?<!?(--|)(\d+)\2>(?=(?: ?\\?<!?\2\d+\2>)*$)/
+    CalloutExtractRxt = "(\\\\)?<()(\\d+)>(?=(?: ?\\\\?<\\d+>)*$)"
+    # NOTE special characters have not been replaced when scanning
     CalloutQuickScanRx = /\\?<!?(--|)(\d+)\1>(?=(?: ?\\?<!?\1\d+\1>)*#{CC_EOL})/
-    CalloutScanRx = /(?:(?:\/\/|#|;;) ?)?(\\)?<!?(--|)(\d+)\2>(?=(?: ?\\?<!?\2\d+\2>)*#{CC_EOL})/
+    # NOTE special characters have already been replaced when converting to an SGML format
+    CalloutSourceRx = /(?:(?:\/\/|#|--|;;) ?)?(\\)?&lt;!?(--|)(\d+)\2&gt;(?=(?: ?\\?&lt;!?\2\d+\2&gt;)*#{CC_EOL})/
+    CalloutSourceRxt = "(\\\\)?&lt;()(\\d+)&gt;(?=(?: ?\\\\?&lt;\\d+&gt;)*#{CC_EOL})"
 
     # A Hash of regexps for lists used for dynamic access.
     ListRxMap = {

--- a/lib/asciidoctor/parser.rb
+++ b/lib/asciidoctor/parser.rb
@@ -938,7 +938,7 @@ class Parser
 
       if block.sub? :callouts
         unless (catalog_callouts block.source, document)
-          # No need to look for callouts if they aren't there
+          # No need to sub callouts if they aren't there
           block.remove_sub :callouts
         end
       end

--- a/lib/asciidoctor/substitutors.rb
+++ b/lib/asciidoctor/substitutors.rb
@@ -1105,13 +1105,15 @@ module Substitutors
     text
   end
 
-  # Public: Substitute callout references
+  # Public: Substitute callout source references
   #
   # text - The String text to process
   #
   # Returns the converted String text
   def sub_callouts(text)
-    text.gsub(CalloutConvertRx) {
+    # FIXME cache this dynamic regex
+    callout_rx = (attr? 'line-comment') ? /(?:#{::Regexp.escape(attr 'line-comment')} )?#{CalloutSourceRxt}/ : CalloutSourceRx
+    text.gsub(callout_rx) {
       # alias match for Ruby 1.8.7 compat
       m = $~
       # honor the escape
@@ -1401,10 +1403,12 @@ module Substitutors
     if process_callouts
       callout_marks = {}
       last = -1
+      # FIXME cache this dynamic regex
+      callout_rx = (attr? 'line-comment') ? /(?:#{::Regexp.escape(attr 'line-comment')} )?#{CalloutExtractRxt}/ : CalloutExtractRx
       # extract callout marks, indexed by line number
       source = source.split(EOL).map {|line|
         lineno = lineno + 1
-        line.gsub(CalloutScanRx) {
+        line.gsub(callout_rx) {
           # alias match for Ruby 1.8.7 compat
           m = $~
           # honor the escape


### PR DESCRIPTION
- make line comment before callout number configurable
- add -- as built-in line comment to support Haskell, SQL, Ada, etc.
- add more tests for stripping line comment preceding callout number
