### PR TITLE
resolves #1103 allow numeric characters in block attribute name

### DIFF
--- a/lib/asciidoctor/attribute_list.rb
+++ b/lib/asciidoctor/attribute_list.rb
@@ -26,7 +26,7 @@ class AttributeList
   BoundaryRxs = {
     '"' => /.*?[^\\](?=")/,
     '\'' => /.*?[^\\](?=')/,
-    ',' => /.*?(?=[ \t]*(,|$))/
+    ',' => /.*?(?=#{CG_BLANK}*(,|$))/
   }
 
   # Public: Regular expressions for unescaping quoted characters
@@ -35,16 +35,16 @@ class AttributeList
     '\'' => /\\'/
   }
 
-  # Public: A regular expression for an attribute name
+  # Public: A regular expression for an attribute name (approx. name token from XML)
   # TODO named attributes cannot contain dash characters
-  NameRx = /[A-Za-z:_][A-Za-z:_\-.]*/
+  NameRx = /#{CG_WORD}[#{CC_WORD}\-.]*/
 
-  BlankRx = /[ \t]+/
+  BlankRx = /#{CG_BLANK}+/
 
   # Public: Regular expressions for skipping blanks and delimiters
   SkipRxs = {
     :blank => BlankRx,
-    ',' => /[ \t]*(,|$)/
+    ',' => /#{CG_BLANK}*(,|$)/
   }
 
   def initialize source, block = nil, delimiter = ','

--- a/test/attributes_test.rb
+++ b/test/attributes_test.rb
@@ -788,6 +788,20 @@ after: {counter:mycounter}
   end
 
   context 'Block attributes' do
+    test 'parses attribute names as name token' do
+      input = <<-EOS
+[normal,foo="bar",_foo="_bar",foo1="bar1",foo-foo="bar-bar",foo.foo="bar.bar"]
+content
+      EOS
+
+      block = block_from_string input
+      assert_equal 'bar', block.attr('foo') 
+      assert_equal '_bar', block.attr('_foo') 
+      assert_equal 'bar1', block.attr('foo1') 
+      assert_equal 'bar-bar', block.attr('foo-foo') 
+      assert_equal 'bar.bar', block.attr('foo.foo') 
+    end
+
     test 'positional attributes assigned to block' do
       input = <<-EOS
 [quote, author, source]


### PR DESCRIPTION
- allow numeric characters in block attribute name (per name token spec)
- use character constants to define regex in AttributeList class
