### PR TITLE
add UTF-8 encoding header to all Ruby files with logic

### DIFF
--- a/features/step_definitions.rb
+++ b/features/step_definitions.rb
@@ -1,3 +1,4 @@
+# encoding: UTF-8
 ASCIIDOCTOR_PROJECT_DIR = File.dirname File.dirname(__FILE__)
 Dir.chdir ASCIIDOCTOR_PROJECT_DIR
 

--- a/lib/asciidoctor.rb
+++ b/lib/asciidoctor.rb
@@ -1,3 +1,4 @@
+# encoding: UTF-8
 RUBY_ENGINE = 'unknown' unless defined? RUBY_ENGINE
 RUBY_ENGINE_OPAL = (RUBY_ENGINE == 'opal')
 RUBY_ENGINE_JRUBY = (RUBY_ENGINE == 'jruby')

--- a/lib/asciidoctor/abstract_block.rb
+++ b/lib/asciidoctor/abstract_block.rb
@@ -1,3 +1,4 @@
+# encoding: UTF-8
 module Asciidoctor
 class AbstractBlock < AbstractNode
   # Public: The types of content that this block can accomodate

--- a/lib/asciidoctor/abstract_node.rb
+++ b/lib/asciidoctor/abstract_node.rb
@@ -1,3 +1,4 @@
+# encoding: UTF-8
 module Asciidoctor
 # Public: An abstract base class that provides state and methods for managing a
 # node of AsciiDoc content. The state and methods on this class are comment to

--- a/lib/asciidoctor/attribute_list.rb
+++ b/lib/asciidoctor/attribute_list.rb
@@ -1,3 +1,4 @@
+# encoding: UTF-8
 module Asciidoctor
 # Public: Handles parsing AsciiDoc attribute lists into a Hash of key/value
 # pairs. By default, attributes must each be separated by a comma and quotes

--- a/lib/asciidoctor/block.rb
+++ b/lib/asciidoctor/block.rb
@@ -1,3 +1,4 @@
+# encoding: UTF-8
 module Asciidoctor
 # Public: Methods for managing blocks of Asciidoc content in a section.
 #

--- a/lib/asciidoctor/callouts.rb
+++ b/lib/asciidoctor/callouts.rb
@@ -1,3 +1,4 @@
+# encoding: UTF-8
 module Asciidoctor
 # Public: Maintains a catalog of callouts and their associations.
 class Callouts

--- a/lib/asciidoctor/cli/invoker.rb
+++ b/lib/asciidoctor/cli/invoker.rb
@@ -1,3 +1,4 @@
+# encoding: UTF-8
 module Asciidoctor
   module Cli
     # Public Invocation class for starting Asciidoctor via CLI

--- a/lib/asciidoctor/cli/options.rb
+++ b/lib/asciidoctor/cli/options.rb
@@ -1,3 +1,4 @@
+# encoding: UTF-8
 module Asciidoctor
   module Cli
 

--- a/lib/asciidoctor/converter.rb
+++ b/lib/asciidoctor/converter.rb
@@ -1,3 +1,4 @@
+# encoding: UTF-8
 module Asciidoctor
   # A base module for defining converters that can be used to convert {AbstractNode}
   # objects in a parsed AsciiDoc document to a backend format such as HTML or

--- a/lib/asciidoctor/converter/base.rb
+++ b/lib/asciidoctor/converter/base.rb
@@ -1,3 +1,4 @@
+# encoding: UTF-8
 module Asciidoctor
   module Converter; end # required for Opal
 

--- a/lib/asciidoctor/converter/composite.rb
+++ b/lib/asciidoctor/converter/composite.rb
@@ -1,3 +1,4 @@
+# encoding: UTF-8
 module Asciidoctor
   # A {Converter} implementation that delegates to the chain of {Converter}
   # objects passed to the constructor. Selects the first {Converter} that

--- a/lib/asciidoctor/converter/docbook45.rb
+++ b/lib/asciidoctor/converter/docbook45.rb
@@ -1,3 +1,4 @@
+# encoding: UTF-8
 require 'asciidoctor/converter/docbook5'
 
 module Asciidoctor

--- a/lib/asciidoctor/converter/docbook5.rb
+++ b/lib/asciidoctor/converter/docbook5.rb
@@ -1,3 +1,4 @@
+# encoding: UTF-8
 module Asciidoctor
   # A built-in {Converter} implementation that generates DocBook 5 output
   # similar to the docbook45 backend from AsciiDoc Python, but migrated to the

--- a/lib/asciidoctor/converter/factory.rb
+++ b/lib/asciidoctor/converter/factory.rb
@@ -1,3 +1,4 @@
+# encoding: UTF-8
 module Asciidoctor
   module Converter
     # A factory for instantiating converters that are used to convert a

