### PR TITLE
Adds option to include the section number in a cross-reference

### DIFF
--- a/lib/asciidoctor/abstract_block.rb
+++ b/lib/asciidoctor/abstract_block.rb
@@ -404,7 +404,7 @@ class AbstractBlock < AbstractNode
   #
   # IMPORTANT You must invoke this method on a node after removing
   # child sections or else the internal counters will be off.
-  # 
+  #
   # Returns nothing
   def reindex_sections
     @next_section_index = 0
@@ -415,6 +415,7 @@ class AbstractBlock < AbstractNode
         block.reindex_sections
       end
     }
+    sections.each(&:set_references)
   end
 end
 end

--- a/lib/asciidoctor/document.rb
+++ b/lib/asciidoctor/document.rb
@@ -697,7 +697,10 @@ class Document < AbstractBlock
   #
   # Returns The parent Block
   def << block
-    assign_index block if block.context == :section
+    if block.context == :section
+      assign_index block
+      block.set_references
+    end
     super
   end
 

--- a/lib/asciidoctor/parser.rb
+++ b/lib/asciidoctor/parser.rb
@@ -1599,10 +1599,7 @@ class Parser
     end
 
     # generate an id if one was not embedded or specified as anchor above section title
-    id = (section.id ||= (attributes['id'] || (Section.generate_id section.title, document)))
-
-    # TODO sub reftext
-    document.register(:ids, [id, (attributes['reftext'] || section.title)]) if id
+    section.id ||= (attributes['id'] || (Section.generate_id section.title, document))
 
     section.update_attributes(attributes)
     reader.skip_blank_lines

--- a/lib/asciidoctor/section.rb
+++ b/lib/asciidoctor/section.rb
@@ -150,6 +150,23 @@ class Section < AbstractBlock
     super
   end
 
+  # TODO document me
+  def set_references
+    set_reference
+    sections.each do |section|
+      section.set_references
+    end
+  end
+
+  def set_reference
+    if id
+      if (reftext = (attributes['reftext'] || document.attributes['section-label']))
+        reftext = sub_attributes(reftext, section_reftext: { sectnum: sectnum, secttitle: title })
+      end
+      document.register(:ids, [id, (reftext || title)])
+    end
+  end
+
   def to_s
     if @title != nil
       qualified_title = @numbered ? %(#{sectnum} #{@title}) : @title

--- a/lib/asciidoctor/substitutors.rb
+++ b/lib/asciidoctor/substitutors.rb
@@ -478,6 +478,12 @@ module Substitutors
           end
         elsif doc_attrs.key?(key = m[2].downcase)
           doc_attrs[key]
+        elsif (section_subs = opts[:section_reftext])
+          if 'sectnum' == m[2].downcase
+            section_subs[:sectnum]
+          elsif 'secttitle' == m[2].downcase
+            section_subs[:secttitle]
+          end
         elsif INTRINSIC_ATTRIBUTES.key? key
           INTRINSIC_ATTRIBUTES[key]
         else

--- a/test/sections_test.rb
+++ b/test/sections_test.rb
@@ -211,6 +211,70 @@ content
     end
   end
 
+  test 'should sub section number for {sectnum} in section-label' do
+    input = <<-EOS
+:sectnums:
+:section-label: {sectnum}
+
+== First Install
+EOS
+    doc = document_from_string input
+    reftext = doc.references[:ids]['_first_install']
+    refute_nil reftext
+    assert_equal '1.', reftext
+  end
+
+  test 'should insert section title for {secttitle} in section-label' do
+    input = <<-EOS
+:sectnums:
+:section-label: {secttitle}
+
+== First Install
+EOS
+    doc = document_from_string input
+    reftext = doc.references[:ids]['_first_install']
+    refute_nil reftext
+    assert_equal 'First Install', reftext
+  end
+
+  test 'should sub sectnum and secttitle in local section reftext' do
+    input = <<-EOS
+:sectnums:
+:section-label: {secttitle}
+
+[reftext="{sectnum} {secttitle}"]
+== First Install
+EOS
+    doc = document_from_string input
+    reftext = doc.references[:ids]['_first_install']
+    refute_nil reftext
+    assert_equal '1. First Install', reftext
+  end
+
+  test 'should sub with correct sectnum for subsection' do
+    input = <<-EOS
+:sectnums:
+:section-label: {secttitle}
+
+== Install
+
+== First Install
+
+content
+
+=== Subsection One
+
+[reftext="{sectnum} {secttitle}"]
+=== Subsection Two
+
+content
+EOS
+    doc = document_from_string input, parse: true
+    reftext = doc.references[:ids]['_subsection_two']
+    refute_nil reftext
+    assert_equal '2.2. Subsection Two', reftext
+  end
+
   context "document title (level 0)" do
     test "document title with multiline syntax" do
       title = "My Title"


### PR DESCRIPTION
This is my implementation for the proposal I made in [asciidoctor-pdf-464](https://github.com/asciidoctor/asciidoctor-pdf/issues/464#issuecomment-259584614).
I broke one test but I currently don't understand how and why.
Feedback would be welcome.