### PR TITLE
Adds sourcemap on list items

### DIFF
--- a/lib/asciidoctor/parser.rb
+++ b/lib/asciidoctor/parser.rb
@@ -1277,7 +1277,9 @@ class Parser
   def self.next_list_item(reader, list_block, match, sibling_trait = nil)
     if (list_type = list_block.context) == :dlist
       list_term = ListItem.new(list_block, match[1])
+      list_term.source_location = reader.cursor if list_block.document.sourcemap
       list_item = ListItem.new(list_block, match[3])
+      list_item.source_location = reader.cursor if list_block.document.sourcemap
       has_text = !match[3].nil_or_empty?
     else
       # Create list item using first line as the text of the list item
@@ -1295,6 +1297,7 @@ class Parser
         end
       end
       list_item = ListItem.new(list_block, text)
+      list_item.source_location = reader.cursor if list_block.document.sourcemap
 
       if checkbox
         # FIXME checklist never makes it into the options attribute
@@ -1310,7 +1313,9 @@ class Parser
 
     # first skip the line with the marker / term
     reader.advance
-    list_item_reader = Reader.new read_lines_for_list_item(reader, list_type, sibling_trait, has_text), reader.cursor
+    cursor = reader.cursor
+
+    list_item_reader = Reader.new read_lines_for_list_item(reader, list_type, sibling_trait, has_text), cursor
     if list_item_reader.has_more_lines?
       # NOTE peek on the other side of any comment lines
       comment_lines = list_item_reader.skip_line_comments
@@ -1337,6 +1342,9 @@ class Parser
       # list
       while list_item_reader.has_more_lines?
         if (new_block = next_block(list_item_reader, list_item, {}, options))
+          if list_type == :dlist
+            list_item.source_location = cursor if list_block.document.sourcemap
+          end
           list_item << new_block
         end
       end

--- a/test/document_test.rb
+++ b/test/document_test.rb
@@ -339,6 +339,19 @@ preamble
       assert_equal 'sample.asciidoc', last_block.file
       assert_equal 23, last_block.lineno
 
+      list_items = last_block.blocks
+      refute_nil list_items[0].source_location
+      assert_equal 'sample.asciidoc', list_items[0].file
+      assert_equal 23, list_items[0].lineno
+
+      refute_nil list_items[1].source_location
+      assert_equal 'sample.asciidoc', list_items[1].file
+      assert_equal 24, list_items[1].lineno
+
+      refute_nil list_items[2].source_location
+      assert_equal 'sample.asciidoc', list_items[2].file
+      assert_equal 25, list_items[2].lineno
+
       doc = Asciidoctor.load_file fixture_path('master.adoc'), :sourcemap => true, :safe => :safe
 
       section_1 = doc.sections[0]
@@ -346,6 +359,129 @@ preamble
       refute_nil section_1.source_location
       assert_equal fixture_path('chapter-a.adoc'), section_1.file
       assert_equal 1, section_1.lineno
