### PR TITLE
resolves #1849 only disable implicit header on table when noheader option is set

### DIFF
--- a/lib/asciidoctor/parser.rb
+++ b/lib/asciidoctor/parser.rb
@@ -2290,15 +2290,17 @@ class Parser
     skipped = table_reader.skip_blank_lines
 
     parser_ctx = Table::ParserContext.new(table_reader, table, attributes)
+    skip_implicit_header = (attributes.key? 'header-option') || (attributes.key? 'noheader-option')
     loop_idx = -1
     while table_reader.has_more_lines?
       loop_idx += 1
       line = table_reader.read_line
 
-      if skipped == 0 && loop_idx == 0 && !attributes.has_key?('options') &&
+      if !skip_implicit_header && skipped == 0 && loop_idx == 0 &&
           !(next_line = table_reader.peek_line).nil? && next_line.empty?
         table.has_header_option = true
-        table.set_option 'header'
+        attributes['header-option'] = ''
+        attributes['options'] = (attributes.key? 'options') ? %(#{attributes['options']},header) : 'header'
       end
 
       if parser_ctx.format == 'psv'

--- a/lib/asciidoctor/table.rb
+++ b/lib/asciidoctor/table.rb
@@ -392,7 +392,7 @@ class Table::ParserContext
   # when the cell is being closed.
   #
   # returns The cell spec Hash captured from parsing the previous cell
-  def take_cell_spec()
+  def take_cell_spec
     @cell_specs.shift
   end
 

--- a/test/tables_test.rb
+++ b/test/tables_test.rb
@@ -384,6 +384,27 @@ A | here| a | there
       assert_css 'table > tbody > tr', output, 2
     end
 
+    test 'table with implicit header row when other options set' do
+      input = <<-EOS
+[%autowidth]
+|===
+|Column 1 |Column 2
+
+|Data A1
+|Data B1
+|===
+      EOS
+      output = render_embedded_string input
+      assert_css 'table', output, 1
+      assert_css 'table[style*="width"]', output, 0
+      assert_css 'table > colgroup > col', output, 2
+      assert_css 'table > thead', output, 1
+      assert_css 'table > thead > tr', output, 1
+      assert_css 'table > thead > tr > th', output, 2
+      assert_css 'table > tbody', output, 1
+      assert_css 'table > tbody > tr', output, 1
+    end
+
     test 'no implicit header row if second line not blank' do
       input = <<-EOS
 |===
@@ -425,9 +446,9 @@ A | here| a | there
       assert_css 'table > tbody > tr', output, 3
     end
 
-    test 'no implicit header row if options is specified' do
+    test 'no implicit header row if noheader option is specified' do
       input = <<-EOS
-[options=""]
+[%noheader]
 |===
 |Column 1 |Column 2
 


### PR DESCRIPTION
- don't check for implicit header if noheader option is set
- don't check for implicit header if header option is set (already implied)