### PR TITLE
resolves #1651 don't share attributes between blocks parsed by parse_content

### DIFF
--- a/lib/asciidoctor/extensions.rb
+++ b/lib/asciidoctor/extensions.rb
@@ -106,16 +106,16 @@ module Extensions
 
     # Public: Parses blocks in the content and attaches the block to the parent.
     #
-    # Returns nothing
+    # Returns The parent node into which the blocks are parsed.
     #--
     # QUESTION is parse_content the right method name? should we wrap in open block automatically?
-    def parse_content parent, content, attributes = {}
-      reader = (content.is_a? Reader) ? content : (Reader.new content)
+    def parse_content parent, content, attributes = nil
+      reader = Reader === content ? content : (Reader.new content)
       while reader.has_more_lines?
-        block = Parser.next_block reader, parent, attributes
+        block = Parser.next_block reader, parent, (attributes ? attributes.dup : {})
         parent << block if block
       end
-      nil
+      parent
     end
 
     # TODO fill out remaining methods


### PR DESCRIPTION
- dup attributes before passing to next_block
- return parent node from parse_content method
- use === for type comparison instead of is_a?