### PR TITLE
Avoid boundary pseudo-tags in manpage table output

### DIFF
--- a/lib/asciidoctor/converter/manpage.rb
+++ b/lib/asciidoctor/converter/manpage.rb
@@ -457,6 +457,7 @@ allbox tab(:);'
               else
                 cell_content = cell.content.join
               end
+              cell_content = manify cell_content
               row_text[row_index] << %(#{cell_content}#{LF})
             elsif tsec == :foot
               if row_header[row_index].empty? ||

--- a/test/manpage_test.rb
+++ b/test/manpage_test.rb
@@ -69,6 +69,17 @@ BBB this line and the one above it should be visible)
       output = Asciidoctor.convert input, :backend => :manpage
       assert_equal '\&.if 1 .nx', output.lines.entries[-2].chomp
     end
+
+    test 'should not leave boundary element in tables' do
+      input = %(#{SAMPLE_MANPAGE_HEADER}
+
+|===
+| A   | B
+| `0` | *1*
+|===)
+      output = Asciidoctor.convert input, :backend => :manpage
+      refute_match(/<\/?BOUNDARY>/, output)
+    end
   end
 
   context 'Backslash' do


### PR DESCRIPTION
When using inline styling in a manpage table cell, the resulting manpage would result in `<BOUNDARY>` tags in the output. Call the manify function to fix up the text and remove these tags.