### PR TITLE
resolves #1195 implementation of epigraphs using roles

### DIFF
--- a/lib/asciidoctor/converter/docbook5.rb
+++ b/lib/asciidoctor/converter/docbook5.rb
@@ -766,8 +766,9 @@ module Asciidoctor
     end
 
     def quote_like node, content
+      tag_name = (node.has_role? 'epigraph') ? 'epigraph' : 'blockquote'
       result = []
-      result << %(<blockquote#{common_attributes node.id, node.role, node.reftext}>)
+      result << %(<#{tag_name}#{common_attributes node.id, node.role, node.reftext}>)
       result << %(<title>#{node.title}</title>) if node.title?
       if (node.attr? 'attribution') || (node.attr? 'citetitle')
         result << '<attribution>'
@@ -780,7 +781,7 @@ module Asciidoctor
         result << '</attribution>'
       end
       result << content
-      result << '</blockquote>'
+      result << %(</#{tag_name}>)
       result * LF
     end
   end

--- a/lib/asciidoctor/converter/docbook5.rb
+++ b/lib/asciidoctor/converter/docbook5.rb
@@ -352,22 +352,7 @@ module Asciidoctor
     end
 
     def quote node
-      result = []
-      result << %(<blockquote#{common_attributes node.id, node.role, node.reftext}>)
-      result << %(<title>#{node.title}</title>) if node.title?
-      if (node.attr? 'attribution') || (node.attr? 'citetitle')
-        result << '<attribution>'
-        if node.attr? 'attribution'
-          result << (node.attr 'attribution')
-        end
-        if node.attr? 'citetitle'
-          result << %(<citetitle>#{node.attr 'citetitle'}</citetitle>)
-        end
-        result << '</attribution>'
-      end
-      result << (resolve_content node)
-      result << '</blockquote>'
-      result * LF
+      quote_like node, resolve_content(node)
     end
 
     def thematic_break node
@@ -485,22 +470,7 @@ module Asciidoctor
     end
 
     def verse node
-      result = []
-      result << %(<blockquote#{common_attributes node.id, node.role, node.reftext}>)
-      result << %(<title>#{node.title}</title>) if node.title?
-      if (node.attr? 'attribution') || (node.attr? 'citetitle')
-        result << '<attribution>'
-        if node.attr? 'attribution'
-          result << (node.attr 'attribution')
-        end
-        if node.attr? 'citetitle'
-          result << %(<citetitle>#{node.attr 'citetitle'}</citetitle>)
-        end
-        result << '</attribution>'
-      end
-      result << %(<literallayout>#{node.content}</literallayout>)
-      result << '</blockquote>'
-      result * LF
+      quote_like node, %(<literallayout>#{node.content}</literallayout>)
     end
 
     alias video skip
@@ -793,6 +763,25 @@ module Asciidoctor
       elsif use_placeholder
         %(<cover role="#{face}"/>)
       end
+    end
+
+    def quote_like node, content
+      result = []
+      result << %(<blockquote#{common_attributes node.id, node.role, node.reftext}>)
+      result << %(<title>#{node.title}</title>) if node.title?
+      if (node.attr? 'attribution') || (node.attr? 'citetitle')
+        result << '<attribution>'
+        if node.attr? 'attribution'
+          result << (node.attr 'attribution')
+        end
+        if node.attr? 'citetitle'
+          result << %(<citetitle>#{node.attr 'citetitle'}</citetitle>)
+        end
+        result << '</attribution>'
+      end
+      result << content
+      result << '</blockquote>'
+      result * LF
     end
   end
 end

--- a/test/blocks_test.rb
+++ b/test/blocks_test.rb
@@ -309,6 +309,42 @@ ____
       assert_equal "#{decode_char 8212} Famous Person", author.text.strip
     end
 
+    test 'quote block with attribution in DocBook' do
+      input = <<-EOS
+[quote, Famous Person, Famous Book (1999)]
+____
+A famous quote.
+____
+      EOS
+      output = render_string input, :backend => :docbook
+      assert_css 'blockquote', output, 1
+      assert_css 'blockquote > simpara', output, 1
+      assert_css 'blockquote > attribution', output, 1
+      assert_css 'blockquote > attribution > citetitle', output, 1
+      assert_xpath '//blockquote/attribution/citetitle[text() = "Famous Book (1999)"]', output, 1
+      attribution = xmlnodes_at_xpath '//blockquote/attribution', output, 1
+      author = attribution.children.first
+      assert_equal "Famous Person", author.text.strip
+    end
+
+    test 'epigraph quote block with attribution in DocBook' do
+      input = <<-EOS
+[quote.epigraph, Famous Person, Famous Book (1999)]
+____
+A famous quote.
+____
+      EOS
+      output = render_string input, :backend => :docbook
+      assert_css 'epigraph', output, 1
+      assert_css 'epigraph > simpara', output, 1
+      assert_css 'epigraph > attribution', output, 1
+      assert_css 'epigraph > attribution > citetitle', output, 1
+      assert_xpath '//epigraph/attribution/citetitle[text() = "Famous Book (1999)"]', output, 1
+      attribution = xmlnodes_at_xpath '//epigraph/attribution', output, 1
+      author = attribution.children.first
+      assert_equal "Famous Person", author.text.strip
+    end
+
     test 'quote block with attribute and id and role shorthand' do
       input = <<-EOS
 [quote#think.big, Donald Trump]
@@ -481,6 +517,44 @@ ____
       attribution = xmlnodes_at_xpath '//*[@class = "verseblock"]/*[@class = "attribution"]', output, 1
       author = attribution.children.first
       assert_equal "#{decode_char 8212} Famous Poet", author.text.strip
+    end
+
+    test 'single-line verse block with attribution in DocBook' do
+      input = <<-EOS
+[verse, Famous Poet, Famous Poem]
+____
+A famous verse.
+____
+      EOS
+      output = render_string input, :backend => :docbook
+      assert_css 'blockquote', output, 1
+      assert_css 'blockquote simpara', output, 0
+      assert_css 'blockquote > literallayout', output, 1
+      assert_css 'blockquote > attribution', output, 1
+      assert_css 'blockquote > attribution > citetitle', output, 1
+      assert_xpath '//blockquote/attribution/citetitle[text() = "Famous Poem"]', output, 1
+      attribution = xmlnodes_at_xpath '//blockquote/attribution', output, 1
+      author = attribution.children.first
+      assert_equal "Famous Poet", author.text.strip
+    end
+
+    test 'single-line epigraph verse block with attribution in DocBook' do
+      input = <<-EOS
+[verse.epigraph, Famous Poet, Famous Poem]
+____
+A famous verse.
+____
+      EOS
+      output = render_string input, :backend => :docbook
+      assert_css 'epigraph', output, 1
+      assert_css 'epigraph simpara', output, 0
+      assert_css 'epigraph > literallayout', output, 1
+      assert_css 'epigraph > attribution', output, 1
+      assert_css 'epigraph > attribution > citetitle', output, 1
+      assert_xpath '//epigraph/attribution/citetitle[text() = "Famous Poem"]', output, 1
+      attribution = xmlnodes_at_xpath '//epigraph/attribution', output, 1
+      author = attribution.children.first
+      assert_equal "Famous Poet", author.text.strip
     end
 
     test 'multi-stanza verse block' do


### PR DESCRIPTION
This adds support for epigraphs for quote and verse blocks by using the "epigraph" role.  I couldn't find any tests for the DocBook output of the existing quote and verse blocks, so I added some to make sure I didn't regress anything with my changes.

The quote and verse functions were almost identical, so they were refactored into a single function that did most of the work.  The tests pass after each commit.

Fixes #1195.
