### PR TITLE
resolves #1105 support custom YouTube playlists

### DIFF
--- a/test/blocks_test.rb
+++ b/test/blocks_test.rb
@@ -1812,12 +1812,24 @@ video::67480300[vimeo, 400, 300, start=60, options=autoplay]
 
     test 'video macro should output custom HTML with iframe for youtube service' do
       input = <<-EOS
-video::U8GBXvdmHT4/PLg7s6cbtAD15Das5LK9mXt_g59DLWxKUe[youtube, 640, 360, start=60, options=autoplay]
+video::U8GBXvdmHT4/PLg7s6cbtAD15Das5LK9mXt_g59DLWxKUe[youtube, 640, 360, start=60, options="autoplay,modest", theme=light]
       EOS
       output = render_embedded_string input
       assert_css 'video', output, 0
       assert_css 'iframe', output, 1
-      assert_css 'iframe[src="//www.youtube.com/embed/U8GBXvdmHT4?rel=0&start=60&autoplay=1&list=PLg7s6cbtAD15Das5LK9mXt_g59DLWxKUe"]', output, 1
+      assert_css 'iframe[src="//www.youtube.com/embed/U8GBXvdmHT4?rel=0&start=60&autoplay=1&list=PLg7s6cbtAD15Das5LK9mXt_g59DLWxKUe&modestbranding=1&theme=light"]', output, 1
+      assert_css 'iframe[width="640"]', output, 1
+      assert_css 'iframe[height="360"]', output, 1
+    end
+
+    test 'video macro should output custom HTML with iframe for youtube service with dynamic playlist' do
+      input = <<-EOS
+video::SCZF6I-Rc4I,AsKGOeonbIs,HwrPhOp6-aM[youtube, 640, 360, start=60, options=autoplay]
+      EOS
+      output = render_embedded_string input
+      assert_css 'video', output, 0
+      assert_css 'iframe', output, 1
+      assert_css 'iframe[src="//www.youtube.com/embed/SCZF6I-Rc4I?rel=0&start=60&autoplay=1&playlist=AsKGOeonbIs,HwrPhOp6-aM"]', output, 1
       assert_css 'iframe[width="640"]', output, 1
       assert_css 'iframe[height="360"]', output, 1
     end


### PR DESCRIPTION
- build custom playlist from comma-separated target on video macro
- add test for custom playlist
- fix fullscreen settings for HTML5 player
- add modest option to enable modestbranding param
- add theme attribute to control theme param
- add hl param if lang attribute is set on macro or document
- add relative option to control rel param
- don't bubble start and end attributes
- cleanup some logic in the video convert method
- remove trailing whitespace from html5 converter file
