### PR TITLE
track ordered list starting marker

### DIFF
--- a/test/lists_test.rb
+++ b/test/lists_test.rb
@@ -1738,6 +1738,18 @@ List
       assert_xpath '(//orderedlist)/listitem', output, 2
       assert_xpath '(//orderedlist)[@startingnumber = "7"]', output, 1
     end
+
+    test 'should offset ordered list to first marker' do
+      input = <<-EOS
+== List
+
+5. item 5
+6. item 6
+      EOS
+
+      output = render_string input
+      assert_xpath '//ol[@start = 5]', output, 1
+    end
   end
 end
 


### PR DESCRIPTION
See https://github.com/asciidoctor/asciidoctor/issues/1464. This change checks the marker of an ordered list and adjusts the start attribute to match the marker. This lets
```
5. five
6. six
```
do the same thing as
```
[start=5]
. five
. six
```
This is still under discussion. 