### PR TITLE
Fixed Travis Status button in README file

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -73,7 +73,7 @@ Asciidoctor.js is used to power the AsciiDoc preview extensions for Chrome, Atom
 
 ifdef::badges[]
 .*Project health*
-image:https://travis-ci.org/asciidoctor/asciidoctor.svg?branch=master["Build Status (Travis CI)", link="https://travis-ci.org/asciidoctor/asciidoctor"]
+image:https://img.shields.io/travis/asciidoctor/asciidoctor.svg["Build Status (Travis CI)", link="https://travis-ci.org/asciidoctor/asciidoctor"]
 image:https://ci.appveyor.com/api/projects/status/ifplu67oxvgn6ceq/branch/master?svg=true&amp;passingText=green%20bar&amp;failingText=%23fail&amp;pendingText=building%2E%2E%2E[Build Status (AppVeyor), link=https://ci.appveyor.com/project/asciidoctor/asciidoctor] 
 //image:https://img.shields.io/coveralls/asciidoctor/asciidoctor/master.svg[Coverage Status, link=https://coveralls.io/r/asciidoctor/asciidoctor]
 image:https://codeclimate.com/github/asciidoctor/asciidoctor/badges/gpa.svg[Code Climate, link="https://codeclimate.com/github/asciidoctor/asciidoctor"]

--- a/README.adoc
+++ b/README.adoc
@@ -73,7 +73,7 @@ Asciidoctor.js is used to power the AsciiDoc preview extensions for Chrome, Atom
 
 ifdef::badges[]
 .*Project health*
-image:https://img.shields.io/travis/asciidoctor/asciidoctor/master.svg[Build Status (Travis CI), link=https://travis-ci.org/asciidoctor/asciidoctor] 
+image:https://travis-ci.org/asciidoctor/asciidoctor.svg?branch=master["Build Status (Travis CI)", link="https://travis-ci.org/asciidoctor/asciidoctor"]
 image:https://ci.appveyor.com/api/projects/status/ifplu67oxvgn6ceq/branch/master?svg=true&amp;passingText=green%20bar&amp;failingText=%23fail&amp;pendingText=building%2E%2E%2E[Build Status (AppVeyor), link=https://ci.appveyor.com/project/asciidoctor/asciidoctor] 
 //image:https://img.shields.io/coveralls/asciidoctor/asciidoctor/master.svg[Coverage Status, link=https://coveralls.io/r/asciidoctor/asciidoctor]
 image:https://codeclimate.com/github/asciidoctor/asciidoctor/badges/gpa.svg[Code Climate, link="https://codeclimate.com/github/asciidoctor/asciidoctor"]
@@ -587,4 +587,3 @@ Infrastructure::
   * rework README (@mogztter) (#651)
 
 Refer to the {uri-changelog}[CHANGELOG] for a complete list of changes in older releases.
-

--- a/README.adoc
+++ b/README.adoc
@@ -587,3 +587,4 @@ Infrastructure::
   * rework README (@mogztter) (#651)
 
 Refer to the {uri-changelog}[CHANGELOG] for a complete list of changes in older releases.
+


### PR DESCRIPTION
Fixed Travis Status button in README file.

Example: https://github.com/jasnow/asciidoctor