### PR TITLE
resolves #1192 preserve URI targets universally

### DIFF
--- a/lib/asciidoctor.rb
+++ b/lib/asciidoctor.rb
@@ -1082,6 +1082,7 @@ module Asciidoctor
     # Examples
     #   http://domain
     #   https://domain
+    #   file:///path
     #   data:info
     #
     #   not c:/sample.adoc or c:\sample.adoc

--- a/lib/asciidoctor/converter/html5.rb
+++ b/lib/asciidoctor/converter/html5.rb
@@ -54,7 +54,7 @@ module Asciidoctor
           result << %(<link rel="stylesheet" href="#{asset_uri_scheme}//fonts.googleapis.com/css?family=#{webfonts.empty? ? 'Open+Sans:300,300italic,400,400italic,600,600italic%7CNoto+Serif:400,400italic,700,700italic%7CDroid+Sans+Mono:400' : webfonts}"#{slash}>)
         end
         if linkcss
-          result << %(<link rel="stylesheet" href="#{node.normalize_web_path DEFAULT_STYLESHEET_NAME, (node.attr 'stylesdir', '')}"#{slash}>)
+          result << %(<link rel="stylesheet" href="#{node.normalize_web_path DEFAULT_STYLESHEET_NAME, (node.attr 'stylesdir', ''), false}"#{slash}>)
         else
           result << @stylesheets.embed_primary_stylesheet
         end
@@ -73,7 +73,7 @@ module Asciidoctor
           result << %(<link rel="stylesheet" href="#{node.attr 'iconfont-cdn', %[#{cdn_base}/font-awesome/4.2.0/css/font-awesome.min.css]}"#{slash}>)
         else
           iconfont_stylesheet = %(#{node.attr 'iconfont-name', 'font-awesome'}.css)
-          result << %(<link rel="stylesheet" href="#{node.normalize_web_path iconfont_stylesheet, (node.attr 'stylesdir', '')}"#{slash}>)
+          result << %(<link rel="stylesheet" href="#{node.normalize_web_path iconfont_stylesheet, (node.attr 'stylesdir', ''), false}"#{slash}>)
         end
       end
 
@@ -81,7 +81,7 @@ module Asciidoctor
       when 'coderay'
         if (node.attr 'coderay-css', 'class') == 'class'
           if linkcss
-            result << %(<link rel="stylesheet" href="#{node.normalize_web_path @stylesheets.coderay_stylesheet_name, (node.attr 'stylesdir', '')}"#{slash}>)
+            result << %(<link rel="stylesheet" href="#{node.normalize_web_path @stylesheets.coderay_stylesheet_name, (node.attr 'stylesdir', ''), false}"#{slash}>)
           else
             result << @stylesheets.embed_coderay_stylesheet
           end
@@ -90,7 +90,7 @@ module Asciidoctor
         if (node.attr 'pygments-css', 'class') == 'class'
           pygments_style = node.attr 'pygments-style'
           if linkcss
-            result << %(<link rel="stylesheet" href="#{node.normalize_web_path @stylesheets.pygments_stylesheet_name(pygments_style), (node.attr 'stylesdir', '')}"#{slash}>)
+            result << %(<link rel="stylesheet" href="#{node.normalize_web_path @stylesheets.pygments_stylesheet_name(pygments_style), (node.attr 'stylesdir', ''), false}"#{slash}>)
           else
             result << (@stylesheets.embed_pygments_stylesheet pygments_style)
           end

--- a/lib/asciidoctor/path_resolver.rb
+++ b/lib/asciidoctor/path_resolver.rb
@@ -394,6 +394,9 @@ class PathResolver
   # The main function of this operation is to resolve any parent
   # references and remove any self references.
   #
+  # The target is assumed to be a path, not a qualified URI.
+  # That check should happen before this method is invoked.
+  #
   # target - the String target path
   # start  - the String start (i.e., parent) path
   #
@@ -412,6 +415,20 @@ class PathResolver
         target = target[uri_prefix.length..-1]
       end
     end
+
+    # use this logic instead if we want to normalize target if it contains a URI
+    #unless is_web_root? target
+    #  if preserve_uri_target && (target.include? ':') && UriSniffRx =~ target
+    #    uri_prefix = $~[0]
+    #    target = target[uri_prefix.length..-1]
+    #  elsif !start.nil_or_empty?
+    #    target = %(#{start}#{SLASH}#{target})
+    #    if (target.include? ':') && UriSniffRx =~ target
+    #      uri_prefix = $~[0]
+    #      target = target[uri_prefix.length..-1]
+    #    end
+    #  end
+    #end
 
     target_segments, target_root, _ = partition_path target, true
     resolved_segments = []

--- a/test/document_test.rb
+++ b/test/document_test.rb
@@ -457,6 +457,9 @@ text
       output = Asciidoctor.render(input, :header_footer => true, :attributes => {'stylesheet' => './custom.css'})
       assert_css 'html:root > head > link[rel="stylesheet"][href^="https://fonts.googleapis.com"]', output, 0
       assert_css 'html:root > head > link[rel="stylesheet"][href="./custom.css"]', output, 1
+
+      output = Asciidoctor.render(input, :header_footer => true, :attributes => {'stylesheet' => 'file:///home/username/custom.css'})
+      assert_css 'html:root > head > link[rel="stylesheet"][href="file:///home/username/custom.css"]', output, 1
     end
 
     test 'should resolve custom stylesheet relative to stylesdir' do

--- a/test/paths_test.rb
+++ b/test/paths_test.rb
@@ -56,6 +56,16 @@ context 'Path Resolver' do
       assert_equal 'http://www.example.com/assets/images', @resolver.web_path('images', 'http://www.example.com/assets')
     end
 
+    # enable if we want to allow web_path to detect and preserve a target URI
+    #test 'target with file url appended to relative path' do
+    #  assert_equal 'file:///home/username/styles/asciidoctor.css', @resolver.web_path('file:///home/username/styles/asciidoctor.css', '.')
+    #end
+
+    # enable if we want to allow web_path to detect and preserve a target URI
+    #test 'target with http url appended to relative path' do
+    #  assert_equal 'http://example.com/asciidoctor.css', @resolver.web_path('http://example.com/asciidoctor.css', '.')
+    #end
+
     test 'normalize target' do
       assert_equal '../images', @resolver.web_path('../images/../images')
     end


### PR DESCRIPTION
- preserve URI targets universally by moving logic to normalize_web_path
- remove checks for URI whereever normalize_web_path is used
