### PR TITLE
resolves #1253 don't abort of syntax highlighter isn't available

### DIFF
--- a/lib/asciidoctor/abstract_node.rb
+++ b/lib/asciidoctor/abstract_node.rb
@@ -130,23 +130,18 @@ class AbstractNode
 
   # Public: Assign the value to the attribute name for the current node.
   #
-  # name      - The String attribute name
-  # value     - The Object value to assign to the attribute name
+  # name      - The String attribute name to assign
+  # value     - The Object value to assign to the attribute
   # overwrite - A Boolean indicating whether to assign the attribute
-  #             if currently present in the attributes Hash
+  #             if currently present in the attributes Hash (default: true)
   #
   # Returns a [Boolean] indicating whether the assignment was performed
-  def set_attr name, value, overwrite = nil
-    if overwrite.nil?
+  def set_attr name, value, overwrite = true
+    if overwrite == false && (@attributes.key? name)
+      false
+    else
       @attributes[name] = value
       true
-    else
-      if overwrite || !(@attributes.key? name)
-        @attributes[name] = value
-        true
-      else
-        false
-      end
     end
   end
 

--- a/lib/asciidoctor/helpers.rb
+++ b/lib/asciidoctor/helpers.rb
@@ -5,24 +5,39 @@ module Helpers
   #
   # Attempts to load the library specified in the first argument using the
   # Kernel#require. Rescues the LoadError if the library is not available and
-  # passes a message to Kernel#fail to communicate to the user that processing
-  # is being aborted. If a gem_name is specified, the failure message
-  # communicates that a required gem is not installed.
+  # passes a message to Kernel#fail if on_failure is :abort or Kernel#warn if
+  # on_failure is :warn to communicate to the user that processing is being
+  # aborted or functionality is disabled, respectively. If a gem_name is
+  # specified, the message communicates that a required gem is not installed.
   #
-  # name  - the String name of the library to require.
-  # gem   - a Boolean that indicates whether this library is provided by a RubyGem,
-  #         or the String name of the RubyGem if it differs from the library name
-  #         (default: true)
+  # name       - the String name of the library to require.
+  # gem_name   - a Boolean that indicates whether this library is provided by a RubyGem,
+  #              or the String name of the RubyGem if it differs from the library name
+  #              (default: true)
+  # on_failure - a Symbol that indicates how to handle a load failure (:abort, :warn, :ignore) (default: :abort)
   #
-  # returns the return value of Kernel#require if the library is available,
-  # otherwise Kernel#fail is called with an appropriate message.
-  def self.require_library name, gem = true
+  # returns The return value of Kernel#require if the library is available and can be, or was previously, loaded.
+  # Otherwise, Kernel#fail is called with an appropriate message if on_failure is :abort.
+  # Otherwise, Kernel#warn is called with an appropriate message and nil returned if on_failure is :warn.
+  # Otherwise, nil is returned.
+  def self.require_library name, gem_name = true, on_failure = :abort
     require name
   rescue ::LoadError => e
-    if gem
-      fail %(asciidoctor: FAILED: required gem '#{gem == true ? name : gem}' is not installed. Processing aborted.)
+    if gem_name
+      gem_name = name if gem_name == true
+      case on_failure
+      when :abort
+        fail %(asciidoctor: FAILED: required gem '#{gem_name}' is not installed. Processing aborted.)
+      when :warn
+        warn %(asciidoctor: WARNING: optional gem '#{gem_name}' is not installed. Functionality disabled.)
+      end
     else
-      fail %(asciidoctor: FAILED: #{e.message.chomp '.'}. Processing aborted.)
+      case on_failure
+      when :abort
+        fail %(asciidoctor: FAILED: #{e.message.chomp '.'}. Processing aborted.)
+      when :warn
+        warn %(asciidoctor: WARNING: #{e.message.chomp '.'}. Functionality disabled.)
+      end
     end
   end
 

--- a/lib/asciidoctor/parser.rb
+++ b/lib/asciidoctor/parser.rb
@@ -906,7 +906,7 @@ class Parser
         resolved_target = attributes['target']
         block.document.register(:images, resolved_target)
         attributes['alt'] ||= Helpers.basename(resolved_target, true).tr('_-', ' ')
-        attributes['alt'] = block.sub_specialcharacters attributes['alt']
+        attributes['alt'] = block.sub_specialchars attributes['alt']
         block.assign_caption attributes.delete('caption'), 'figure'
         if (scaledwidth = attributes['scaledwidth'])
           # append % to scaledwidth if ends in number (no units present)


### PR DESCRIPTION
- don't abort if server-side syntax highlighter isn't available (coderay, pygments)
- only attempt to load source highlighting library if not already loaded
- use document attribute to avoid redundant warnings if library can't be loaded
- use basic substitutions (specialcharacters, callouts) if source highlighter isn't available
- don't abort trying to load the Pygments stylesheet if Pygments isn't available
- add on_failure argument to require_library helper to control behavior on load failure