### PR TITLE
Fallback to require with a non relative path

### DIFF
--- a/bin/asciidoctor
+++ b/bin/asciidoctor
@@ -2,7 +2,11 @@
 
 require 'rubygems' if RUBY_VERSION < '1.9'
 
-require File.join File.dirname(__FILE__), '../lib/asciidoctor'
+if File.exist?(asciidoctor_lib_path = File.join(File.dirname(__FILE__), '../lib/asciidoctor'))
+  require asciidoctor_lib_path
+else
+  require 'asciidoctor'
+end
 require 'asciidoctor/cli'
 
 invoker = Asciidoctor::Cli::Invoker.new ARGV


### PR DESCRIPTION
Allow to require asciidoctor when then `lib/` directory is not relative to the binary.
For instance, Debian package copies binary in `/usr/bin/asciidoctor` and lib/ in `/usr/lib/ruby/vendor_ruby/`