### PR TITLE
autoload extensions source file when Asciidoctor::Extensions is referenced

### DIFF
--- a/lib/asciidoctor.rb
+++ b/lib/asciidoctor.rb
@@ -1604,6 +1604,7 @@ module Asciidoctor
   else
     autoload :VERSION, 'asciidoctor/version'
     autoload :Timings, 'asciidoctor/timings'
+    autoload :Extensions, 'asciidoctor/extensions'
   end
 end
 

--- a/test/extensions_test.rb
+++ b/test/extensions_test.rb
@@ -3,7 +3,6 @@ unless defined? ASCIIDOCTOR_PROJECT_DIR
   $: << File.dirname(__FILE__); $:.uniq!
   require 'test_helper'
 end
-require 'asciidoctor/extensions'
 
 class SamplePreprocessor < Asciidoctor::Extensions::Preprocessor
   def process doc, reader


### PR DESCRIPTION
Avoids the need for the `require 'asciidoctor/extensions'` statement.