### PR TITLE
Honour SOURCE-DATE_EPOCH.

### DIFF
--- a/lib/asciidoctor.rb
+++ b/lib/asciidoctor.rb
@@ -1,4 +1,4 @@
-# encoding: UTF-8
+# encoding: utf-8
 RUBY_ENGINE = 'unknown' unless defined? RUBY_ENGINE
 RUBY_ENGINE_OPAL = (RUBY_ENGINE == 'opal')
 RUBY_ENGINE_JRUBY = (RUBY_ENGINE == 'jruby')
@@ -1311,7 +1311,15 @@ module Asciidoctor
     if ::File === input
       # TODO cli checks if input path can be read and is file, but might want to add check to API
       input_path = ::File.expand_path input.path
-      input_mtime = input.mtime
+      # If the environment variable SOURCE_DATE_EPOCH is set, use it
+      # as the epoch of the document date. If not, use the file last
+      # modification date.
+      # See https://reproducible-builds.org/specs/source-date-epoch/
+      if ENV['SOURCE_DATE_EPOCH'].nil?
+        input_mtime = input.mtime
+      else
+        input_mtime = ::Time.at(ENV['SOURCE_DATE_EPOCH'].to_i).gmtime
+      end
       lines = input.readlines
       # hold off on setting infile and indir until we get a better sense of their purpose
       attributes['docfile'] = input_path

--- a/lib/asciidoctor/document.rb
+++ b/lib/asciidoctor/document.rb
@@ -401,7 +401,14 @@ class Document < AbstractBlock
       #attrs['infile'] = attrs['docfile']
 
       # dynamic intrinstic attribute values
-      now = ::Time.now
+      # If the environment variable SOURCE_DATE_EPOCH is set, use it
+      # as the epoch of the document date. If not, use current date.
+      # See https://reproducible-builds.org/specs/source-date-epoch/
+      if ENV['SOURCE_DATE_EPOCH'].nil?
+        now = ::Time.now
+      else
+        now = ::Time.at(ENV['SOURCE_DATE_EPOCH'].to_i).gmtime
+      end
       localdate = (attrs['localdate'] ||= now.strftime('%Y-%m-%d'))
       unless (localtime = attrs['localtime'])
         begin

--- a/man/asciidoctor.adoc
+++ b/man/asciidoctor.adoc
@@ -144,6 +144,10 @@ Matching templates found in subsequent directories override ones previously disc
 +
 `-v` can also be used if no other flags or arguments are present.
 
+== ENVIRONMENT VARIABLES
+
+*Asciidoctor* honours the SOURCE_DATE_EPOCH environment variable: if set to an integer value, it will be used as the epoch of the generated documents' date. See https://reproducible-builds.org/specs/source-date-epoch/.
+
 == EXIT STATUS
 
 *0*::

--- a/test/invoker_test.rb
+++ b/test/invoker_test.rb
@@ -1,4 +1,4 @@
-# encoding: UTF-8
+# encoding: utf-8
 unless defined? ASCIIDOCTOR_PROJECT_DIR
   $: << File.dirname(__FILE__); $:.uniq!
   require 'test_helper'
@@ -550,4 +550,13 @@ context 'Invoker' do
     assert_match(/Total time/, error)
   end
 
+  test 'should get date from SOURCE_DATE_EPOCH for file' do
+    saved = ENV['SOURCE_DATE_EPOCH']
+    ENV['SOURCE_DATE_EPOCH'] = "1234123412"
+    sample_filepath = File.expand_path(File.join(File.dirname(__FILE__), 'fixtures', 'sample.asciidoc'))
+    invoker = invoke_cli_to_buffer %w(-o /dev/null), sample_filepath
+    doc = invoker.document
+    ENV['SOURCE_DATE_EPOCH'] = saved
+    assert_equal '2009-02-08', doc.attr('docdate')
+  end
 end

--- a/test/manpage_test.rb
+++ b/test/manpage_test.rb
@@ -200,4 +200,15 @@ T}
 .TE'
     end
   end
+
+  context 'Environment' do
+    test 'should get date from SOURCE_DATE_EPOCH' do
+      saved = ENV['SOURCE_DATE_EPOCH']
+      ENV['SOURCE_DATE_EPOCH'] = "1234123412"
+      output = Asciidoctor.convert SAMPLE_MANPAGE_HEADER, :backend => :manpage, :header_footer => true
+      ENV['SOURCE_DATE_EPOCH'] = saved
+      assert_match(/Date: 2009-02-08/, output)
+    end
+  end
+
 end


### PR DESCRIPTION
If the environment variable SOURCE_DATE_EPOCH is set, it is used as the epoch of the documents built by asciidoctor.
See https://reproducible-builds.org/specs/source-date-epoch/.
This allows reproducible build for packages using asciidoctor to build their documentation.
See also https://wiki.debian.org/ReproducibleBuilds/.