### PR TITLE
Delegate convert_with_options to convert method

### DIFF
--- a/lib/asciidoctor/converter.rb
+++ b/lib/asciidoctor/converter.rb
@@ -160,9 +160,9 @@ module Asciidoctor
     end
 =end
 
-    # Public: Converts an {AbstractNode} using the specified transform. If a
-    # transform is not specified, implementations typically derive one from the
-    # {AbstractNode#node_name} property.
+    # Public: Converts an {AbstractNode} using the specified transform along
+    # with additional options. If a transform is not specified, implementations
+    # typically derive one from the {AbstractNode#node_name} property.
     #
     # Implementations are free to decide how to carry out the conversion. In
     # the case of the built-in converters, the tranform value is used to
@@ -174,29 +174,16 @@ module Asciidoctor
     #             should be applied to this node. If a transform is not specified,
     #             the transform is typically derived from the value of the
     #             node's node_name property. (optional, default: nil)
+    # opts      - An optional Hash of options that provide additional hints about
+    #             how to convert the node. (optional, default: {})
     #
     # Returns the [String] result
-    def convert node, transform = nil
+    def convert node, transform = nil, opts = {}
       raise ::NotImplementedError
     end
 
-    # Public: Converts an {AbstractNode} using the specified transform along
-    # with additional options. Delegates to {#convert} without options by default.
-    # Used by the template-based converter to delegate to the converter for outline.
-    # (see https://github.com/asciidoctor/asciidoctor-backends/blob/master/slim/html5/block_toc.html.slim#L11)
-    #
-    # node      - The concrete instance of AbstractNode to convert
-    # transform - An optional String transform that hints at which transformation
-    #             should be applied to this node. If a transform is not specified,
-    #             the transform is typically derived from the value of the
-    #             node's node_name property. (optional, default: nil)
-    # opts      - An optional Hash of options that provide additional hints about
-    #             how to convert the node.
-    #
-    # Returns the [String] result
-    def convert_with_options node, transform = nil, opts = {}
-      convert node, transform
-    end
+    # Alias for backward compatibility.
+    alias :convert_with_options :convert
   end
 
   # A module that can be used to mix the {#write} method into a {Converter}

--- a/lib/asciidoctor/converter/base.rb
+++ b/lib/asciidoctor/converter/base.rb
@@ -16,25 +16,25 @@ module Asciidoctor
     def initialize backend, opts = {}
     end
 
-    # Public: Converts the specified {AbstractNode} using the specified transform.
+    # Public: Converts the specified {AbstractNode} using the specified
+    # transform and optionally additional options (when not empty).
+    #
+    # Note: Method that handles the specified transform *may not* accept the
+    # second argument with additional options. In this case the {ArgumentError}
+    # is raised when the given +opts+ Hash is not empty.
+    # The additional options are currently used only in template-based
+    # converters to render outline node.
     #
     # See {Converter#convert} for more details.
     #
     # Returns the [String] result of conversion
-    def convert node, transform = nil
+    def convert node, transform = nil, opts = {}
       transform ||= node.node_name
-      send transform, node
-    end
-
-    # Public: Converts the specified {AbstractNode} using the specified transform 
-    # with additional options.
-    #
-    # See {Converter#convert_with_options} for more details.
-    #
-    # Returns the [String] result of conversion
-    def convert_with_options node, transform = nil, opts = {}
-      transform ||= node.node_name
-      send transform, node, opts
+      if opts.empty?
+        send transform, node
+      else
+        send transform, node, opts
+      end
     end
 
     alias :handles? :respond_to?

--- a/lib/asciidoctor/converter/composite.rb
+++ b/lib/asciidoctor/converter/composite.rb
@@ -16,33 +16,19 @@ module Asciidoctor
     end
 
     # Public: Delegates to the first converter that identifies itself as the
