### PR TITLE
resolves #1967 use empty string as default value for set_attr method

### DIFF
--- a/lib/asciidoctor/abstract_node.rb
+++ b/lib/asciidoctor/abstract_node.rb
@@ -131,12 +131,12 @@ class AbstractNode
   # Public: Assign the value to the attribute name for the current node.
   #
   # name      - The String attribute name to assign
-  # value     - The Object value to assign to the attribute
+  # value     - The Object value to assign to the attribute (default: '')
   # overwrite - A Boolean indicating whether to assign the attribute
   #             if currently present in the attributes Hash (default: true)
   #
   # Returns a [Boolean] indicating whether the assignment was performed
-  def set_attr name, value, overwrite = true
+  def set_attr name, value = '', overwrite = true
     if overwrite == false && (@attributes.key? name)
       false
     else

--- a/lib/asciidoctor/document.rb
+++ b/lib/asciidoctor/document.rb
@@ -821,14 +821,14 @@ class Document < AbstractBlock
   #
   # If the attribute is locked, false is returned. Otherwise, the value is
   # assigned to the attribute name after first performing attribute
-  # substitutions on the value. If the attribute name is 'backend', then the
-  # value of backend-related attributes are updated.
+  # substitutions on the value. If the attribute name is 'backend' or
+  # 'doctype', then the value of backend-related attributes are updated.
   #
   # name  - the String attribute name
-  # value - the String attribute value
+  # value - the String attribute value (default: '')
   #
   # returns true if the attribute was set, false if it was not set because it's locked
-  def set_attribute(name, value)
+  def set_attribute(name, value = '')
     if attribute_locked?(name)
       false
     else

--- a/lib/asciidoctor/parser.rb
+++ b/lib/asciidoctor/parser.rb
@@ -111,9 +111,9 @@ class Parser
         document.title = assigned_doctitle = doctitle
       end
       # default to compat-mode if document uses atx-style doctitle
-      document.set_attribute 'compat-mode', '' unless single_line
+      document.set_attr 'compat-mode' unless single_line || (document.attribute_locked? 'compat-mode')
       if (separator = block_attributes.delete 'separator')
-        document.set_attribute 'title-separator', separator
+        document.set_attr 'title-separator', separator unless document.attribute_locked? 'title-separator'
       end
       document.header.source_location = source_location if source_location
       document.attributes['doctitle'] = section_title = doctitle

--- a/lib/asciidoctor/substitutors.rb
+++ b/lib/asciidoctor/substitutors.rb
@@ -1401,7 +1401,7 @@ module Substitutors
       unless (highlighter_loaded = defined? ::CodeRay) || @document.attributes['coderay-unavailable']
         if (Helpers.require_library 'coderay', true, :warn).nil?
           # prevent further attempts to load CodeRay
-          @document.set_attr 'coderay-unavailable', ''
+          @document.set_attr 'coderay-unavailable'
         else
           highlighter_loaded = true
         end
@@ -1410,7 +1410,7 @@ module Substitutors
       unless (highlighter_loaded = defined? ::Pygments) || @document.attributes['pygments-unavailable']
         if (Helpers.require_library 'pygments', 'pygments.rb', :warn).nil?
           # prevent further attempts to load Pygments
-          @document.set_attr 'pygments-unavailable', ''
+          @document.set_attr 'pygments-unavailable'
         else
           highlighter_loaded = true
         end

--- a/test/attributes_test.rb
+++ b/test/attributes_test.rb
@@ -350,6 +350,12 @@ content
       assert doc.attributes.has_key? 'basebackend-html'
     end
 
+    test 'set_attr should set value to empty string if no value is specified' do
+      node = Asciidoctor::Block.new nil, :paragraph, :attributes => {}
+      node.set_attr 'foo'
+      assert_equal '', (node.attr 'foo')
+    end
+
     test 'set_attr should not overwrite existing key if overwrite is false' do
       node = Asciidoctor::Block.new nil, :paragraph, :attributes => { 'foo' => 'bar' }
       assert_equal 'bar', (node.attr 'foo')


### PR DESCRIPTION
- use empty string as default value for set_attr and set_attribute methods
- use set_attr to assign compat-mode and title-separator attributes on document