### PR TITLE
Initialize slim-related attributes regardless of when slim was loaded

### DIFF
--- a/lib/asciidoctor/converter/template.rb
+++ b/lib/asciidoctor/converter/template.rb
@@ -253,10 +253,10 @@ module Asciidoctor
           unless defined? ::Slim
             # slim doesn't get loaded by Tilt, so we have to load it explicitly
             Helpers.require_library 'slim'
-            if @safe && ::Slim::VERSION >= '3.0'
-              slim_asciidoc_opts = (@engine_options[:slim][:asciidoc] ||= {})
-              slim_asciidoc_opts[:safe] ||= @safe
-            end
+          end
+          if @safe && ::Slim::VERSION >= '3.0'
+            slim_asciidoc_opts = (@engine_options[:slim][:asciidoc] ||= {})
+            slim_asciidoc_opts[:safe] ||= @safe
           end
           # load include plugin when using Slim >= 2.1
           require 'slim/include' unless (defined? ::Slim::Include) || ::Slim::VERSION < '2.1'


### PR DESCRIPTION
Setting instance attributes of the Template class cannot depend on
whether slim has been loaded before or not.