### PR TITLE
Encode filename by UTF-8 when convert_file

### DIFF
--- a/lib/asciidoctor.rb
+++ b/lib/asciidoctor.rb
@@ -1582,7 +1582,7 @@ module Asciidoctor
   # Returns the Document object if the converted String is written to a
   # file, otherwise the converted String
   def convert_file filename, options = {}
-    ::File.open(filename) {|file| self.convert file, options }
+    ::File.open(filename.encode("utf-8")) {|file| self.convert file, options }
   end
 
   # Alias render_file to convert_file to maintain backwards compatibility


### PR DESCRIPTION
Encode filename by UTF-8 when convert_file, so that source document of which path/file name contains CJK characters would be available.