### PR TITLE
resolves #1815 add support for orient="land" on tables in DocBook

### DIFF
--- a/lib/asciidoctor/converter/docbook5.rb
+++ b/lib/asciidoctor/converter/docbook5.rb
@@ -388,7 +388,7 @@ module Asciidoctor
       has_body = false
       result = []
       pgwide_attribute = (node.option? 'pgwide') ? ' pgwide="1"' : nil
-      result << %(<#{tag_name = node.title? ? 'table' : 'informaltable'}#{common_attributes node.id, node.role, node.reftext}#{pgwide_attribute} frame="#{node.attr 'frame', 'all'}" rowsep="#{['none', 'cols'].include?(node.attr 'grid') ? 0 : 1}" colsep="#{['none', 'rows'].include?(node.attr 'grid') ? 0 : 1}">)
+      result << %(<#{tag_name = node.title? ? 'table' : 'informaltable'}#{common_attributes node.id, node.role, node.reftext}#{pgwide_attribute} frame="#{node.attr 'frame', 'all'}" rowsep="#{['none', 'cols'].include?(node.attr 'grid') ? 0 : 1}" colsep="#{['none', 'rows'].include?(node.attr 'grid') ? 0 : 1}"#{(node.attr? 'orientation', 'landscape', nil) ? ' orient="land"' : nil}>)
       if (node.option? 'unbreakable')
         result << '<?dbfo keep-together="always"?>'
       elsif (node.option? 'breakable')

--- a/lib/asciidoctor/table.rb
+++ b/lib/asciidoctor/table.rb
@@ -90,6 +90,8 @@ class Table < AbstractBlock
       @attributes['tableabswidth'] ||=
           ((@attributes['tablepcwidth'].to_f / 100) * @document.attributes['pagewidth']).round
     end
+
+    attributes['orientation'] = 'landscape' if attributes.key? 'rotate-option'
   end
 
   # Internal: Returns whether the current row being processed is

--- a/test/tables_test.rb
+++ b/test/tables_test.rb
@@ -378,6 +378,21 @@ A | here| a | there
       assert_css 'table > tgroup > tbody > row', output, 3
     end
 
+    test 'table with landscape orientation in DocBook' do
+      ['orientation=landscape', '%rotate'].each do |attrs|
+        input = <<-EOS
+[#{attrs}]
+|===
+|Column A | Column B | Column C
+|===
+        EOS
+
+        output = render_embedded_string input, :backend => 'docbook'
+        assert_css 'informaltable', output, 1
+        assert_css 'informaltable[orient="land"]', output, 1
+      end
+    end
+
     test 'table with implicit header row' do
       input = <<-EOS
 |===


### PR DESCRIPTION
- add orient="land" attribute to tables if orientation attribute or landscape option is specified