### PR TITLE
resolves #1582 don't include default toc in nested document

### DIFF
--- a/lib/asciidoctor/converter/html5.rb
+++ b/lib/asciidoctor/converter/html5.rb
@@ -270,11 +270,13 @@ MathJax.Hub.Config({
         end
       end
 
-      if (node.attr? 'toc') && !['macro', 'preamble'].include?(node.attr 'toc-placement')
-        result << %(<div id="toc" class="toc">
+      unless node.nested?
+        if (node.attr? 'toc') && !['macro', 'preamble'].include?(node.attr 'toc-placement')
+          result << %(<div id="toc" class="toc">
 <div id="toctitle">#{node.attr 'toc-title'}</div>
 #{outline node}
 </div>)
+        end
       end
 
       result << node.content
@@ -952,6 +954,7 @@ Your browser does not support the audio tag.
           asset_uri_scheme = %(#{asset_uri_scheme}:)
         end
         rel_param_val = (node.option? 'related') ? 1 : 0
+        # NOTE start and end must be seconds (t parameter allows XmYs where X is minutes and Y is seconds)
         start_param = (node.attr? 'start', nil, false) ? %(&amp;start=#{node.attr 'start'}) : nil
         end_param = (node.attr? 'end', nil, false) ? %(&amp;end=#{node.attr 'end'}) : nil
         autoplay_param = (node.option? 'autoplay') ? '&amp;autoplay=1' : nil

--- a/test/tables_test.rb
+++ b/test/tables_test.rb
@@ -856,6 +856,24 @@ a|AsciiDoc footnote:[A lightweight markup language.]
       assert_css 'table > tbody > tr > td:nth-child(2) table > tbody > tr > td', output, 2
     end
 
+    test 'toc from parent document should not be included in an AsciiDoc table cell' do
+      input = <<-EOS
+= Document Title
+:toc:
+
+== Section A
+
+[cols="1a"]
+|===
+|AsciiDoc content
+|===
+      EOS
+
+      output = render_string input
+      assert_css '.toc', output, 1
+      assert_css 'table .toc', output, 0
+    end
+
     test 'nested document in AsciiDoc cell should not see doctitle of parent' do
       input = <<-EOS
 = Document Title


### PR DESCRIPTION
- prevent default toc from being inserted into AsciiDoc table cell
- add test to cover scenario