+    end
+
+    test 'should track file and line information on list items if sourcemap option is set' do
+      doc = Asciidoctor.load_file fixture_path('lists.adoc'), :sourcemap => true
+
+      first_section = doc.blocks[1]
+
+      unordered_basic_list = first_section.blocks[0]
+      assert_equal 11, unordered_basic_list.lineno
+      unordered_basic_list_items = unordered_basic_list.find_by(:context => :list_item)
+      assert_equal 3, unordered_basic_list_items.length
+      assert_equal 11, unordered_basic_list_items[0].lineno
+      assert_equal 12, unordered_basic_list_items[1].lineno
+      assert_equal 13, unordered_basic_list_items[2].lineno
+
+      unordered_max_nesting = first_section.blocks[1]
+      assert_equal 16, unordered_max_nesting.lineno
+      unordered_max_nesting_items = unordered_max_nesting.find_by(:context => :list_item)
+      assert_equal 2, unordered_max_nesting.blocks.length
+      assert_equal 6, unordered_max_nesting_items.length
+      assert_equal 16, unordered_max_nesting_items[0].lineno
+      assert_equal 17, unordered_max_nesting_items[1].lineno
+      assert_equal 18, unordered_max_nesting_items[2].lineno
+      assert_equal 19, unordered_max_nesting_items[3].lineno
+      assert_equal 20, unordered_max_nesting_items[4].lineno
+      assert_equal 21, unordered_max_nesting_items[5].lineno
+
+      checklist = first_section.blocks[2]
+      assert_equal 24, checklist.lineno
+      checklist_list_items = checklist.find_by(:context => :list_item)
+      assert_equal 4, checklist_list_items.length
+      assert_equal 24, checklist_list_items[0].lineno
+      assert_equal 25, checklist_list_items[1].lineno
+      assert_equal 26, checklist_list_items[2].lineno
+      assert_equal 27, checklist_list_items[3].lineno
+
+      ordered_basic = first_section.blocks[3]
+      assert_equal 30, ordered_basic.lineno
+      ordered_basic_list_items = ordered_basic.find_by(:context => :list_item)
+      assert_equal 3, ordered_basic_list_items.length
+      assert_equal 30, ordered_basic_list_items[0].lineno
+      assert_equal 31, ordered_basic_list_items[1].lineno
+      assert_equal 32, ordered_basic_list_items[2].lineno
+
+      ordered_nested = first_section.blocks[4]
+      assert_equal 35, ordered_nested.lineno
+      ordered_nested_list_items = ordered_nested.find_by(:context => :list_item)
+      assert_equal 5, ordered_nested_list_items.length
+      assert_equal 35, ordered_nested_list_items[0].lineno
+      assert_equal 36, ordered_nested_list_items[1].lineno
+      assert_equal 37, ordered_nested_list_items[2].lineno
+      assert_equal 38, ordered_nested_list_items[3].lineno
+      assert_equal 39, ordered_nested_list_items[4].lineno
+
+      ordered_max_nesting = first_section.blocks[5]
+      assert_equal 42, ordered_max_nesting.lineno
+      ordered_max_nesting_items = ordered_max_nesting.find_by(:context => :list_item)
+      assert_equal 6, ordered_max_nesting_items.length
+      assert_equal 42, ordered_max_nesting_items[0].lineno
+      assert_equal 43, ordered_max_nesting_items[1].lineno
+      assert_equal 44, ordered_max_nesting_items[2].lineno
+      assert_equal 45, ordered_max_nesting_items[3].lineno
+      assert_equal 46, ordered_max_nesting_items[4].lineno
+      assert_equal 47, ordered_max_nesting_items[5].lineno
+
+      labeled_singleline = first_section.blocks[6]
+      assert_equal 50, labeled_singleline.lineno
+      labeled_singleline_items = labeled_singleline.find_by(:context => :list_item)
+      assert_equal 4, labeled_singleline_items.length
+      assert_equal 50, labeled_singleline_items[0].lineno
+      assert_equal 50, labeled_singleline_items[1].lineno
+      assert_equal 51, labeled_singleline_items[2].lineno
+      assert_equal 51, labeled_singleline_items[3].lineno
+
+      labeled_multiline = first_section.blocks[7]
+      assert_equal 54, labeled_multiline.lineno
+      labeled_multiline_items = labeled_multiline.find_by(:context => :list_item)
+      assert_equal 4, labeled_multiline_items.length
+      assert_equal 54, labeled_multiline_items[0].lineno
+      assert_equal 55, labeled_multiline_items[1].lineno
+      assert_equal 56, labeled_multiline_items[2].lineno
+      assert_equal 57, labeled_multiline_items[3].lineno
+
+      qanda = first_section.blocks[8]
+      assert_equal 61, qanda.lineno
+      qanda_items = qanda.find_by(:context => :list_item)
+      assert_equal 4, qanda_items.length
+      assert_equal 61, qanda_items[0].lineno
+      assert_equal 62, qanda_items[1].lineno
+      assert_equal 63, qanda_items[2].lineno
+      assert_equal 63, qanda_items[3].lineno
+
+      mixed = first_section.blocks[9]
+      assert_equal 66, mixed.lineno
+      mixed_items = mixed.find_by(:context => :list_item){|block| block.text?}
+      assert_equal 17, mixed_items.length
+      assert_equal 66, mixed_items[0].lineno
+      assert_equal 67, mixed_items[1].lineno
+      assert_equal 68, mixed_items[2].lineno
+      assert_equal 69, mixed_items[3].lineno
+      assert_equal 70, mixed_items[4].lineno
+      assert_equal 71, mixed_items[5].lineno
+      assert_equal 72, mixed_items[6].lineno
+      assert_equal 73, mixed_items[7].lineno
+      assert_equal 74, mixed_items[8].lineno
+      assert_equal 75, mixed_items[9].lineno
+      assert_equal 77, mixed_items[10].lineno
+      assert_equal 78, mixed_items[11].lineno
+      assert_equal 79, mixed_items[12].lineno
+      assert_equal 80, mixed_items[13].lineno
+      assert_equal 81, mixed_items[14].lineno
+      assert_equal 82, mixed_items[15].lineno
+      assert_equal 83, mixed_items[16].lineno
+
+      unordered_complex_list = first_section.blocks[10]
+      assert_equal 86, unordered_complex_list.lineno
+      unordered_complex_items = unordered_complex_list.find_by(:context => :list_item)
+      assert_equal 5, unordered_complex_items.length
+      assert_equal 86, unordered_complex_items[0].lineno
+      assert_equal 87, unordered_complex_items[1].lineno
+      assert_equal 88, unordered_complex_items[2].lineno
+      assert_equal 92, unordered_complex_items[3].lineno
+      assert_equal 96, unordered_complex_items[4].lineno
     end
 
     test 'should allow sourcemap option on document to be modified' do

