### PR TITLE
optimize the Substitutors#apply_subs method

### DIFF
--- a/lib/asciidoctor/block.rb
+++ b/lib/asciidoctor/block.rb
@@ -109,7 +109,7 @@ class Block < AbstractBlock
     when :compound
       super
     when :simple
-      apply_subs(@lines * EOL, @subs)
+      apply_subs @lines * EOL, @subs
     when :verbatim, :raw
       #((apply_subs @lines.join(EOL), @subs).sub StripLineWiseRx, '\1')
 

--- a/lib/asciidoctor/core_ext.rb
+++ b/lib/asciidoctor/core_ext.rb
@@ -5,5 +5,6 @@ if RUBY_MIN_VERSION_1_9
 elsif RUBY_ENGINE != 'opal'
   require 'asciidoctor/core_ext/1.8.7/string/chr'
   require 'asciidoctor/core_ext/1.8.7/string/limit_bytesize'
+  require 'asciidoctor/core_ext/1.8.7/symbol/empty'
   require 'asciidoctor/core_ext/1.8.7/symbol/length'
 end

--- a/lib/asciidoctor/core_ext/1.8.7/symbol/empty.rb
+++ b/lib/asciidoctor/core_ext/1.8.7/symbol/empty.rb
@@ -1,0 +1,6 @@
+# Educate Ruby 1.8.7 about the Symbol#empty? method.
+class Symbol
+  def empty?
+    to_s.empty?
+  end unless method_defined? :empty?
+end

--- a/lib/asciidoctor/core_ext/1.8.7/symbol/length.rb
+++ b/lib/asciidoctor/core_ext/1.8.7/symbol/length.rb
@@ -1,4 +1,4 @@
-# Educate Ruby 1.8.7 about the Symbol#length method.
+# Educate Ruby 1.8.7 about the Symbol#empty? and Symbol#length methods.
 class Symbol
   def length
     to_s.length

--- a/test/substitutions_test.rb
+++ b/test/substitutions_test.rb
@@ -26,6 +26,17 @@ context 'Substitutions' do
       result = para.apply_subs(para.lines * "\n")
       assert_equal %(this<br>\nis<br>\n&#8594; Asciidoctor<br>\n<br>\n), result
     end
+
+    test 'should expand subs passed to apply_subs when expand argument is set' do
+      para = block_from_string %({program}\n*bold*\n2 > 1)
+      para.document.attributes['program'] = 'Asciidoctor'
+      result = para.apply_subs para.lines, [:specialchars], true
+      assert_equal ['{program}', '*bold*', '2 &gt; 1'], result
+      result = para.apply_subs para.lines, [:none], true
+      assert_equal ['{program}', '*bold*', '2 > 1'], result
+      result = para.apply_subs para.lines, [:normal], true
+      assert_equal ['Asciidoctor', '<strong>bold</strong>', '2 &gt; 1'], result
+    end
   end
 
   context 'Quotes' do


### PR DESCRIPTION
- short-circuit apply_subs if source or subs arguments are empty
- only check for empty subs again in apply_subs after resolving substitution aliases
- fix tomdoc on apply_subs method
- change docinfosubs assignment so it isn't resolved multiple times
- don't check for subs key on passthrough entry as it's required
- consolidate code
- add tomdoc to the Document#resolve_docinfo_subs method