### PR TITLE
resolves #1689 fix sequential inline anchor macros with empty reftext

### DIFF
--- a/lib/asciidoctor.rb
+++ b/lib/asciidoctor.rb
@@ -817,7 +817,7 @@ module Asciidoctor
     #   anchor:idname[]
     #   anchor:idname[Reference Text]
     #
-    InlineAnchorRx = /\\?(?:\[\[([#{CC_ALPHA}:_][#{CC_WORD}:.-]*)(?:,#{CG_BLANK}*(\S.*?))?\]\]|anchor:(\S+)\[(.*?[^\\])?\])/
+    InlineAnchorRx = /\\?(?:\[\[([#{CC_ALPHA}:_][#{CC_WORD}:.-]*)(?:,#{CG_BLANK}*(\S.*?))?\]\]|anchor:([#{CC_ALPHA}:_][#{CC_WORD}:.-]*)\[(?:\]|(.*?[^\\])\]))/
 
     # Matches a bibliography anchor anywhere inline.
     #

--- a/test/links_test.rb
+++ b/test/links_test.rb
@@ -219,6 +219,18 @@ context 'Links' do
     end
   end
 
+  test 'repeating inline anchor macro with empty reftext' do
+    input = 'anchor:one[] anchor:two[] anchor:three[]'
+    result = render_inline_string input
+    assert_equal '<a id="one"></a> <a id="two"></a> <a id="three"></a>', result
+  end
+
+  test 'mixed inline anchor macro and anchor shorthand with empty reftext' do
+    input = 'anchor:one[][[two]]anchor:three[][[four]]anchor:five[]'
+    result = render_inline_string input
+    assert_equal '<a id="one"></a><a id="two"></a><a id="three"></a><a id="four"></a><a id="five"></a>', result
+  end
+
   test 'xref using angled bracket syntax' do
     doc = document_from_string '<<tigers>>'
     doc.references[:ids]['tigers'] = '[tigers]'

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -187,6 +187,11 @@ class Minitest::Test
     document_from_string(src, opts).render
   end
 
+  def render_inline_string(src, opts = {})
+    opts[:doctype] = :inline
+    document_from_string(src, opts).render
+  end
+
   def parse_header_metadata(source, doc = nil)
     reader = Asciidoctor::Reader.new source.split ::Asciidoctor::EOL
     [::Asciidoctor::Parser.parse_header_metadata(reader, doc), reader]


### PR DESCRIPTION
- don't skip sequential inline anchor macros
- make inline anchor macro less greedy; only match valid id chars