### PR TITLE
resolves #1342 fix precision error in timings report

### DIFF
--- a/lib/asciidoctor/timings.rb
+++ b/lib/asciidoctor/timings.rb
@@ -32,9 +32,9 @@ module Asciidoctor
 
     def print_report to = $stdout, subject = nil
       to.puts %(Input file: #{subject}) if subject
-      to.puts %(  Time to read and parse source: #{'%05.5f' % read_parse.to_i})
-      to.puts %(  Time to convert document: #{'%05.5f' % convert.to_i})
-      to.puts %(  Total time (read, parse and convert): #{'%05.5f' % read_parse_convert.to_i})
+      to.puts %(  Time to read and parse source: #{'%05.5f' % read_parse.to_f})
+      to.puts %(  Time to convert document: #{'%05.5f' % convert.to_f})
+      to.puts %(  Total time (read, parse and convert): #{'%05.5f' % read_parse_convert.to_f})
     end
   end
 end

--- a/test/document_test.rb
+++ b/test/document_test.rb
@@ -1874,4 +1874,25 @@ text
       assert_match(/missing converter for backend 'unknownBackend'/, exception.message)
     end
   end
+
+  context 'Timing report' do
+    test 'print_report does not lose precision' do
+      timings = Asciidoctor::Timings.new
+      log = timings.instance_variable_get(:@log)
+      log[:read] = 0.00001
+      log[:parse] = 0.00003
+      log[:convert] = 0.00005
+      timings.print_report(sink = StringIO.new)
+      expect = ['0.00004', '0.00005', '0.00009']
+      result = sink.string.split("\n").map {|l| l.sub(/.*:\s*([\d.]+)/, '\1') }
+      assert_equal expect, result
+    end
+
+    test 'print_report should print 0 for untimed phases' do
+      Asciidoctor::Timings.new.print_report(sink = StringIO.new)
+      expect = [].fill('0.00000', 0..2)
+      result = sink.string.split("\n").map {|l| l.sub(/.*:\s*([\d.]+)/, '\1') }
+      assert_equal expect, result
+    end
+  end
 end


### PR DESCRIPTION
- coerce values to float, not integer
- add tests for precision and handling nil values