### PR TITLE
enable CI reports

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ pkg/
 /.ruby-version
 /.yardoc/
 /rdoc/
+/shippable/

--- a/.simplecov
+++ b/.simplecov
@@ -1,0 +1,11 @@
+SimpleCov.start do
+  load_profile 'test_frameworks'
+  coverage_dir ENV['COVERAGE_REPORTS'] || 'tmp/coverage'
+  if ENV['SHIPPABLE']
+    require 'simplecov-csv'
+    formatter SimpleCov::Formatter::CSVFormatter
+  else
+    #formatter SimpleCov::Formatter::MultiFormatter[SimpleCov::Formatter::HTMLFormatter, SimpleCov::Formatter::CSVFormatter]
+    formatter SimpleCov::Formatter::HTMLFormatter
+  end
+end

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,11 +4,11 @@ rvm:
   - 2.0.0
   - 1.9.3
   - 1.8.7
-  - jruby-18mode
-  - jruby-19mode
   - jruby-head
+  - jruby-19mode
+  - jruby-18mode
   - rbx-2
-script: rake test:all
+script: rake coverage test:all
 notifications:
   email: false
-  irc: "irc.freenode.org#asciidoctor"
+  irc: 'irc.freenode.org#asciidoctor'

--- a/Gemfile
+++ b/Gemfile
@@ -11,3 +11,13 @@ gemspec
 #  gem 'libnotify'
 #  gem 'listen', :github => 'guard/listen'
 #end
+
+group :ci do
+  gem 'simplecov', '~> 0.9.1'
+  if ENV['SHIPPABLE']
+    gem 'simplecov-csv', '~> 0.1.3'
+    gem 'ci_reporter', '~> 2.0.0'
+    gem 'ci_reporter_minitest', '~> 1.0.0'
+    #gem 'ci_reporter_cucumber', '~> 1.0.0'
+  end
+end

--- a/Rakefile
+++ b/Rakefile
@@ -19,7 +19,7 @@ begin
   require 'rake/testtask'
   Rake::TestTask.new(:test) do |test|
     prepare_test_env
-    puts "LANG: #{ENV['LANG']}"
+    puts %(LANG: #{ENV['LANG']})
     test.libs << 'test'
     test.pattern = 'test/**/*_test.rb'
     test.verbose = true
@@ -50,6 +50,27 @@ begin
   Cucumber::Rake::Task.new(:features) do |t|
   end
 rescue LoadError
+end
+
+def ci_setup_tasks
+  tasks = []
+  begin
+    require 'ci/reporter/rake/minitest'
+    tasks << 'ci:setup:minitest'
+    # FIXME reporter for Cucumber tests not activating
+    #require 'ci/reporter/rake/cucumber'
+    #tasks << 'ci:setup:cucumber'
+  rescue LoadError
+  end if ENV['SHIPPABLE'] && RUBY_VERSION >= '1.9.3'
+  tasks
+end
+
+desc 'Activates coverage and JUnit-style XML reports for tests'
+task :coverage => ci_setup_tasks do
+  # exclude coverage run for Ruby 1.8.7 or (disabled) if running on Travis CI
+  ENV['COVERAGE'] = 'true' if RUBY_VERSION >= '1.9.3' # && (ENV['SHIPPABLE'] || !ENV['TRAVIS_BUILD_ID'])
+  ENV['CI_REPORTS'] = 'shippable/testresults'
+  ENV['COVERAGE_REPORTS'] = 'shippable/codecoverage'
 end
 
 namespace :test do

--- a/features/step_definitions.rb
+++ b/features/step_definitions.rb
@@ -1,4 +1,14 @@
-require "#{File.dirname __FILE__}/../lib/asciidoctor"
+ASCIIDOCTOR_PROJECT_DIR = File.dirname File.dirname(__FILE__)
+Dir.chdir ASCIIDOCTOR_PROJECT_DIR
+
+if RUBY_VERSION < '1.9'
+  require 'rubygems'
+end
+
+require 'simplecov' if ENV['COVERAGE'] == 'true'
+
+require File.join(ASCIIDOCTOR_PROJECT_DIR, 'lib', 'asciidoctor')
+
 require 'rspec/expectations'
 require 'tilt'
 require 'slim'

--- a/lib/asciidoctor/abstract_node.rb
+++ b/lib/asciidoctor/abstract_node.rb
@@ -59,14 +59,18 @@ class AbstractNode
   #
   # Returns [Boolean]
   def inline?
+    # :nocov:
     raise ::NotImplementedError
+    # :nocov:
   end
 
   # Public: Returns whether this {AbstractNode} is an instance of {Block}
   #
   # Returns [Boolean]
   def block?
+    # :nocov:
     raise ::NotImplementedError
+    # :nocov:
   end
 
   # Public: Get the value of the specified attribute

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -5,6 +5,8 @@ if RUBY_VERSION < '1.9'
   require 'rubygems'
 end
 
+require 'simplecov' if ENV['COVERAGE'] == 'true'
+
 require File.join(ASCIIDOCTOR_PROJECT_DIR, 'lib', 'asciidoctor')
 
 require 'minitest/autorun'


### PR DESCRIPTION
enable CI reports
- code coverage (locally & for shippable.com builds) (use `rake coverage test:all`)
- JUnit-style XML reports (for shippable.com builds)