-    # handler for the given transform.
-    #
-    # node      - the AbstractNode to convert
-    # transform - the optional String transform, or the name of the node if no
-    #             transform is specified. (default: nil)
-    #
-    # Returns the String result returned from the delegate's convert method
-    def convert node, transform = nil
-      transform ||= node.node_name
-      # QUESTION is there a way we can control whether to use convert or send?
-      (converter_for transform).convert node, transform
-    end
-
-    # Public: Delegates to the first converter that identifies itself as the
     # handler for the given transform. The optional Hash is passed as the last
     # option to the delegate's convert method.
     #
     # node      - the AbstractNode to convert
     # transform - the optional String transform, or the name of the node if no
     #             transform is specified. (default: nil)
-    # opts      - a optional Hash that is passed to the delegate's convert method. (default: {})
+    # opts      - an optional Hash that is passed to the delegate's convert method. (default: {})
     #
     # Returns the String result returned from the delegate's convert method
-    def convert_with_options node, transform = nil, opts = {}
+    def convert node, transform = nil, opts = {}
       transform ||= node.node_name
-      # QUESTION should we check arity, or perhaps do a rescue ::ArgumentError?
-      (converter_for transform).convert_with_options node, transform, opts
+      # QUESTION is there a way we can control whether to use convert or send?
+      (converter_for transform).convert node, transform, opts
     end
 
     # Public: Retrieve the converter for the specified transform.

--- a/lib/asciidoctor/converter/template.rb
+++ b/lib/asciidoctor/converter/template.rb
@@ -166,9 +166,11 @@ module Asciidoctor
     # template_name - the String name of the template to use, or the value of
     #                 the node_name property on the node if a template name is
     #                 not specified. (optional, default: nil)
+    # opts          - an optional Hash that is passed as local variables to the
+    #                 template. (optional, default: {})
     #
     # Returns the [String] result from rendering the template
-    def convert node, template_name = nil
+    def convert node, template_name = nil, opts = {}
       template_name ||= node.node_name
       unless (template = @templates[template_name])
         raise %(Could not find a custom template to handle transform: #{template_name})
@@ -181,32 +183,10 @@ module Asciidoctor
       end
 
       if template_name == 'document'
-        (template.render node).strip
+        (template.render node, opts).strip
       else
-        (template.render node).chomp
+        (template.render node, opts).chomp
       end
-    end
-
-    # Public: Convert an {AbstractNode} using the named template with the
-    # additional options provided.
-    #
-    # Looks for a template that matches the value of the
-    # {AbstractNode#node_name} property if a template name is not specified.
-    #
-    # node          - the AbstractNode to convert
-    # template_name - the String name of the template to use, or the value of
-    #                 the node_name property on the node if a template name is
-    #                 not specified. (optional, default: nil)
-    # opts          - an optional Hash that is passed as local variables to the
-    #                 template. (optional, default: {})
-    #
-    # Returns the [String] result from rendering the template
-    def convert_with_options node, template_name = nil, opts = {}
-      template_name ||= node.node_name
-      unless (template = @templates[template_name])
-        raise %(Could not find a custom template to handle transform: #{template_name})
-      end
-      (template.render node, opts).chomp
     end
 
     # Public: Checks whether there is a Tilt template registered with the specified name.


### PR DESCRIPTION
There’s the change that we’ve discussed in [this](https://github.com/asciidoctor/asciidoctor/commit/d98c8e9cd5e5793fdab6da7a0a6f37eb8349878b#commitcomment-8359933) thread. I’ve run userguide-loop and mdbasics-loop benchmarks on MRI 2.1.2 and there’s no statistically significant difference in performance.
### Before

**userguide-loop (50x):**
Run Total: 19.358426
Best Time: 0.343773

**mdbasics-loop (50x):**
Run Total: 19.917844
Best Time: 0.346665
### After

**userguide-loop (50x):**
Run Total: 19.375733
Best Time: 0.339852

**mdbasics-loop (50x):**
Run Total: 19.79033
Best Time: 0.349473

Should I run some other benchmarks on it?
