### PR TITLE
resolves #1939 add support for book covers in DocBook 5 converter

### DIFF
--- a/lib/asciidoctor/converter/docbook5.rb
+++ b/lib/asciidoctor/converter/docbook5.rb
@@ -4,6 +4,8 @@ module Asciidoctor
   # similar to the docbook45 backend from AsciiDoc Python, but migrated to the
   # DocBook 5 specification.
   class Converter::DocBook5Converter < Converter::BuiltIn
+    ImageMacroRx = /^image::?(.+?)\[(.*?)\]$/
+
     def document node
       result = []
       if (root_tag_name = node.doctype) == 'manpage'
@@ -673,7 +675,7 @@ module Asciidoctor
     end
 
     def document_info_element doc, info_tag_prefix, use_info_tag_prefix = false
-      info_tag_prefix = '' unless use_info_tag_prefix
+      info_tag_prefix = nil unless use_info_tag_prefix
       result = []
       result << %(<#{info_tag_prefix}info>)
       result << document_title_tags(doc.doctitle :partition => true, :use_fallback => true) unless doc.notitle
@@ -702,6 +704,16 @@ module Asciidoctor
           result << %(<revremark>#{doc.attr 'revremark'}</revremark>) if doc.attr? 'revremark'
           result << %(</revision>
 </revhistory>)
+        end
+        unless use_info_tag_prefix
+          if (doc.attr? 'front-cover-image') || (doc.attr? 'back-cover-image')
+            if (back_cover_tag = cover_tag doc, 'back')
+              result << (cover_tag doc, 'front', true)
+              result << back_cover_tag
+            elsif (front_cover_tag = cover_tag doc, 'front')
+              result << front_cover_tag
+            end
+          end
         end
         unless (head_docinfo = doc.docinfo).empty?
           result << head_docinfo
@@ -748,6 +760,35 @@ module Asciidoctor
 
     def title_tag node, optional = true
       !optional || node.title? ? %(<title>#{node.title}</title>\n) : nil
+    end
+
+    def cover_tag doc, face, use_placeholder = false
+      if (cover_image = doc.attr %(#{face}-cover-image))
+        width_attr = nil
+        depth_attr = nil
+        if (cover_image.include? ':') && cover_image =~ ImageMacroRx
+          cover_image = doc.image_uri $1
+          unless $2.empty?
+            attrs = (AttributeList.new $2).parse ['alt', 'width', 'height']
+            if attrs.key? 'scaledwidth'
+              # NOTE scalefit="1" is the default in this case
+              width_attr = %( width="#{attrs['scaledwidth']}")
+            else
+              width_attr = %( contentwidth="#{attrs['width']}") if attrs.key? 'width'
+              depth_attr = %( contentdepth="#{attrs['height']}") if attrs.key? 'height'
+            end
+          end
+        end
+        %(<cover role="#{face}">
+<mediaobject>
+<imageobject>
+<imagedata fileref="#{cover_image}"#{width_attr}#{depth_attr}/>
+</imageobject>
+</mediaobject>
+</cover>)
+      elsif use_placeholder
+        %(<cover role="#{face}"/>)
+      end
     end
   end
 end

--- a/test/document_test.rb
+++ b/test/document_test.rb
@@ -1934,6 +1934,28 @@ chapter body
       assert_equal '_first_chapter', id_attr.value
     end
 
+    test 'adds a front and back cover image to DocBook 5 when doctype is book' do
+      input = <<-EOS
+= Title
+:doctype: book
+:imagesdir: images
+:front-cover-image: image:front-cover.jpg[scaledwidth=210mm]
+:back-cover-image: image:back-cover.jpg[scaledwidth=210mm]
+
+preamble
+
+== First Chapter
+
+chapter body
+      EOS
+
+      result = render_string input, :attributes => {'backend' => 'docbook5'}
+      assert_xpath '//info/cover[@role="front"]', result, 1
+      assert_xpath '//info/cover[@role="front"]//imagedata[@fileref="images/front-cover.jpg"]', result, 1
+      assert_xpath '//info/cover[@role="back"]', result, 1
+      assert_xpath '//info/cover[@role="back"]//imagedata[@fileref="images/back-cover.jpg"]', result, 1
+    end
+
     test 'should be able to set backend using :backend option key' do
       doc = empty_document :backend => 'html5'
       assert_equal 'html5', doc.attributes['backend']


### PR DESCRIPTION
- support front-cover-image and back-cover-image
- value can be a raw path or an image macro