### PR TITLE
resolves #1679 fix false positive for start of list

### DIFF
--- a/lib/asciidoctor.rb
+++ b/lib/asciidoctor.rb
@@ -646,7 +646,9 @@ module Asciidoctor
     ## Lists
 
     # Detects the start of any list item.
-    AnyListRx = /^(?:<?\d+>#{CG_BLANK}+#{CG_GRAPH}|#{CG_BLANK}*(?:-|(?:\*|\.|\u2022){1,5}|\d+\.|[a-zA-Z]\.|[IVXivx]+\))#{CG_BLANK}+#{CG_GRAPH}|#{CG_BLANK}*.*?(?::{2,4}|;;)(?:#{CG_BLANK}+#{CG_GRAPH}|$))/
+    #
+    # NOTE we only have to check as far as the blank character because we know it means non-whitespace follows.
+    AnyListRx = /^(?:#{CG_BLANK}*(?:-|([*.\u2022])\1{0,4}|\d+\.|[a-zA-Z]\.|[IVXivx]+\))#{CG_BLANK}|#{CG_BLANK}*.*?(?::{2,4}|;;)(?:$|#{CG_BLANK})|<?\d+>#{CG_BLANK})/
 
     # Matches an unordered list item (one level for hyphens, up to 5 levels for asterisks).
     #

--- a/test/lists_test.rb
+++ b/test/lists_test.rb
@@ -258,6 +258,18 @@ second wrapped line
       assert !output.include?('* Foo')
     end
 
+    test 'a list item that starts with a sequence of list markers characters should not match a nested list' do
+      input = <<-EOS
+ * first item
+ *. normal text
+      EOS
+
+      output = render_embedded_string input
+      assert_css 'ul', output, 1
+      assert_css 'ul li', output, 1
+      assert_xpath "//ul/li/p[text()='first item\n*. normal text']", output, 1
+    end
+
     test 'a list item for a different list terminates indented paragraph for text of list item' do
       input = <<-EOS
 == Example 1


### PR DESCRIPTION
- fix false positive when checking for start of list causing an infinite loop
- optimize the AnyListRx regex (only check up to blank as we know non-blank follows)