### PR TITLE
resolves #1059 respect image scaling in DocBook converter

### DIFF
--- a/lib/asciidoctor/converter/docbook5.rb
+++ b/lib/asciidoctor/converter/docbook5.rb
@@ -193,17 +193,27 @@ module Asciidoctor
     end
 
     def image node
-      width_attribute = (node.attr? 'width') ? %( contentwidth="#{node.attr 'width'}") : nil
-      depth_attribute = (node.attr? 'height') ? %( contentdepth="#{node.attr 'height'}") : nil
-      # FIXME if scaledwidth is set, we should remove width & depth
-      # See http://www.docbook.org/tdg/en/html/imagedata.html#d0e92271 for details
-      swidth_attribute = (node.attr? 'scaledwidth') ? %( width="#{node.attr 'scaledwidth'}" scalefit="1") : nil
-      scale_attribute = (node.attr? 'scale') ? %( scale="#{node.attr 'scale'}") : nil
+      # NOTE according to the DocBook spec, content area, scaling, and scaling to fit are mutually exclusive
+      # See http://tdg.docbook.org/tdg/4.5/imagedata-x.html#d0e79635
+      if node.attr? 'scaledwidth'
+        width_attribute = %( width="#{node.attr 'scaledwidth'}")
+        depth_attribute = nil
+        scale_attribute = nil
+      elsif node.attr? 'scale'
+        # QUESTION should we set the viewport using width and depth? (the scaled image would be contained within this box)
+        #width_attribute = (node.attr? 'width') ? %( width="#{node.attr 'width'}") : nil
+        #depth_attribute = (node.attr? 'height') ? %( depth="#{node.attr 'height'}") : nil
+        scale_attribute = %( scale="#{node.attr 'scale'}")
+      else
+        width_attribute = (node.attr? 'width') ? %( contentwidth="#{node.attr 'width'}") : nil
+        depth_attribute = (node.attr? 'height') ? %( contentdepth="#{node.attr 'height'}") : nil
+        scale_attribute = nil
+      end
       align_attribute = (node.attr? 'align') ? %( align="#{node.attr 'align'}") : nil
 
       mediaobject = %(<mediaobject>
 <imageobject>
-<imagedata fileref="#{node.image_uri(node.attr 'target')}"#{width_attribute}#{depth_attribute}#{swidth_attribute}#{scale_attribute}#{align_attribute}/>
+<imagedata fileref="#{node.image_uri(node.attr 'target')}"#{width_attribute}#{depth_attribute}#{scale_attribute}#{align_attribute}/>
 </imageobject>
 <textobject><phrase>#{node.attr 'alt'}</phrase></textobject>
 </mediaobject>)

--- a/lib/asciidoctor/parser.rb
+++ b/lib/asciidoctor/parser.rb
@@ -907,11 +907,9 @@ class Parser
         attributes['alt'] ||= Helpers.basename(resolved_target, true).tr('_-', ' ')
         attributes['alt'] = block.sub_specialchars attributes['alt']
         block.assign_caption attributes.delete('caption'), 'figure'
-        if (scaledwidth = attributes['scaledwidth'])
-          # append % to scaledwidth if ends in number (no units present)
-          if (48..57).include?((scaledwidth[-1] || 0).ord)
-            attributes['scaledwidth'] = %(#{scaledwidth}%)
-          end
+        unless (scaledwidth = attributes.delete 'scaledwidth').nil_or_empty?
+          # append % to scaledwidth if it ends with a number (no units present)
+          attributes['scaledwidth'] = ((48..57).include? scaledwidth[-1].ord) ? %(#{scaledwidth}%) : scaledwidth
         end
       else
         block.caption ||= attributes.delete('caption')

--- a/test/blocks_test.rb
+++ b/test/blocks_test.rb
@@ -1656,7 +1656,7 @@ image::images/tiger.png[Tiger]
 
     test 'can align image in DocBook backend' do
       input = <<-EOS
-image::images/sunset.jpg[Sunset, align="right"]
+image::images/sunset.jpg[Sunset,align=right]
       EOS
 
       output = render_embedded_string input, :backend => :docbook
@@ -1664,36 +1664,55 @@ image::images/sunset.jpg[Sunset, align="right"]
       assert_xpath '//imagedata[@align="right"]', output, 1
     end
 
-    test 'can scale image in DocBook backend' do
+    test 'should set content width and depth in DocBook backend if no scaling' do
       input = <<-EOS
-image::images/sunset.jpg[Sunset, scale="200"]
+image::images/sunset.jpg[Sunset,500,332]
       EOS
 
       output = render_embedded_string input, :backend => :docbook
       assert_xpath '//imagedata', output, 1
-      assert_xpath '//imagedata[@scale="200"]', output, 1
+      assert_xpath '//imagedata[@contentwidth="500"]', output, 1
+      assert_xpath '//imagedata[@contentdepth="332"]', output, 1
+      assert_xpath '//imagedata[@width]', output, 0
+      assert_xpath '//imagedata[@depth]', output, 0
     end
 
-    test 'can scale image width in DocBook backend' do
+    test 'can scale image in DocBook backend' do
       input = <<-EOS
-image::images/sunset.jpg[Sunset, scaledwidth="25%"]
+image::images/sunset.jpg[Sunset,500,332,scale=200]
+      EOS
+
+      output = render_embedded_string input, :backend => :docbook
+      warn output
+      assert_xpath '//imagedata', output, 1
+      assert_xpath '//imagedata[@scale="200"]', output, 1
+      assert_xpath '//imagedata[@width]', output, 0
+      assert_xpath '//imagedata[@depth]', output, 0
+      assert_xpath '//imagedata[@contentwidth]', output, 0
+      assert_xpath '//imagedata[@contentdepth]', output, 0
+    end
+
+    test 'scale image width in DocBook backend' do
+      input = <<-EOS
+image::images/sunset.jpg[Sunset,500,332,scaledwidth=25%]
       EOS
 
       output = render_embedded_string input, :backend => :docbook
       assert_xpath '//imagedata', output, 1
       assert_xpath '//imagedata[@width="25%"]', output, 1
-      assert_xpath '//imagedata[@scalefit="1"]', output, 1
+      assert_xpath '//imagedata[@depth]', output, 0
+      assert_xpath '//imagedata[@contentwidth]', output, 0
+      assert_xpath '//imagedata[@contentdepth]', output, 0
     end
 
     test 'adds % to scaled width if no units given in DocBook backend ' do
       input = <<-EOS
-image::images/sunset.jpg[Sunset, scaledwidth="25"]
+image::images/sunset.jpg[Sunset,scaledwidth=25]
       EOS
 
       output = render_embedded_string input, :backend => :docbook
       assert_xpath '//imagedata', output, 1
       assert_xpath '//imagedata[@width="25%"]', output, 1
-      assert_xpath '//imagedata[@scalefit="1"]', output, 1
     end
 
     test 'keeps line unprocessed if image target is missing attribute reference and attribute-missing is skip' do


### PR DESCRIPTION
- treat scaledwidth, scale and width attributes on a block image as mutually exclusive
- update tests
- optimize how % is added to a unitless scaledwidth value