--- a/test/fixtures/lists.adoc
+++ b/test/fixtures/lists.adoc
@@ -1,0 +1,96 @@
+= Document Title
+Doc Writer <thedoc@asciidoctor.org>
+
+Preamble paragraph.
+
+NOTE: This is test, only a test.
+
+== Lists
+
+.Unordered, basic
+* Edgar Allen Poe
+* Sheri S. Tepper
+* Bill Bryson
+
+.Unordered, max nesting
+* level 1
+** level 2
+*** level 3
+**** level 4
+***** level 5
+* level 1
+
+.Checklist
+- [*] checked
+- [x] also checked
+- [ ] not checked
+-     normal list item
+
+.Ordered, basic
+. Step 1
+. Step 2
+. Step 3
+
+.Ordered, nested
+. Step 1
+. Step 2
+.. Step 2a
+.. Step 2b
+. Step 3
+
+.Ordered, max nesting
+. level 1
+.. level 2
+... level 3
+.... level 4
+..... level 5
+. level 1
+
+.Labeled, single-line
+first term:: definition of first term
+section term:: definition of second term
+
+.Labeled, multi-line
+first term::
+definition of first term
+second term::
+definition of second term
+
+.Q&A
+[qanda]
+What is Asciidoctor?::
+  An implementation of the AsciiDoc processor in Ruby.
+What is the answer to the Ultimate Question?:: 42
+
+.Mixed
+Operating Systems::
+  Linux:::
+    . Fedora
+      * Desktop
+    . Ubuntu
+      * Desktop
+      * Server
+  BSD:::
+    . FreeBSD
+    . NetBSD
+
+Cloud Providers::
+  PaaS:::
+    . OpenShift
+    . CloudBees
+  IaaS:::
+    . Amazon EC2
+    . Rackspace
+
+.Unordered, complex
+* level 1
+** level 2
+*** level 3 +
+This is a new line inside an unordered list using {plus} symbol. +
+We can even have another line... +
+Amazing, isn't it ? +
+**** level 4
++
+The {plus} symbol is on a new line.
++
+***** level 5


### PR DESCRIPTION
Quick solution to add sourcemap on list items.

At some point, I think we should refactor this code:

```ruby
# QUESTION should we introduce a parsing context object?
```

If we had a parsing context, we could know that `sourcemap` is enabled and use this information to set the `source_location` when we instantiate a new block. 

### TODO
* [x] line number is invalid on multi-line term/definition or multi-line questions and answers


Ref: https://github.com/asciidoctor/asciidoctor/issues/2068