### PR TITLE
reresolves #1582 don't pass toc location attributes to subdocument

### DIFF
--- a/lib/asciidoctor/converter/html5.rb
+++ b/lib/asciidoctor/converter/html5.rb
@@ -270,13 +270,11 @@ MathJax.Hub.Config({
         end
       end
 
-      unless node.nested?
-        if (node.attr? 'toc') && !['macro', 'preamble'].include?(node.attr 'toc-placement')
-          result << %(<div id="toc" class="toc">
+      if (node.attr? 'toc') && !['macro', 'preamble'].include?(node.attr 'toc-placement')
+        result << %(<div id="toc" class="toc">
 <div id="toctitle">#{node.attr 'toc-title'}</div>
 #{outline node}
 </div>)
-        end
       end
 
       result << node.content

--- a/lib/asciidoctor/document.rb
+++ b/lib/asciidoctor/document.rb
@@ -184,8 +184,9 @@ class Document < AbstractBlock
       # QUESTION should we support setting attribute in parent document from nested document?
       # NOTE we must dup or else all the assignments to the overrides clobbers the real attributes
       attr_overrides = parent_doc.attributes.dup
-      attr_overrides.delete 'doctype'
-      attr_overrides.delete 'compat-mode'
+      ['doctype', 'compat-mode', 'toc', 'toc-placement', 'toc-position'].each do |key|
+        attr_overrides.delete key
+      end
       @attribute_overrides = attr_overrides
       @safe = parent_doc.safe
       @compat_mode = parent_doc.compat_mode

--- a/test/tables_test.rb
+++ b/test/tables_test.rb
@@ -863,15 +863,64 @@ a|AsciiDoc footnote:[A lightweight markup language.]
 
 == Section A
 
-[cols="1a"]
 |===
-|AsciiDoc content
+a|AsciiDoc content
 |===
       EOS
 
       output = render_string input
       assert_css '.toc', output, 1
       assert_css 'table .toc', output, 0
+    end
+
+    test 'should be able to enable toc in AsciiDoc table cell' do
+      input = <<-EOS
+= Document Title
+
+== Section A
+
+|===
+a|
+= Subdocument Title
+:toc:
+
+== Subdocument Section A
+
+content
+|===
+      EOS
+
+      output = render_string input
+      assert_css '.toc', output, 1
+      assert_css 'table .toc', output, 1
+    end
+
+    test 'should be able to enable toc in both outer document and AsciiDoc table cell' do
+      input = <<-EOS
+= Document Title
+:toc:
+
+== Section A
+
+|===
+a|
+= Subdocument Title
+:toc: macro
+
+[#table-cell-toc]
+toc::[]
+
+== Subdocument Section A
+
+content
+|===
+      EOS
+
+      output = render_string input
+      assert_css '.toc', output, 2
+      assert_css '#toc', output, 1
+      assert_css 'table .toc', output, 1
+      assert_css 'table #table-cell-toc', output, 1
     end
 
     test 'nested document in AsciiDoc cell should not see doctitle of parent' do


### PR DESCRIPTION
- don't pass toc location attributes (toc, toc-placement, toc-position) to subdocument
- allow toc to be enabled in AsciiDoc table cell
- add tests for more toc scenarios in AsciiDoc table cell