### PR TITLE
Catalan translations for built-in labels

### DIFF
--- a/data/locale/attributes.adoc
+++ b/data/locale/attributes.adoc
@@ -45,3 +45,23 @@ ifeval::["{lang}" == "fr"]
 :version-label: Version
 :warning-caption: Attention
 endif::[]
+
+// Catalan translation: Abel Salgado Romero <abelromero@gmail.com>
+ifeval::["{lang}" == "ca"]
+:appendix-caption: Apendix
+:caution-caption: Atenció
+:example-caption: Exemple
+:figure-caption: Figura
+:important-caption: Important
+:last-update-label: Última actualització
+//:listing-caption: Llista
+:manname-title: Nom
+:note-caption: Nota
+//:preface-title: Prefaci
+:table-caption: Taula
+:tip-caption: Suggeriment
+:toc-title: Índex
+:untitled-label: Sense títol
+:version-label: Versió
+:warning-caption: Advertència
+endif::[]


### PR DESCRIPTION
Some notes about some of the translations proposed:

* **figure**: I've seen both _Figura_, _Il·lustració_ o _Imatge_, but according to definition 1 3 f of the official dictionary (http://dlc.iec.cat/results.asp?txtEntrada=figura) which translates as "Image that exemplifies the text of a book" I prefer _Figura_, and I think this is the more appropriate in our context.
* **toc**: both _Índex_, _Sumari_ and _Taula de continuguts_ are correct, but _Índex_ is the most common and feels the more natural to me (See 5 2 m which directly is referenced as a library science  usage http://dlc.iec.cat/results.asp?txtEntrada=index).
* **warning**: I doubted between _Advertència_ and _Avís_. No real preference here, I just prefer how _Advertència_ sounds.


/cc @lordofthejars 