### PR TITLE
Allow to read assets when running in Opal

### DIFF
--- a/lib/asciidoctor/opal_ext/file.rb
+++ b/lib/asciidoctor/opal_ext/file.rb
@@ -95,6 +95,10 @@ class File
     true
   end
   
+  def self.readable?(path)
+    true
+  end
+
   def self.read(path)
     case JAVASCRIPT_PLATFORM
     when 'node'
@@ -142,4 +146,13 @@ class File
       ''
     end
   end
+
+end
+
+class IO
+
+  def self.read(path)
+    File.read(path)
+  end
+
 end


### PR DESCRIPTION
See https://github.com/asciidoctor/asciidoctor-extensions-lab/pull/32#issuecomment-98092816

Absolute paths starting with `file://` were considered as relative path (in safe mode) and an exception was thrown:
```
SecurityError : asciidoctor: FAILED: : Failed to parse source, Jail is not an absolute path: file:///workspace/asciidoctor-extensions-lab/lib/chart-block-macro
```

In unsafe mode, the method `read_asset` was using `IO.read` (with no equivalent when running in Opal). AFAIK `::IO.read` and `::File.read` are equivalent so I replaced the first one with the latter.

Finally the method `readable` was undefined when running in Opal so I added the method in `opal_ext/file.rb`. I didn't know how to implement the method in a JavaScript environment so for now the method always returns `true` (until we decide how to implement `file?` and `readable?`)

With these changes I can load CSV files with the chart macro (in the Chrome extension!): `chart::sample.csv[line,800,300]`

