### PR TITLE
resolves #2073 allow tab separator to be specified using \t

### DIFF
--- a/lib/asciidoctor/parser.rb
+++ b/lib/asciidoctor/parser.rb
@@ -859,11 +859,10 @@ class Parser
 
         when :table
           block_reader = Reader.new reader.read_lines_until(:terminator => terminator, :skip_line_comments => true), reader.cursor
-          case terminator.chr
-          when ','
-            attributes['format'] = 'csv'
-          when ':'
-            attributes['format'] = 'dsv'
+          # NOTE it's very rare that format is set when using a format hint char, so short-circuit
+          unless terminator.start_with? '|', '!'
+            # NOTE infer dsv once all other format hint chars are ruled out
+            attributes['format'] ||= (terminator.start_with? ',') ? 'csv' : 'dsv'
           end
           block = next_table(block_reader, parent, attributes)
 

--- a/test/tables_test.rb
+++ b/test/tables_test.rb
@@ -1072,9 +1072,28 @@ key: value <1>
       output = render_embedded_string input
       assert_css 'table', output, 2
       assert_css 'table table', output, 1
-      assert_css 'table table', output, 1
       assert_css 'table > tbody > tr > td:nth-child(2) table', output, 1
       assert_css 'table > tbody > tr > td:nth-child(2) table > tbody > tr > td', output, 2
+    end
+
+    test 'can set format of nested table to psv' do
+      input = <<-EOS
+[cols="2*"]
+|===
+|normal cell
+a|
+[format=psv]
+!===
+!nested cell
+!===
+|===
+      EOS
+
+      output = render_embedded_string input
+      assert_css 'table', output, 2
+      assert_css 'table table', output, 1
+      assert_css 'table > tbody > tr > td:nth-child(2) table', output, 1
+      assert_css 'table > tbody > tr > td:nth-child(2) table > tbody > tr > td', output, 1
     end
 
     test 'toc from parent document should not be included in an AsciiDoc table cell' do
@@ -1314,13 +1333,45 @@ a,b,c
       assert_css 'table > tbody > tr:nth-child(2) > td', output, 3
     end
 
-    test 'custom separator' do
+    test 'tsv as format' do
       input = <<-EOS
-[format="csv", separator=";"]
+[format=tsv]
+,===
+a\tb\tc
+1\t2\t3
+,===
+      EOS
+      output = render_embedded_string input
+      assert_css 'table', output, 1
+      assert_css 'table > colgroup > col', output, 3
+      assert_css 'table > tbody > tr', output, 2
+      assert_css 'table > tbody > tr:nth-child(1) > td', output, 3
+      assert_css 'table > tbody > tr:nth-child(2) > td', output, 3
+    end
+
+    test 'custom csv separator' do
+      input = <<-EOS
+[format=csv,separator=;]
 |===
 a;b;c
 1;2;3
 |===
+      EOS
+      output = render_embedded_string input
+      assert_css 'table', output, 1
+      assert_css 'table > colgroup > col', output, 3
+      assert_css 'table > tbody > tr', output, 2
+      assert_css 'table > tbody > tr:nth-child(1) > td', output, 3
+      assert_css 'table > tbody > tr:nth-child(2) > td', output, 3
+    end
+
+    test 'tab as separator' do
+      input = <<-EOS
+[separator=\\t]
+,===
+a\tb\tc
+1\t2\t3
+,===
       EOS
       output = render_embedded_string input
       assert_css 'table', output, 1


### PR DESCRIPTION
- allow tab separator for table to be specified using \t
- recognize tsv format as alias for csv format using tab separator
- warn at error level if table format is illegal instead of throwing exception
- consolidate code to resolve regular expression for table separator
- format attribute should take precedence over implicit table separator
- add tests for tab as separator
- add test to verify format attribute takes precedence