### PR TITLE
preserve inline break in manpages

### DIFF
--- a/lib/asciidoctor/converter/manpage.rb
+++ b/lib/asciidoctor/converter/manpage.rb
@@ -60,6 +60,7 @@ module Asciidoctor
         gsub('\'', '\(aq').       # apostrophe-quote
         gsub(MockBoundaryRx, ''). # mock boundary
         gsub(ESC_BS, '\\').       # unescape troff backslash (NOTE update if more escapes are added)
+        gsub(ESC_FS, '.').        # unescape full stop in troff commands (NOTE must take place after gsub(LeadingPeriodRx))
         rstrip                    # strip trailing space
       opts[:append_newline] ? %(#{str}#{LF}) : str
     end
@@ -610,8 +611,7 @@ allbox tab(:);'
     end
 
     def inline_break node
-      %(#{node.text}
-.br)
+      %(#{node.text}#{LF}#{ESC_FS}br)
     end
 
     def inline_button node

--- a/test/manpage_test.rb
+++ b/test/manpage_test.rb
@@ -215,4 +215,17 @@ T}
     end
   end
 
+  context 'Escaped commands' do
+    test 'should preserve inline breaks' do
+      input = %(#{SAMPLE_MANPAGE_HEADER}
+
+Before break. +
+After break.)
+      output = Asciidoctor.convert input, :backend => :manpage
+      assert_equal 'Before break.
+.br
+After break.', output.lines.entries[-3..-1].join
+    end
+  end
+
 end


### PR DESCRIPTION
* escape the roff line break command
* unescape escaped roff commands after the leading period substitution pass