### PR TITLE
Add option to control timestamp generation.

### DIFF
--- a/lib/asciidoctor/converter/docbook5.rb
+++ b/lib/asciidoctor/converter/docbook5.rb
@@ -661,7 +661,9 @@ module Asciidoctor
       result = []
       result << %(<#{info_tag_prefix}info>)
       result << document_title_tags(doc.doctitle :partition => true, :use_fallback => true) unless doc.notitle
-      result << %(<date>#{(doc.attr? 'revdate') ? (doc.attr 'revdate') : (doc.attr 'docdate')}</date>)
+      if (doc.attr? 'revdate') || (doc.attr? 'timestamps')
+        result << %(<date>#{(doc.attr? 'revdate') ? (doc.attr 'revdate') : (doc.attr 'docdate')}</date>)
+      end
       if doc.has_header?
         if doc.attr? 'author'
           if (authorcount = (doc.attr 'authorcount').to_i) < 2

--- a/lib/asciidoctor/converter/html5.rb
+++ b/lib/asciidoctor/converter/html5.rb
@@ -199,7 +199,7 @@ module Asciidoctor
         result << '<div id="footer">'
         result << '<div id="footer-text">'
         result << %(#{node.attr 'version-label'} #{node.attr 'revnumber'}#{br}) if node.attr? 'revnumber'
-        result << %(#{node.attr 'last-update-label'} #{node.attr 'docdatetime'}) if node.attr? 'last-update-label'
+        result << %(#{node.attr 'last-update-label'} #{node.attr 'docdatetime'}) if (node.attr? 'last-update-label') && (node.attr? 'timestamps')
         result << '</div>'
         result << '</div>'
       end

--- a/lib/asciidoctor/converter/manpage.rb
+++ b/lib/asciidoctor/converter/manpage.rb
@@ -62,15 +62,16 @@ module Asciidoctor
       mantitle = node.attr 'mantitle'
       manvolnum = node.attr 'manvolnum', '1'
       manname = node.attr 'manname', mantitle
+      docdate = (node.attr? 'timestamps') ? (node.attr 'docdate') : nil
       result = [%('\\" t
 .\\"     Title: #{mantitle}
 .\\"    Author: #{(node.attr? 'authors') ? (node.attr 'authors') : '[see the "AUTHORS" section]'}
-.\\" Generator: Asciidoctor #{node.attr 'asciidoctor-version'}
-.\\"      Date: #{docdate = node.attr 'docdate'}
-.\\"    Manual: #{manual = (node.attr? 'manmanual') ? (node.attr 'manmanual') : '\ \&'}
+.\\" Generator: Asciidoctor #{node.attr 'asciidoctor-version'})]
+      result << %(.\\"      Date: #{docdate}) if docdate
+      result << %(.\\"    Manual: #{manual = (node.attr? 'manmanual') ? (node.attr 'manmanual') : '\ \&'}
 .\\"    Source: #{source = (node.attr? 'mansource') ? (node.attr 'mansource') : '\ \&'}
 .\\"  Language: English
-.\\")]
+.\\")
       # TODO add document-level setting to disable capitalization of manname
       result << %(.TH "#{manify manname.upcase}" "#{manvolnum}" "#{docdate}" "#{manify source}" "#{manify manual}")
       # define portability settings

--- a/lib/asciidoctor/document.rb
+++ b/lib/asciidoctor/document.rb
@@ -262,6 +262,7 @@ class Document < AbstractBlock
     attrs['attribute-undefined'] = Compliance.attribute_undefined
     attrs['attribute-missing'] = Compliance.attribute_missing
     attrs['iconfont-remote'] = ''
+    attrs['timestamps'] = ''
 
     # language strings
     # TODO load these based on language settings

--- a/test/document_test.rb
+++ b/test/document_test.rb
@@ -261,6 +261,30 @@ preamble
       assert doc.attributes.has_key?('toc')
     end
 
+    test 'should generate timestamps by default' do
+      doc = document_from_string 'text', :backend => :html5, :attributes => nil
+      result = doc.convert
+      assert doc.attributes.has_key?('docdate')
+      assert_equal doc.attributes['timestamps'], ''
+      assert_xpath '//div[@id="footer-text" and contains(string(.//text()), "Last updated")]', result
+    end
+
+    test 'should not generate timestamps if timestamps is unset in HTML 5' do
+      doc = document_from_string 'text', :backend => :html5, :attributes => { 'timestamps' => nil }
+      result = doc.convert
+      assert doc.attributes.has_key?('docdate')
+      assert !doc.attributes['timestamps']
+      assert_xpath '//div[@id="footer-text" and contains(string(.//text()), "Last updated")]', result, 0
+    end
+
+    test 'should not generate timestamps if timestamps is unset in DocBook' do
+      doc = document_from_string 'text', :backend => :docbook, :attributes => { 'timestamps' => nil }
+      result = doc.convert
+      assert doc.attributes.has_key?('docdate')
+      assert !doc.attributes['timestamps']
+      assert_xpath '/article/info/date', result, 0
+    end
+
     test 'should not modify options argument' do
       options = {
         :safe => Asciidoctor::SafeMode::SAFE


### PR DESCRIPTION
This commit adds a "timestamps" option, defaulting to true, that controls whether timestamps (docdate, doctime, docdatetime, localdate, localtime, and localdatetime) are generated. If unset, this option ensures that output is reproducible.

Fixes #1453.

Viewing with git diff -w is recommended.