### PR TITLE
resolves #1597 change xlink namespace to xl in DocBook 5 output

### DIFF
--- a/lib/asciidoctor/converter/docbook5.rb
+++ b/lib/asciidoctor/converter/docbook5.rb
@@ -503,13 +503,13 @@ module Asciidoctor
       when :xref
         if (path = node.attributes['path'])
           # QUESTION should we use refid as fallback text instead? (like the html5 backend?)
-          %(<link xlink:href="#{node.target}">#{node.text || path}</link>)
+          %(<link xl:href="#{node.target}">#{node.text || path}</link>)
         else
           linkend = node.attributes['fragment'] || node.target
           (text = node.text) ? %(<link linkend="#{linkend}">#{text}</link>) : %(<xref linkend="#{linkend}"/>)
         end
       when :link
-        %(<link xlink:href="#{node.target}">#{node.text}</link>)
+        %(<link xl:href="#{node.target}">#{node.text}</link>)
       when :bibref
         target = node.target
         %(<anchor#{common_attributes target, nil, "[#{target}]"}/>[#{target}])
@@ -707,7 +707,7 @@ module Asciidoctor
     end
 
     def document_ns_attributes doc
-      ' xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" version="5.0"'
+      ' xmlns="http://docbook.org/ns/docbook" xmlns:xl="http://www.w3.org/1999/xlink" version="5.0"'
     end
 
     def lang_attribute_name

--- a/test/document_test.rb
+++ b/test/document_test.rb
@@ -1787,7 +1787,7 @@ section body
       assert_xpath '/xmlns:article', result, 1
       doc = xmlnodes_at_xpath('/xmlns:article', result, 1).first
       assert_equal 'http://docbook.org/ns/docbook', doc.namespaces['xmlns']
-      assert_equal 'http://www.w3.org/1999/xlink', doc.namespaces['xmlns:xlink']
+      assert_equal 'http://www.w3.org/1999/xlink', doc.namespaces['xmlns:xl']
       assert_xpath '/xmlns:article[@version="5.0"]', result, 1
       assert_xpath '/xmlns:article/xmlns:info/xmlns:title[text() = "Title"]', result, 1
       assert_xpath '/xmlns:article/xmlns:simpara[text() = "preamble"]', result, 1
@@ -1821,7 +1821,7 @@ section body
       assert_xpath '/xmlns:refentry', result, 1
       doc = xmlnodes_at_xpath('/xmlns:refentry', result, 1).first
       assert_equal 'http://docbook.org/ns/docbook', doc.namespaces['xmlns']
-      assert_equal 'http://www.w3.org/1999/xlink', doc.namespaces['xmlns:xlink']
+      assert_equal 'http://www.w3.org/1999/xlink', doc.namespaces['xmlns:xl']
       assert_xpath '/xmlns:refentry[@version="5.0"]', result, 1
       assert_xpath '/xmlns:refentry/xmlns:info/xmlns:title[text() = "asciidoctor(1)"]', result, 1
       assert_xpath '/xmlns:refentry/xmlns:refmeta/xmlns:refentrytitle[text() = "asciidoctor"]', result, 1
@@ -1855,7 +1855,7 @@ chapter body
       assert_xpath '/xmlns:book', result, 1
       doc = xmlnodes_at_xpath('/xmlns:book', result, 1).first
       assert_equal 'http://docbook.org/ns/docbook', doc.namespaces['xmlns']
-      assert_equal 'http://www.w3.org/1999/xlink', doc.namespaces['xmlns:xlink']
+      assert_equal 'http://www.w3.org/1999/xlink', doc.namespaces['xmlns:xl']
       assert_xpath '/xmlns:book[@version="5.0"]', result, 1
       assert_xpath '/xmlns:book/xmlns:info/xmlns:title[text() = "Title"]', result, 1
       assert_xpath '/xmlns:book/xmlns:preface/xmlns:simpara[text() = "preamble"]', result, 1

--- a/test/links_test.rb
+++ b/test/links_test.rb
@@ -38,6 +38,16 @@ context 'Links' do
     assert_xpath %{//a[@href='http://asciidoc.org'][text() = 'AsciiDoc\nmarkup']}, render_string("We're parsing link:http://asciidoc.org[AsciiDoc\nmarkup]")
   end
 
+  test 'qualified url with label containing square brackets using link macro' do
+    str = 'http://example.com[[bracket1\]]'
+    doc = document_from_string str, :header_footer => false, :doctype => 'inline'
+    assert_match '<a href="http://example.com">[bracket1]</a>', doc.convert, 1
+    doc = document_from_string str, :header_footer => false, :backend => 'docbook', :doctype => 'inline'
+    assert_match '<link xl:href="http://example.com">[bracket1]</link>', doc.convert, 1
+    doc = document_from_string str, :header_footer => false, :backend => 'docbook45', :doctype => 'inline'
+    assert_match '<ulink url="http://example.com">[bracket1]</ulink>', doc.convert, 1
+  end
+
   test 'qualified url surrounded by angled brackets' do
     assert_xpath '//a[@href="http://asciidoc.org"][text()="http://asciidoc.org"]', render_string('<http://asciidoc.org> is the project page for AsciiDoc.'), 1
   end
@@ -204,7 +214,7 @@ context 'Links' do
 
   test 'xref using angled bracket syntax with path sans extension using docbook backend' do
     doc = document_from_string '<<tigers#>>', :header_footer => false, :backend => 'docbook'
-    assert_match '<link xlink:href="tigers.xml">tigers.xml</link>', doc.render, 1
+    assert_match '<link xl:href="tigers.xml">tigers.xml</link>', doc.render, 1
     doc = document_from_string '<<tigers#>>', :header_footer => false, :backend => 'docbook45'
     assert_match '<ulink url="tigers.xml">tigers.xml</ulink>', doc.render, 1
   end


### PR DESCRIPTION
- change xlink namespace to xl to prevent invalid substitutions
- add test for square brackets in link text