### PR TITLE
resolves #1412 use outfilesuffix defined in header when resolving outfile

### DIFF
--- a/lib/asciidoctor.rb
+++ b/lib/asciidoctor.rb
@@ -1424,6 +1424,7 @@ module Asciidoctor
   # file, otherwise the converted String
   def convert input, options = {}
     options = options.dup
+    options.delete(:parse)
     to_file = options.delete(:to_file)
     to_dir = options.delete(:to_dir)
     mkdirs = options.delete(:mkdirs) || false
@@ -1471,9 +1472,11 @@ module Asciidoctor
     end
 
     doc = self.load input, options
+    # QUESTION should we restore_attributes eagerly?
+    #doc.restore_attributes
 
     if write_to_same_dir
-      outfile = ::File.join outdir, %(#{doc.attributes['docname']}#{doc.attributes['outfilesuffix']})
+      outfile = ::File.join outdir, %(#{doc.attributes['docname']}#{doc.outfilesuffix})
       if outfile == input_path
         raise ::IOError, %(input file and output file cannot be the same: #{outfile})
       end
@@ -1488,7 +1491,7 @@ module Asciidoctor
           # reestablish outdir as the final target directory (in the case to_file had directory segments)
           outdir = ::File.dirname outfile
         else
-          outfile = ::File.join outdir, %(#{doc.attributes['docname']}#{doc.attributes['outfilesuffix']})
+          outfile = ::File.join outdir, %(#{doc.attributes['docname']}#{doc.outfilesuffix})
         end
       elsif to_file
         outfile = doc.normalize_system_path(to_file, working_dir, jail, :target_name => 'to_dir', :recover => false)

--- a/lib/asciidoctor/document.rb
+++ b/lib/asciidoctor/document.rb
@@ -139,6 +139,9 @@ class Document < AbstractBlock
   # Public: Get the Hash of resolved options used to initialize this Document
   attr_reader :options
 
+  # Public: Get the outfilesuffix defined at the end of the header.
+  attr_reader :outfilesuffix
+
   # Public: Get a reference to the parent Document of this nested document.
   attr_reader :parent_document
 
@@ -770,6 +773,9 @@ class Document < AbstractBlock
       @compat_mode = false
     end
 
+    # NOTE pin the outfilesuffix after the header is parsed
+    @outfilesuffix = attrs['outfilesuffix']
+
     @original_attributes = attrs.dup
 
     # unfreeze "flexible" attributes
@@ -1109,7 +1115,7 @@ class Document < AbstractBlock
       ''
     else
       qualifier = (location == :footer ? '-footer' : nil)
-      ext = @attributes['outfilesuffix'] unless ext
+      ext = @outfilesuffix unless ext
       docinfodir = @attributes['docinfodir']
 
       content = nil


### PR DESCRIPTION
- assign outfilesuffix to instance variable on Document after parsing header
- expose reader for outfilesuffix property on Document
- force load method to parse document when invoked from convert* methods