--- a/lib/asciidoctor/converter/html5.rb
+++ b/lib/asciidoctor/converter/html5.rb
@@ -1,3 +1,4 @@
+# encoding: UTF-8
 module Asciidoctor
   # A built-in {Converter} implementation that generates HTML 5 output
   # consistent with the html5 backend from AsciiDoc Python.

--- a/lib/asciidoctor/converter/template.rb
+++ b/lib/asciidoctor/converter/template.rb
@@ -1,3 +1,4 @@
+# encoding: UTF-8
 module Asciidoctor
   # A {Converter} implementation that uses templates composed in template
   # languages supported by {https://github.com/rtomayko/tilt Tilt} to convert

--- a/lib/asciidoctor/document.rb
+++ b/lib/asciidoctor/document.rb
@@ -1,3 +1,4 @@
+# encoding: UTF-8
 module Asciidoctor
 # Public: Methods for parsing and converting AsciiDoc documents.
 #

--- a/lib/asciidoctor/extensions.rb
+++ b/lib/asciidoctor/extensions.rb
@@ -1,3 +1,4 @@
+# encoding: UTF-8
 module Asciidoctor
 # Extensions provide a way to participate in the parsing and converting
 # phases of the AsciiDoc processor or extend the AsciiDoc syntax.

--- a/lib/asciidoctor/helpers.rb
+++ b/lib/asciidoctor/helpers.rb
@@ -1,3 +1,4 @@
+# encoding: UTF-8
 module Asciidoctor
 module Helpers
   # Internal: Require the specified library using Kernel#require.

--- a/lib/asciidoctor/inline.rb
+++ b/lib/asciidoctor/inline.rb
@@ -1,3 +1,4 @@
+# encoding: UTF-8
 module Asciidoctor
 # Public: Methods for managing inline elements in AsciiDoc block
 class Inline < AbstractNode

--- a/lib/asciidoctor/list.rb
+++ b/lib/asciidoctor/list.rb
@@ -1,3 +1,4 @@
+# encoding: UTF-8
 module Asciidoctor
 # Public: Methods for managing AsciiDoc lists (ordered, unordered and labeled lists)
 class List < AbstractBlock

--- a/lib/asciidoctor/parser.rb
+++ b/lib/asciidoctor/parser.rb
@@ -1,3 +1,4 @@
+# encoding: UTF-8
 module Asciidoctor
 # Public: Methods to parse lines of AsciiDoc into an object hierarchy
 # representing the structure of the document. All methods are class methods and

--- a/lib/asciidoctor/path_resolver.rb
+++ b/lib/asciidoctor/path_resolver.rb
@@ -1,3 +1,4 @@
+# encoding: UTF-8
 module Asciidoctor
 # Public: Handles all operations for resolving, cleaning and joining paths.
 # This class includes operations for handling both web paths (request URIs) and

--- a/lib/asciidoctor/reader.rb
+++ b/lib/asciidoctor/reader.rb
@@ -1,3 +1,4 @@
+# encoding: UTF-8
 module Asciidoctor
 # Public: Methods for retrieving lines from AsciiDoc source files
 class Reader

--- a/lib/asciidoctor/section.rb
+++ b/lib/asciidoctor/section.rb
@@ -1,3 +1,4 @@
+# encoding: UTF-8
 module Asciidoctor
 # Public: Methods for managing sections of AsciiDoc content in a document.
 # The section responds as an Array of content blocks by delegating

--- a/lib/asciidoctor/stylesheets.rb
+++ b/lib/asciidoctor/stylesheets.rb
@@ -1,3 +1,4 @@
+# encoding: UTF-8
 module Asciidoctor
 # A utility class for working with the built-in stylesheets.
 #--

--- a/lib/asciidoctor/substitutors.rb
+++ b/lib/asciidoctor/substitutors.rb
@@ -1,3 +1,4 @@
+# encoding: UTF-8
 module Asciidoctor
 # Public: Methods to perform substitutions on lines of AsciiDoc text. This module
 # is intented to be mixed-in to Section and Block to provide operations for performing

--- a/lib/asciidoctor/table.rb
+++ b/lib/asciidoctor/table.rb
@@ -1,3 +1,4 @@
+# encoding: UTF-8
 module Asciidoctor
 # Public: Methods and constants for managing AsciiDoc table content in a document.
 # It supports all three of AsciiDoc's table formats: psv, dsv and csv.

--- a/lib/asciidoctor/timings.rb
+++ b/lib/asciidoctor/timings.rb
@@ -1,3 +1,4 @@
+# encoding: UTF-8
 module Asciidoctor
   class Timings
     def initialize

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,3 +1,4 @@
+# encoding: UTF-8
 ASCIIDOCTOR_PROJECT_DIR = File.dirname File.dirname(__FILE__)
 Dir.chdir ASCIIDOCTOR_PROJECT_DIR
 


### PR DESCRIPTION
Fixes Asciidoctor running on systems that have a filesystem encoding different from UTF-8. Since Asciidoctor forces all input strings to UTF-8, the Ruby source files also need to be read this way.
