### PR TITLE
Remove webkitAllowFullScreen and mozallowfullscreen from block_video

### DIFF
--- a/lib/asciidoctor/converter/html5.rb
+++ b/lib/asciidoctor/converter/html5.rb
@@ -912,7 +912,7 @@ Your browser does not support the audio tag.
         loop_param = (node.option? 'loop') ? "#{delimiter}loop=1" : nil
         %(<div#{id_attribute}#{class_attribute}>#{title_element}
 <div class="content">
-<iframe#{width_attribute}#{height_attribute} src="//player.vimeo.com/video/#{node.attr 'target'}#{start_anchor}#{autoplay_param}#{loop_param}" frameborder="0"#{append_boolean_attribute 'webkitAllowFullScreen', xml}#{append_boolean_attribute 'mozallowfullscreen', xml}#{append_boolean_attribute 'allowFullScreen', xml}></iframe>
+<iframe#{width_attribute}#{height_attribute} src="//player.vimeo.com/video/#{node.attr 'target'}#{start_anchor}#{autoplay_param}#{loop_param}" frameborder="0"#{(node.option? 'nofullscreen') ? nil : (append_boolean_attribute 'allowfullscreen', xml)}></iframe>
 </div>
 </div>)
       when 'youtube'


### PR DESCRIPTION
These attributes are already deprecated and not needed since [Firefox 18](https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Releases/18?redirectlocale=en-US&redirectslug=Firefox_18_for_developers#HTML) and [Chrome/Chromium 27](https://bugs.webkit.org/show_bug.cgi?id=110374).
