### PR TITLE
fix crash in generate_id when both idprefix & idseparator are blank

### DIFF
--- a/lib/asciidoctor/section.rb
+++ b/lib/asciidoctor/section.rb
@@ -87,8 +87,8 @@ class Section < AbstractBlock
       sep = @document.attributes['idseparator'] || '_'
       pre = @document.attributes['idprefix'] || '_'
       base_id = %(#{pre}#{title.downcase.gsub(InvalidSectionIdCharsRx, sep).tr_s(sep, sep).chomp(sep)})
-      # ensure id doesn't begin with idprefix if requested it doesn't
-      if pre.empty? && base_id.start_with?(sep)
+      # ensure id doesn't begin with idseparator if idprefix is empty and idseparator is not empty
+      if pre.empty? && !sep.empty? && base_id.start_with?(sep)
         base_id = base_id[1..-1]
         base_id = base_id[1..-1] while base_id.start_with?(sep)
       end

--- a/test/sections_test.rb
+++ b/test/sections_test.rb
@@ -51,6 +51,16 @@ context 'Sections' do
       assert_equal '_sectionone', sec.id
     end
 
+    test 'synthetic id separator can be set to blank when idprefix is blank' do
+      sec = block_from_string(":idprefix:\n:idseparator:\n\n== Section One")
+      assert_equal 'sectionone', sec.id
+    end
+
+    test 'synthetic id separator is removed from beginning of id when idprefix is blank' do
+      sec = block_from_string(":idprefix:\n:idseparator: _\n\n== +Section One")
+      assert_equal 'section_one', sec.id
+    end
+
     test 'synthetic ids can be disabled' do
       sec = block_from_string(":sectids!:\n\n== Section One\n")
       assert sec.id.nil?


### PR DESCRIPTION
- short-circuit prefix check if idseparator is blank
- add test for when idprefix and idseparator are both blank
- add test to verify leading idseparator is dropped if idprefix is empty