### PR TITLE
Updated Italian translation

### DIFF
--- a/data/locale/attributes.adoc
+++ b/data/locale/attributes.adoc
@@ -170,7 +170,7 @@ endif::[]
 ifeval::["{lang}" == "it"]
 :appendix-caption: Appendice
 :caution-caption: Attenzione
-:chapter-label: // Capitolo
+:chapter-label: Capitolo
 :example-caption: Esempio
 :figure-caption: Figura
 :important-caption: Importante


### PR DESCRIPTION
I've changed my mind.

If the "Chapter" string is present "by default" it is just right to translate it. If I do not want it, it is easy to un-assign the string for all languages altogether. 