### PR TITLE
Fixes #1366: Added method AbstractNode#add_role

### DIFF
--- a/lib/asciidoctor/abstract_node.rb
+++ b/lib/asciidoctor/abstract_node.rb
@@ -221,6 +221,21 @@ class AbstractNode
     end
   end
 
+  # Public: A convenience method that adds the given role directly to this node
+  def add_role(name)
+    unless (roles = (@attributes['role'] || '').split(' ')).include? name
+      @attributes['role'] = roles.push(name) * ' '
+    end
+  end
+
+  # Public: A convenience method that removes the given role directly from this node
+  def remove_role(name)
+    if (roles = (@attributes['role'] || '').split(' ')).include? name
+      roles.delete name
+      @attributes['role'] = roles * ' '
+    end
+  end
+
   # Public: A convenience method that checks if the reftext attribute is specified
   def reftext?
     @attributes.has_key?('reftext') || @document.attributes.has_key?('reftext')

--- a/test/attributes_test.rb
+++ b/test/attributes_test.rb
@@ -1067,6 +1067,79 @@ Text
       assert para.attributes.has_key?('option2-option')
     end
 
+    test 'a role can be added using add_role when the node has no roles' do
+        input = <<-EOS
+A normal paragraph        
+        EOS
+      doc = document_from_string(input)
+      para = doc.blocks.first
+      para.add_role 'role1'
+      assert_equal 'role1', para.attributes['role']
+      assert para.has_role? 'role1'
+    end
+
+    test 'a role can be added using add_role when the node already has a role' do
+        input = <<-EOS
+[.role1]
+A normal paragraph        
+        EOS
+      doc = document_from_string(input)
+      para = doc.blocks.first
+      para.add_role 'role2'
+      assert_equal 'role1 role2', para.attributes['role']
+      assert para.has_role? 'role1'
+      assert para.has_role? 'role2'
+    end
+
+    test 'a role is not added using add_role if the node already has that role' do
+        input = <<-EOS
+[.role1]
+A normal paragraph        
+        EOS
+      doc = document_from_string(input)
+      para = doc.blocks.first
+      para.add_role 'role1'
+      assert_equal 'role1', para.attributes['role']
+      assert para.has_role? 'role1'
+    end
+
+    test 'an existing role can be removed using remove_role' do
+        input = <<-EOS
+[.role1.role2]
+A normal paragraph        
+        EOS
+      doc = document_from_string(input)
+      para = doc.blocks.first
+      para.remove_role 'role1'
+      assert_equal 'role2', para.attributes['role']
+      assert para.has_role? 'role2'
+      assert !para.has_role?('role1')
+    end
+
+    test 'roles are not changed when a non-existent role is removed using remove_role' do
+        input = <<-EOS
+[.role1]
+A normal paragraph        
+        EOS
+      doc = document_from_string(input)
+      para = doc.blocks.first
+      para.remove_role 'role2'
+      assert_equal 'role1', para.attributes['role']
+      assert para.has_role? 'role1'
+      assert !para.has_role?('role2')
+    end
+
+    test 'roles are not changed when using remove_role if the node has no roles' do
+        input = <<-EOS
+A normal paragraph        
+        EOS
+      doc = document_from_string(input)
+      para = doc.blocks.first
+      para.remove_role 'role1'
+      assert_equal nil, para.attributes['role']
+      assert !para.has_role?('role1')
+    end
+
     test 'option can be specified in first position of block style using shorthand syntax' do
       input = <<-EOS
 [%interactive]


### PR DESCRIPTION
This PR adds a method `AbstractNode#add_role` to add a role to a certain node.
Document level roles are not considered when adding a role, it will be added in any case, if the node itself does not carry that role yet.