### PR TITLE
resolves #1943 allow spaces in target of block image

### DIFF
--- a/lib/asciidoctor.rb
+++ b/lib/asciidoctor.rb
@@ -794,7 +794,7 @@ module Asciidoctor
     #   image::filename.png[Caption]
     #   video::http://youtube.com/12345[Cats vs Dogs]
     #
-    MediaBlockMacroRx = /^(image|video|audio)::(\S+?)\[((?:\\\]|[^\]])*?)\]$/
+    MediaBlockMacroRx = /^(image|video|audio)::(.+?)\[((?:\\\]|[^\]])*?)\]$/
 
     # Matches the TOC block macro.
     #

--- a/lib/asciidoctor/abstract_node.rb
+++ b/lib/asciidoctor/abstract_node.rb
@@ -315,21 +315,22 @@ class AbstractNode
   #
   # Returns A String reference or data URI for the target image
   def image_uri(target_image, asset_dir_key = 'imagesdir')
-    if (doc = @document).safe < SafeMode::SECURE && doc.attr?('data-uri')
+    if (doc = @document).safe < SafeMode::SECURE && (doc.attr? 'data-uri')
       if (Helpers.uriish? target_image) ||
-          (asset_dir_key && (images_base = doc.attr(asset_dir_key)) && (Helpers.uriish? images_base) &&
-          (target_image = normalize_web_path(target_image, images_base, false)))
-        if doc.attr?('allow-uri-read')
-          generate_data_uri_from_uri target_image, doc.attr?('cache-uri')
+          (asset_dir_key && (images_base = doc.attr asset_dir_key) && (Helpers.uriish? images_base) &&
+          (target_image = normalize_web_path target_image, images_base, false))
+        if doc.attr? 'allow-uri-read'
+          generate_data_uri_from_uri target_image, (doc.attr? 'cache-uri')
         else
-          (target_image.include? ' ') ? (target_image.gsub ' ', '%20') : target_image
+          target_image
         end
       else
         generate_data_uri target_image, asset_dir_key
       end
+    elsif asset_dir_key
+      normalize_web_path target_image, (doc.attr asset_dir_key)
     else
-      target_image = normalize_web_path target_image, (asset_dir_key ? doc.attr(asset_dir_key) : nil)
-      (target_image.include? ' ') ? (target_image.gsub ' ', '%20') : target_image
+      normalize_web_path target_image
     end
   end
 
@@ -482,9 +483,9 @@ class AbstractNode
     end
   end
 
-  # Public: Normalize the web page using the PathResolver.
+  # Public: Normalize the web path using the PathResolver.
   #
-  # See {PathResolver#web_path} for details.
+  # See {PathResolver#web_path} for details about path resolution and encoding.
   #
   # target              - the String target path
   # start               - the String start (i.e, parent) path (optional, default: nil)

--- a/lib/asciidoctor/abstract_node.rb
+++ b/lib/asciidoctor/abstract_node.rb
@@ -322,13 +322,14 @@ class AbstractNode
         if doc.attr?('allow-uri-read')
           generate_data_uri_from_uri target_image, doc.attr?('cache-uri')
         else
-          target_image
+          (target_image.include? ' ') ? (target_image.gsub ' ', '%20') : target_image
         end
       else
         generate_data_uri target_image, asset_dir_key
       end
     else
-      normalize_web_path target_image, (asset_dir_key ? doc.attr(asset_dir_key) : nil)
+      target_image = normalize_web_path target_image, (asset_dir_key ? doc.attr(asset_dir_key) : nil)
+      (target_image.include? ' ') ? (target_image.gsub ' ', '%20') : target_image
     end
   end
 

--- a/lib/asciidoctor/path_resolver.rb
+++ b/lib/asciidoctor/path_resolver.rb
@@ -453,11 +453,11 @@ class PathResolver
       end
     end
 
-    if uri_prefix
-      %(#{uri_prefix}#{join_path resolved_segments, target_root})
-    else
-      join_path resolved_segments, target_root
+    if (resolved_path = join_path resolved_segments, target_root).include? ' '
+      resolved_path = resolved_path.gsub ' ', '%20'
     end
+
+    uri_prefix ? %(#{uri_prefix}#{resolved_path}) : resolved_path
   end
 
   # Public: Calculate the relative path to this absolute filename from the specified base directory

--- a/test/blocks_test.rb
+++ b/test/blocks_test.rb
@@ -1562,6 +1562,17 @@ image::images/tiger.png[A [Bengal\\] Tiger]
       assert_equal 'A [Bengal] Tiger', img.attr('alt').value
     end
 
+    test 'can render block image with target containing spaces' do
+      input = <<-EOS
+image::images/big tiger.png[A Big Tiger]
+      EOS
+
+      output = render_string input
+      img = xmlnodes_at_xpath '//img', output, 1
+      assert_equal 'images/big%20tiger.png', img.attr('src').value
+      assert_equal 'A Big Tiger', img.attr('alt').value
+    end
+
     test 'can render block image with alt text defined in block attribute above macro' do
       input = <<-EOS
 [Tiger]

--- a/test/paths_test.rb
+++ b/test/paths_test.rb
@@ -95,6 +95,10 @@ context 'Path Resolver' do
       assert_equal 'assets/images', @resolver.web_path('assets\\images')
       assert_equal '../assets/images', @resolver.web_path('assets\\images', '..\\images\\..')
     end
+
+    test 'URL encode spaces in path' do
+      assert_equal 'assets%20and%20stuff/lots%20of%20images', @resolver.web_path('lots of images', 'assets and stuff')
+    end
   end
 
   context 'System Paths' do


### PR DESCRIPTION
- allow spaces in target of block image
- URL encode spaces in web paths, including image URIs (replace space with %20)