### PR TITLE
resolves #2074 don't match headings with mixed leading characters

### DIFF
--- a/lib/asciidoctor.rb
+++ b/lib/asciidoctor.rb
@@ -619,7 +619,7 @@ module Asciidoctor
     # match[1] is the delimiter, whose length determines the level
     # match[2] is the title itself
     # match[3] is an inline anchor, which becomes the section id
-    AtxSectionRx = /^((?:=|#){1,6})#{CG_BLANK}+(\S.*?)(?:#{CG_BLANK}+\1)?$/
+    AtxSectionRx = /^(={1,6}|\#{1,6})#{CG_BLANK}+(\S.*?)(?:#{CG_BLANK}+\1)?$/
 
     # Matches the restricted section name for a two-line (Setext-style) section title.
     # The name cannot begin with a dot and has at least one alphanumeric character.

--- a/test/sections_test.rb
+++ b/test/sections_test.rb
@@ -495,6 +495,15 @@ blah blah
       output = render_string input
       assert_xpath "//h2[@id='_section_one'][text() = 'Section One']", output, 1
     end
+
+    test 'should not match mixed single-line syntax' do
+      input = <<-EOS
+=#= My Title
+      EOS
+      output = render_embedded_string input
+      assert_xpath "//h3[@id='_my_title'][text() = 'My Title']", output, 0
+      assert_includes output, '<p>=#= My Title</p>'
+    end
   end
 
   context 'Floating Title' do


### PR DESCRIPTION
- match either all equals (=) or all hashes (#), not a mix of both