### PR TITLE
improve BOM processing

### DIFF
--- a/lib/asciidoctor.rb
+++ b/lib/asciidoctor.rb
@@ -195,10 +195,9 @@ module Asciidoctor
   FORCE_ENCODING = COERCE_ENCODING && ::Encoding.default_external != ::Encoding::UTF_8
 
   # Byte arrays for UTF-* Byte Order Marks
-  # hex escape sequence used for Ruby 1.8 compatibility
-  BOM_BYTES_UTF_8 = "\xef\xbb\xbf".bytes.to_a
-  BOM_BYTES_UTF_16LE = "\xff\xfe".bytes.to_a
-  BOM_BYTES_UTF_16BE = "\xfe\xff".bytes.to_a
+  BOM_BYTES_UTF_8 = [0xef, 0xbb, 0xbf]
+  BOM_BYTES_UTF_16LE = [0xff, 0xfe]
+  BOM_BYTES_UTF_16BE = [0xfe, 0xff]
 
   # Flag to indicate that line length should be calculated using a unicode mode hint
   FORCE_UNICODE_LINE_LENGTH = !::RUBY_MIN_VERSION_1_9

--- a/lib/asciidoctor/helpers.rb
+++ b/lib/asciidoctor/helpers.rb
@@ -64,17 +64,16 @@ module Helpers
   def self.normalize_lines_array data
     return [] if data.empty?
 
-    # NOTE if data encoding is UTF-*, we only need 0..1
-    leading_bytes = (first_line = data[0])[0..2].bytes.to_a
+    leading_bytes = (first_line = data[0]).unpack 'C3'
     if COERCE_ENCODING
       utf8 = ::Encoding::UTF_8
-      if (leading_2_bytes = leading_bytes[0..1]) == BOM_BYTES_UTF_16LE
+      if (leading_2_bytes = leading_bytes[0, 2]) == BOM_BYTES_UTF_16LE
         # Ruby messes up trailing whitespace on UTF-16LE, so take a different route
-        return ((data.join.force_encoding ::Encoding::UTF_16LE)[1..-1].encode utf8).lines.map {|line| line.rstrip }
+        return ((data.join.force_encoding ::Encoding::UTF_16LE)[1..-1].encode utf8).lines.map &:rstrip
       elsif leading_2_bytes == BOM_BYTES_UTF_16BE
         data[0] = (first_line.force_encoding ::Encoding::UTF_16BE)[1..-1]
         return data.map {|line| "#{((line.force_encoding ::Encoding::UTF_16BE).encode utf8).rstrip}" }
-      elsif leading_bytes[0..2] == BOM_BYTES_UTF_8
+      elsif leading_bytes == BOM_BYTES_UTF_8
         data[0] = (first_line.force_encoding utf8)[1..-1]
       end
 
@@ -84,7 +83,7 @@ module Helpers
       if leading_bytes == BOM_BYTES_UTF_8
         data[0] = first_line[3..-1]
       end
-      data.map {|line| line.rstrip }
+      data.map &:rstrip
     end
   end
 
@@ -102,26 +101,25 @@ module Helpers
   def self.normalize_lines_from_string data
     return [] if data.nil_or_empty?
 
+    leading_bytes = data.unpack 'C3'
     if COERCE_ENCODING
       utf8 = ::Encoding::UTF_8
-      # NOTE if data encoding is UTF-*, we only need 0..1
-      leading_bytes = data[0..2].bytes.to_a
-      if (leading_2_bytes = leading_bytes[0..1]) == BOM_BYTES_UTF_16LE
+      if (leading_2_bytes = leading_bytes[0, 2]) == BOM_BYTES_UTF_16LE
         data = (data.force_encoding ::Encoding::UTF_16LE)[1..-1].encode utf8
       elsif leading_2_bytes == BOM_BYTES_UTF_16BE
         data = (data.force_encoding ::Encoding::UTF_16BE)[1..-1].encode utf8
-      elsif leading_bytes[0..2] == BOM_BYTES_UTF_8
+      elsif leading_bytes == BOM_BYTES_UTF_8
         data = data.encoding == utf8 ? data[1..-1] : (data.force_encoding utf8)[1..-1]
       else
         data = data.force_encoding utf8 unless data.encoding == utf8
       end
     else
       # Ruby 1.8 has no built-in re-encoding, so no point in removing the UTF-16 BOMs
-      if data[0..2].bytes.to_a == BOM_BYTES_UTF_8
+      if leading_bytes == BOM_BYTES_UTF_8
         data = data[3..-1]
       end
     end
-    data.each_line.map {|line| line.rstrip }
+    data.each_line.map &:rstrip
   end
 
   # Public: Efficiently checks whether the specified String resembles a URI


### PR DESCRIPTION
* use unpack('C3') to grab leading bytes
* define BOM chars using 0x shorthand
* use optimized version of slice to reduce bytes array
* don't slice leading bytes array when checking for UTF-8 BOM