### PR TITLE
fix tags for languages like Mathematica, OCaml or F#

### DIFF
--- a/lib/asciidoctor/reader.rb
+++ b/lib/asciidoctor/reader.rb
@@ -949,6 +949,7 @@ class PreprocessorReader < Reader
                 l = l.rstrip
                 # tagged lines in XML may end with '-->'
                 tl = l.chomp('-->').rstrip
+                tl = l.chomp('*)').rstrip
                 if active_tag
                   if tl.end_with?(%(end::#{active_tag}[]))
                     active_tag = nil


### PR DESCRIPTION
in such languages, comments are like this

``` ocaml
let x = 3 (* this is a line comment *)
```

note this is a proposed fix, I don't really know how asciidoctor works, maybe you can have better fix
