### PR TITLE
promote subs to top-level constants

### DIFF
--- a/lib/asciidoctor/list.rb
+++ b/lib/asciidoctor/list.rb
@@ -57,7 +57,7 @@ class ListItem < AbstractBlock
     super parent, :list_item
     @text = text
     @level = parent.level
-    @subs = SUBS[:normal].dup
+    @subs = NORMAL_SUBS.dup
   end
 
   # Public: A convenience method that checks whether the text of this list item

--- a/lib/asciidoctor/parser.rb
+++ b/lib/asciidoctor/parser.rb
@@ -935,10 +935,8 @@ class Parser
       #end
 
       if block.sub? :callouts
-        unless (catalog_callouts block.source, document)
-          # No need to sub callouts if they aren't there
-          block.remove_sub :callouts
-        end
+        # No need to sub callouts if none are found when cataloging
+        block.remove_sub :callouts unless catalog_callouts block.source, document
       end
     end
 

--- a/test/blocks_test.rb
+++ b/test/blocks_test.rb
@@ -475,7 +475,7 @@ ____
       EOS
 
       verse = block_from_string input
-      assert_equal Asciidoctor::Substitutors::SUBS[:normal], verse.subs
+      assert_equal Asciidoctor::Substitutors::NORMAL_SUBS, verse.subs
     end
 
     test 'should not recognize callouts in a verse' do


### PR DESCRIPTION
* promote subs to top-level constants
* reuse constants instead of using hard-coded subs arrays
* make lock_in_subs more efficient
* change lock_in_subs to return resolved subs
* minor style improvements