### PR TITLE
Avoid direct access to config instance variable

### DIFF
--- a/lib/asciidoctor/extensions.rb
+++ b/lib/asciidoctor/extensions.rb
@@ -425,7 +425,7 @@ module Extensions
   class InlineMacroProcessor < MacroProcessor
     def initialize name, config = {}
       super
-      @config[:regexp] ||= (resolve_regexp @name, @config[:format])
+      self.config[:regexp] ||= (resolve_regexp @name, @config[:format])
     end
 
     def resolve_regexp name, format


### PR DESCRIPTION
There is currently a false positive in the AsciidoctorJ tests.
The tests for the InlineMacroProcessor should fail but they don't.
Depending on the regexp the ManPageProcessor should be applied or not but it always applies.
https://github.com/asciidoctor/asciidoctorj/blob/master/asciidoctorj-core/src/test/java/org/asciidoctor/extension/WhenJavaExtensionIsRegistered.java#L554

The reason is that Asciidoctor does not see the regexp in the options because it directly accesses the config instance variable.
Thereby it bypasses the possibility of the extension proxy to make the config of the instance visible.
The PR changes the access to the config by not accessing the config ivar directly but by calling the accessor that invokes the extension proxy and makes the correct configuration visible.
