### PR TITLE
Adding hl_lines parameter support for pygments source-highlighter.

### DIFF
--- a/lib/asciidoctor/block.rb
+++ b/lib/asciidoctor/block.rb
@@ -50,6 +50,7 @@ class Block < AbstractBlock
   # QUESTION should we store source_data as lines for blocks that have compound content models?
   def initialize parent, context, opts = {}
     super
+	@extraopts =  if opts.key? :attributes then opts[:attributes] else {} end
     @content_model = opts[:content_model] || DEFAULT_CONTENT_MODEL[context]
     if opts.key? :subs
       # FIXME feels funky; we have to be defensive to get lock_in_subs to honor override
@@ -116,7 +117,7 @@ class Block < AbstractBlock
 
       # QUESTION could we use strip here instead of popping empty lines?
       # maybe apply_subs can know how to strip whitespace?
-      result = apply_subs @lines, @subs
+      result = apply_subs @lines, @subs, false, @extraopts
       if result.size < 2
         result[0]
       else

--- a/lib/asciidoctor/substitutors.rb
+++ b/lib/asciidoctor/substitutors.rb
@@ -118,7 +118,7 @@ module Substitutors
       when :macros
         text = sub_macros text
       when :highlight
-        text = highlight_source text, (subs.include? :callouts)
+        text = highlight_source text, (subs.include? :callouts), nil, extraopts
       when :callouts
         text = sub_callouts text unless subs.include? :highlight
       when :post_replacements
@@ -1397,7 +1397,7 @@ module Substitutors
   #
   # returns the highlighted source code, if a source highlighter is defined
   # on the document, otherwise the unprocessed text
-  def highlight_source(source, process_callouts, highlighter = nil)
+  def highlight_source(source, process_callouts, highlighter = nil, extraopts = {})
     highlighter ||= @document.attributes['source-highlighter']
     Helpers.require_library highlighter, (highlighter == 'pygments' ? 'pygments.rb' : highlighter)
     lineno = 0
@@ -1444,6 +1444,20 @@ module Substitutors
         opts[:noclasses] = true
         opts[:style] = (@document.attributes['pygments-style'] || Stylesheets::DEFAULT_PYGMENTS_STYLE)
       end
+	  
+      _params = [:hl_lines]
+      newconfs = Hash[_params.select { |k| extraopts.key?(k.to_s) }.collect {
+                 |x| 
+                 [x,
+                 begin
+                  instance_eval(extraopts[x.to_s])
+                 rescue
+                  extraopts[x]
+                 end]
+                 }]
+    
+      opts = opts.merge(newconfs)
+	 	  
       if attr? 'linenums'
         # TODO we could add the line numbers in ourselves instead of having to strip out the junk
         # FIXME move these regular expressions into constants


### PR DESCRIPTION
The HTMLFormater parameter "hl_lines" of pygments is really important in some situations, this pull request includes that.
Now you can write:

```
[source, python, numbered, hl_lines="[2, 3]"]
----
def function():
    for i in range(55):
        print(3)
----
```

and the lines number 2 and 3 will be highlighted.