### PR TITLE
path_resolver.relative_path: use standard library that just works

### DIFF
--- a/lib/asciidoctor/path_resolver.rb
+++ b/lib/asciidoctor/path_resolver.rb
@@ -470,12 +470,10 @@ class PathResolver
   #
   # Return the relative path String of the filename calculated from the base directory
   def relative_path filename, base_directory
-    if (is_root? filename) && (is_root? base_directory)
-      offset = (base_directory.end_with? @file_separator) ? base_directory.length : base_directory.length + 1
-      filename[offset..-1]
-    else
-      filename
-    end
+    Helpers.require_library 'pathname'
+    f = Pathname.new filename
+    d = Pathname.new base_directory
+    (f.relative_path_from d).to_s
   end
 end
 end

--- a/test/paths_test.rb
+++ b/test/paths_test.rb
@@ -219,6 +219,14 @@ context 'Path Resolver' do
       assert_equal 'part1/chapter1/section1.adoc', @resolver.relative_path(filename, JAIL)
     end
 
+    test 'should calculate relative path' do
+      filename = @resolver.system_path('common/shared/stuff.adoc', nil, JAIL)
+      dir = @resolver.system_path('part1/chapter1', nil, JAIL)
+      assert_equal "#{JAIL}/common/shared/stuff.adoc", filename
+      assert_equal "#{JAIL}/part1/chapter1", dir
+      assert_equal '../../common/shared/stuff.adoc', @resolver.relative_path(filename, dir)
+    end
+
     test 'should resolve relative path relative to base dir in unsafe mode' do
       base_dir = fixture_path 'base'
       doc = empty_document :base_dir => base_dir, :safe => Asciidoctor::SafeMode::UNSAFE


### PR DESCRIPTION
`path_resolver.relative_path` does not work if the path of interest is not in the subtree of the reference directory.

Original function naively cut longest common path prefix.

NOTE: Can we afford requiring pathname library? Does it work properly with OPAL?

WARNING: unable to run tests due to dependency errors so cannot confirm the test is correct, please review/rerun.