### PR TITLE
Parse version alone in header as version, not date.

### DIFF
--- a/lib/asciidoctor/parser.rb
+++ b/lib/asciidoctor/parser.rb
@@ -1827,8 +1827,13 @@ class Parser
       if reader.has_more_lines? && !reader.next_line_empty?
         rev_line = reader.read_line 
         if (match = RevisionInfoLineRx.match(rev_line))
-          rev_metadata['revdate'] = match[2].strip
-          rev_metadata['revnumber'] = match[1].rstrip unless match[1].nil?
+          component = match[2].strip
+          if match[1].nil? && (component.start_with? 'v')
+            rev_metadata['revnumber'] = component[1..-1]
+          else
+            rev_metadata['revdate'] = component
+            rev_metadata['revnumber'] = match[1].rstrip unless match[1].nil?
+          end
           rev_metadata['revremark'] = match[3].rstrip unless match[3].nil?
         else
           # throw it back

--- a/test/document_test.rb
+++ b/test/document_test.rb
@@ -1161,6 +1161,38 @@ more info...
       assert_xpath '/article/info/author/email[text() = "founder@asciidoc.org"]', output, 1
     end
 
+    test 'should parse version alone as revnumber to DocBook45' do
+      input = <<-EOS
+= AsciiDoc
+Stuart Rackham <founder@asciidoc.org>
+v8.6.8
+
+== Sample Header
+
+Version {revnumber}
+      EOS
+      output = render_string input, :backend => 'docbook45'
+      assert_xpath '/article/articleinfo', output, 1
+      assert_xpath '/article/articleinfo/title[text() = "AsciiDoc"]', output, 1
+      assert_xpath '/article/section/simpara[text() = "Version 8.6.8"]', output, 1
+    end
+
+    test 'should parse version alone as revnumber to DocBook' do
+      input = <<-EOS
+= AsciiDoc
+Stuart Rackham <founder@asciidoc.org>
+v8.6.8
+
+== Sample Header
+
+Version {revnumber}
+      EOS
+      output = render_string input, :backend => 'docbook'
+      assert_xpath '/article/info', output, 1
+      assert_xpath '/article/info/title[text() = "AsciiDoc"]', output, 1
+      assert_xpath '/article/section/simpara[text() = "Version 8.6.8"]', output, 1
+    end
+
     test 'with author defined using attribute entry to DocBook 4.5' do
       input = <<-EOS
 = Document Title


### PR DESCRIPTION
If a version alone (without a date) is given in the document header, treat it as a version, not a date. The criterion used to determine this is whether the component begins with a "v"; dates hopefully will not begin that way.

Note that the tests use an attribute expansion to verify that the revnumber attribute is set, as the DocBook backend doesn't generate revision entries unless there's a revdate, and there are tests for that, so I didn't want to change it. I can, however, if you think that's a better idea.

This patch fixes #790.