### PR TITLE
resolves #2055 set filetype to man when backend is manpage

### DIFF
--- a/lib/asciidoctor.rb
+++ b/lib/asciidoctor.rb
@@ -257,6 +257,7 @@ module Asciidoctor
     'docbook' => '.xml',
     'pdf' => '.pdf',
     'epub' => '.epub',
+    'manpage' => '.man',
     'asciidoc' => '.adoc'
   }
 

--- a/lib/asciidoctor/document.rb
+++ b/lib/asciidoctor/document.rb
@@ -936,9 +936,12 @@ class Document < AbstractBlock
         new_filetype = @converter.filetype
       else
         new_basebackend = new_backend.sub TrailingDigitsRx, ''
-        # QUESTION should we be forcing the basebackend to html if unknown?
-        new_outfilesuffix = DEFAULT_EXTENSIONS[new_basebackend] || '.html'
-        new_filetype = new_outfilesuffix[1..-1]
+        if (new_outfilesuffix = DEFAULT_EXTENSIONS[new_basebackend])
+          new_filetype = new_outfilesuffix[1..-1]
+        else
+          new_outfilesuffix = '.html'
+          new_basebackend = new_filetype = 'html'
+        end
         attrs['outfilesuffix'] = new_outfilesuffix unless attribute_locked? 'outfilesuffix'
       end
       if (current_filetype = attrs['filetype'])

--- a/test/manpage_test.rb
+++ b/test/manpage_test.rb
@@ -24,6 +24,19 @@ EOS
 
 context 'Manpage' do
   context 'Configuration' do
+    test 'should set proper manpage-related attributes' do
+      input = SAMPLE_MANPAGE_HEADER
+      doc = Asciidoctor.load input, :backend => :manpage
+      assert_equal 'man', doc.attributes['filetype']
+      assert_equal '', doc.attributes['filetype-man']
+      assert_equal '1', doc.attributes['manvolnum']
+      assert_equal '.1', doc.attributes['outfilesuffix']
+      assert_equal 'command', doc.attributes['manname']
+      assert_equal 'command', doc.attributes['mantitle']
+      assert_equal 'does stuff', doc.attributes['manpurpose']
+      assert_equal 'command', doc.attributes['docname']
+    end
+
     test 'should define default linkstyle' do
       input = SAMPLE_MANPAGE_HEADER
       output = Asciidoctor.convert input, :backend => :manpage, :header_footer => true


### PR DESCRIPTION
- set filetype to man when backend is manpage
- add test to verify manpage-related attributes are set in manpage backend
- add manpage to list of default extensions map