### PR TITLE
resolves #1544 built-in writer should not fail if output is nil

### DIFF
--- a/lib/asciidoctor/document.rb
+++ b/lib/asciidoctor/document.rb
@@ -1037,7 +1037,7 @@ class Document < AbstractBlock
       if (block = @blocks[0]) && block.content_model != :compound
         output = block.content
       else
-        output = ''
+        output = nil
       end
     else
       transform = ((opts.key? :header_footer) ? opts[:header_footer] : @options[:header_footer]) ? 'document' : 'embedded'
@@ -1067,9 +1067,11 @@ class Document < AbstractBlock
       @converter.write output, target
     else
       if target.respond_to? :write
-        target.write output.chomp
-        # ensure there's a trailing endline
-        target.write EOL
+        unless output.nil_or_empty?
+          target.write output.chomp
+          # ensure there's a trailing endline
+          target.write EOL
+        end
       else
         ::File.open(target, 'w') {|f| f.write output }
       end

--- a/test/paragraphs_test.rb
+++ b/test/paragraphs_test.rb
@@ -514,10 +514,10 @@ Wise words from a wise person.
         assert_equal '<a href="http://asciidoc.org">AsciiDoc</a> is a <em>lightweight</em> markup language&#8230;&#8203;', output
       end
 
-      test 'should output empty string if first block is not a paragraph' do
+      test 'should output nil if first block is not a paragraph' do
         input = '* bullet'
         output = render_string input, :doctype => 'inline'
-        assert output.empty?
+        assert output.nil?
       end
     end
   end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -185,7 +185,7 @@ class Minitest::Test
     else
       # this is required because nokogiri is ignorant
       result = document_from_string(src, opts).render
-      result = result.sub(RE_XMLNS_ATTRIBUTE, '')
+      result = result.sub(RE_XMLNS_ATTRIBUTE, '') if result
       result
     end
   end


### PR DESCRIPTION
- don't fail if output is nil
- don't output trailing endline if output is empty
- inline doctype should return nil if there's nothing to convert