### PR TITLE
Paths with file URI scheme are inevitably absolute

### DIFF
--- a/lib/asciidoctor/path_resolver.rb
+++ b/lib/asciidoctor/path_resolver.rb
@@ -145,8 +145,8 @@ class PathResolver
     # Windows roots can begin with drive letter
     elsif @file_separator == BACKSLASH && WindowsRootRx =~ path
       true
-    # Absolute paths in the browser start with file:///
-    elsif ::RUBY_ENGINE_OPAL && ::JAVASCRIPT_PLATFORM == 'browser' && (path.start_with? 'file:///')
+    # Absolute paths in the browser start with file://
+    elsif ::RUBY_ENGINE_OPAL && ::JAVASCRIPT_PLATFORM == 'browser' && (path.start_with? 'file://')
       true
     else
       false


### PR DESCRIPTION
* `file://c:/foo/bar` is absolute (Windows path)
* `file:///foo/bar` is absolute (Linux path)
* `file://host/foo/bar` is absolute (URI path)

Currently `is_root?` method will return false when the path is `file://c:/foo/bar` (absolute path on Windows)