### PR TITLE
Remove horizontal space after .URL's third argument…

### DIFF
--- a/lib/asciidoctor/converter/manpage.rb
+++ b/lib/asciidoctor/converter/manpage.rb
@@ -26,6 +26,7 @@ module Asciidoctor
         gsub(/(?:\A|[^#{ESC}])\\/, '\&(rs'). # literal backslash (not a troff escape sequence)
         gsub(/^\./, '\\\&.').     # leading . is used in troff for macro call or other formatting
         # unescape troff macro and quote last URL argument
+        gsub(/^#{ESC}\.((?:URL|MTO) ".*?" ".*?" )( |[^\s]*) *$/,          ".\\1\"\\2\"#{LF}\\c").
         gsub(/^#{ESC}\.((?:URL|MTO) ".*?" ".*?" )( |[^\s]*) *(.*?)( *)$/, ".\\1\"\\2\"#{LF}\\c#{LF}\\3").
         # strip blank lines in source that precede a URL
         gsub(/(?:\A\n|(?:\n *| +)(\n))^\.(URL|MTO) /, '\1.\2 ').

--- a/lib/asciidoctor/converter/manpage.rb
+++ b/lib/asciidoctor/converter/manpage.rb
@@ -26,7 +26,7 @@ module Asciidoctor
         gsub(/(?:\A|[^#{ESC}])\\/, '\&(rs'). # literal backslash (not a troff escape sequence)
         gsub(/^\./, '\\\&.').     # leading . is used in troff for macro call or other formatting
         # unescape troff macro and quote last URL argument
-        gsub(/^#{ESC}\.((?:URL|MTO) ".*?" ".*?" )( |[^\s]*)(.*?)( *)$/, ".\\1\"\\2\"#{LF}\\c#{LF}\\3").
+        gsub(/^#{ESC}\.((?:URL|MTO) ".*?" ".*?" )( |[^\s]*) *(.*?)( *)$/, ".\\1\"\\2\"#{LF}\\c#{LF}\\3").
         # strip blank lines in source that precede a URL
         gsub(/(?:\A\n|(?:\n *| +)(\n))^\.(URL|MTO) /, '\1.\2 ').
         gsub('-', '\\-').


### PR DESCRIPTION
…since linefeed after \c is already a space.

This is a subtle bug that occurs at only some line lengths. E.g.,
```
The script troff2page runs on the Unix command-line on Cygwin, Linux,
Mac OS X, and Solaris.  It uses the Common Lisp implementation mentioned
in the shell environment variable LISP, which can currently be set to
either clisp, clozure, cmu, ecl or sbcl: the corresponding Lisp
implementations being
http://clisp.sf.net[CLISP],
http://ccl.clozure.com[Clozure CL],
http://cmucl.org[CMUCL],
http://ecls.sf.net[ECL], and
http://sbcl.sf.net[SBCL].
```
The line `http://ecls.sf.net[ECL], and` currently gets translated to
```
.URL "http://ecls.sf.net" "ECL" ","
\c
 and
```
Note the space before `and`. If the man pager happens to line break just at the `,`, that space shows up as a glaring leading space in the immediately following line.  (My example above will show up this error if you have a `MANWIDTH` of 80.)

The translation is placing after the generated `\c` whatever's after `.URL`'s 3rd argument, and this typically has some leading space.  But this isn't needed (indeed, _shouldn't_ be included), because the linefeed introduced after the generated `\c` is already a space. (The extraneous space shows up even when there is no coincidental linebreak, but is less visible to human eyes then because it seems like it could be an artifact of the rather courageous monospace-based both-sides line justification done by the man pager.)

PR submitted.