### PR TITLE
Fix for issue 1140, 2 files changed

### DIFF
--- a/lib/asciidoctor/converter/docbook5.rb
+++ b/lib/asciidoctor/converter/docbook5.rb
@@ -376,10 +376,9 @@ module Asciidoctor
       result << %(<#{tag_name = node.title? ? 'table' : 'informaltable'}#{common_attributes node.id, node.role, node.reftext}#{pgwide_attribute} frame="#{node.attr 'frame', 'all'}" rowsep="#{['none', 'cols'].include?(node.attr 'grid') ? 0 : 1}" colsep="#{['none', 'rows'].include?(node.attr 'grid') ? 0 : 1}">)
 
       if (node.option? 'breakable')
-        result << %(<?dbfo keep-together="auto"?>)
-      end 
-      else if (node.option? 'unbreakable')
-        result << %(<?dbfo keep-together="always"?>)
+        result << '<?dbfo keep-together="auto"?>'
+      elsif (node.option? 'unbreakable')
+        result << '<?dbfo keep-together="always"?>'
       end 
 
       result << %(<title>#{node.title}</title>) if tag_name == 'table'

--- a/lib/asciidoctor/converter/docbook5.rb
+++ b/lib/asciidoctor/converter/docbook5.rb
@@ -374,7 +374,6 @@ module Asciidoctor
       result = []
       pgwide_attribute = (node.option? 'pgwide') ? ' pgwide="1"' : nil
       result << %(<#{tag_name = node.title? ? 'table' : 'informaltable'}#{common_attributes node.id, node.role, node.reftext}#{pgwide_attribute} frame="#{node.attr 'frame', 'all'}" rowsep="#{['none', 'cols'].include?(node.attr 'grid') ? 0 : 1}" colsep="#{['none', 'rows'].include?(node.attr 'grid') ? 0 : 1}">)
-      result << %(<title>#{node.title}</title>) if tag_name == 'table'
 
       if (node.option? 'breakable')
         result << %(<?dbfo keep-together="auto"?>)
@@ -383,6 +382,7 @@ module Asciidoctor
         result << %(<?dbfo keep-together="always"?>)
       end 
 
+      result << %(<title>#{node.title}</title>) if tag_name == 'table'
       if (width = (node.attr? 'width') ? (node.attr 'width') : nil)
         TABLE_PI_NAMES.each do |pi_name|
           result << %(<?#{pi_name} table-width="#{width}"?>)

--- a/lib/asciidoctor/converter/docbook5.rb
+++ b/lib/asciidoctor/converter/docbook5.rb
@@ -375,6 +375,14 @@ module Asciidoctor
       pgwide_attribute = (node.option? 'pgwide') ? ' pgwide="1"' : nil
       result << %(<#{tag_name = node.title? ? 'table' : 'informaltable'}#{common_attributes node.id, node.role, node.reftext}#{pgwide_attribute} frame="#{node.attr 'frame', 'all'}" rowsep="#{['none', 'cols'].include?(node.attr 'grid') ? 0 : 1}" colsep="#{['none', 'rows'].include?(node.attr 'grid') ? 0 : 1}">)
       result << %(<title>#{node.title}</title>) if tag_name == 'table'
+
+      if (node.option? 'breakable')
+        result << %(<?dbfo keep-together="auto"?>)
+      end 
+      else if (node.option? 'unbreakable')
+        result << %(<?dbfo keep-together="always"?>)
+      end 
+
       if (width = (node.attr? 'width') ? (node.attr 'width') : nil)
         TABLE_PI_NAMES.each do |pi_name|
           result << %(<?#{pi_name} table-width="#{width}"?>)

--- a/test/tables_test.rb
+++ b/test/tables_test.rb
@@ -960,5 +960,57 @@ single cell
       output = render_embedded_string input
       assert_css 'table td', output, 1
     end
+
+    test 'table with breakable db45' do
+      input = <<-EOS
+.Table with breakable
+[options="breakable"]
+|===
+|Item       |Quantity
+|Item 1     |1        
+|===
+      EOS
+      output = render_embedded_string input, :backend => 'docbook45'
+      assert output.include?('<?dbfo keep-together="auto"?>')
+    end
+
+    test 'table with breakable db5' do
+      input = <<-EOS
+.Table with breakable
+[options="breakable"]
+|===
+|Item       |Quantity
+|Item 1     |1        
+|===
+      EOS
+      output = render_embedded_string input, :backend => 'docbook5'
+      assert output.include?('<?dbfo keep-together="auto"?>')
+    end
+
+    test 'table with unbreakable db5' do
+      input = <<-EOS
+.Table with unbreakable
+[options="unbreakable"]
+|===
+|Item       |Quantity
+|Item 1     |1        
+|===
+      EOS
+      output = render_embedded_string input, :backend => 'docbook5'
+      assert output.include?('<?dbfo keep-together="always"?>')
+    end
+
+    test 'table with unbreakable db45' do
+      input = <<-EOS
+.Table with unbreakable
+[options="unbreakable"]
+|===
+|Item       |Quantity
+|Item 1     |1        
+|===
+      EOS
+      output = render_embedded_string input, :backend => 'docbook45'
+      assert output.include?('<?dbfo keep-together="always"?>')
+    end
   end
 end


### PR DESCRIPTION
#1140 Support breakable and unbreakable for tables in docbook 5 and 4.5 backends.
Translated into dbfo processing instructions. Unbreakable is included for completeness, even though it is the default. Only needed to change the docbook5.rb converter - I think the 4.5 backend delagates to it (at least its tests pass without making any changes to docbook45.rb).
If this change is accepted, I will update the docs (I assume I can't do it in one pull request because the docs are in a different repository).