### PR TITLE
add stripes attribute for tables

### DIFF
--- a/data/stylesheets/asciidoctor-default.css
+++ b/data/stylesheets/asciidoctor-default.css
@@ -105,7 +105,6 @@ table{background:#fff;margin-bottom:1.25em;border:solid 1px #dedede}
 table thead,table tfoot{background:#f7f8f7;font-weight:bold}
 table thead tr th,table thead tr td,table tfoot tr th,table tfoot tr td{padding:.5em .625em .625em;font-size:inherit;color:rgba(0,0,0,.8);text-align:left}
 table tr th,table tr td{padding:.5625em .625em;font-size:inherit;color:rgba(0,0,0,.8)}
-table tr.even,table tr.alt,table tr:nth-of-type(even){background:#f8f8f7}
 table thead tr th,table tfoot tr th,table tbody tr td,table tr td,table tfoot tr td{display:table-cell;line-height:1.6}
 h1,h2,h3,#toctitle,.sidebarblock>.content>.title,h4,h5,h6{line-height:1.2;word-spacing:-.05em}
 h1 strong,h2 strong,h3 strong,#toctitle strong,.sidebarblock>.content>.title strong,h4 strong,h5 strong,h6 strong{font-weight:400}

--- a/lib/asciidoctor/converter/html5.rb
+++ b/lib/asciidoctor/converter/html5.rb
@@ -805,8 +805,40 @@ Your browser does not support the audio tag.
         result << '</colgroup>'
         [:head, :foot, :body].select {|tsec| !node.rows[tsec].empty? }.each do |tsec|
           result << %(<t#{tsec}>)
+          striped_rows_counter = 0
+          rowspan = 0
+          same_strip = false
           node.rows[tsec].each do |row|
-            result << '<tr>'
+            row_style_attribute = nil
+            if tsec == :body
+              row_without_headers = (row.all? { |cell| cell.style != :header })
+              if rowspan > 0
+                same_strip = true
+                rowspan -= 1
+              else
+                same_strip = false
+                row.each { |cell| rowspan = [cell.rowspan ? cell.rowspan - 1 : 0, rowspan].max }
+              end
+              if row_without_headers
+                unless same_strip
+                    striped_rows_counter += 1
+                end
+                stripesbgcolor = node.document.attr 'stripesbgcolor', '#f8f8f7'
+                case node.attr 'stripes', 'even', false
+                  when 'all'
+                    row_style_attribute = %( style="background-color: #{stripesbgcolor};")
+                  when 'even'
+                    row_style_attribute = striped_rows_counter.even? ? %( style="background-color: #{stripesbgcolor};") : nil
+                  when 'odd'
+                    row_style_attribute = striped_rows_counter.odd? ? %( style="background-color: #{stripesbgcolor};") : nil
+                  else # none
+                    row_style_attribute = nil
+                end
+              else
+                striped_rows_counter = 0
+              end
+            end
+            result << %(<tr#{row_style_attribute}>)
             row.each do |cell|
               if tsec == :head
                 cell_content = cell.text

--- a/test/tables_test.rb
+++ b/test/tables_test.rb
@@ -1412,5 +1412,136 @@ single cell
       output = render_embedded_string input, :backend => 'docbook45'
       assert output.include?('<?dbfo keep-together="always"?>')
     end
+
+    test 'table with even stripes by default' do
+      input = <<-EOS
+.Table with stripes by default
+|===
+| Column 1  | Column 2
+| Row 1     | Row 1
+| Row 2     | Row 2
+| Row 3     | Row 3
+| Row 4     | Row 4
+|===
+      EOS
+      output = render_embedded_string input
+      assert_xpath '(/table/tbody/tr)[1][@style="background-color: #f8f8f7;"]', output, 0
+      assert_xpath '(/table/tbody/tr)[2][@style="background-color: #f8f8f7;"]', output, 1
+      assert_xpath '(/table/tbody/tr)[3][@style="background-color: #f8f8f7;"]', output, 0
+      assert_xpath '(/table/tbody/tr)[4][@style="background-color: #f8f8f7;"]', output, 1
+    end
+
+    test 'table with odd stripes' do
+      input = <<-EOS
+.Table with odd stripes
+[stripes=odd]
+|===
+| Column 1  | Column 2
+| Row 1     | Row 1
+| Row 2     | Row 2
+| Row 3     | Row 3
+| Row 4     | Row 4
+|===
+      EOS
+      output = render_embedded_string input
+      assert_xpath '(/table/tbody/tr)[1][@style="background-color: #f8f8f7;"]', output, 1
+      assert_xpath '(/table/tbody/tr)[2][@style="background-color: #f8f8f7;"]', output, 0
+      assert_xpath '(/table/tbody/tr)[3][@style="background-color: #f8f8f7;"]', output, 1
+      assert_xpath '(/table/tbody/tr)[4][@style="background-color: #f8f8f7;"]', output, 0
+    end
+
+    test 'table with all stripes' do
+      input = <<-EOS
+.Table with odd stripes
+[stripes=all]
+|===
+| Column 1  | Column 2
+| Row 1     | Row 1
+| Row 2     | Row 2
+| Row 3     | Row 3
+| Row 4     | Row 4
+|===
+      EOS
+      output = render_embedded_string input
+      assert_xpath '(/table/tbody/tr)[1][@style="background-color: #f8f8f7;"]', output, 1
+      assert_xpath '(/table/tbody/tr)[2][@style="background-color: #f8f8f7;"]', output, 1
+      assert_xpath '(/table/tbody/tr)[3][@style="background-color: #f8f8f7;"]', output, 1
+      assert_xpath '(/table/tbody/tr)[4][@style="background-color: #f8f8f7;"]', output, 1
+    end
+
+    test 'table with no stripes' do
+      input = <<-EOS
+.Table with no stripes
+[stripes=none]
+|===
+| Column 1  | Column 2
+| Row 1     | Row 1
+| Row 2     | Row 2
+| Row 3     | Row 3
+| Row 4     | Row 4
+|===
+      EOS
+      output = render_embedded_string input
+      assert_xpath '(/table/tbody/tr)[1][@style="background-color: #f8f8f7;"]', output, 0
+      assert_xpath '(/table/tbody/tr)[2][@style="background-color: #f8f8f7;"]', output, 0
+      assert_xpath '(/table/tbody/tr)[3][@style="background-color: #f8f8f7;"]', output, 0
+      assert_xpath '(/table/tbody/tr)[4][@style="background-color: #f8f8f7;"]', output, 0
+    end
+
+    test 'table with custom colored stripes' do
+      input = <<-EOS
+{set:stripesbgcolor:red}
+.Table with red stripes
+|===
+| Column 1  | Column 2
+| Row 1     | Row 1
+| Row 2     | Row 2
+| Row 3     | Row 3
+| Row 4     | Row 4
+|===
+{set:stripesbgcolor!}
+      EOS
+      output = render_embedded_string input
+      assert_xpath '(/table/tbody/tr)[1][@style="background-color: red;"]', output, 0
+      assert_xpath '(/table/tbody/tr)[2][@style="background-color: red;"]', output, 1
+      assert_xpath '(/table/tbody/tr)[3][@style="background-color: red;"]', output, 0
+      assert_xpath '(/table/tbody/tr)[4][@style="background-color: red;"]', output, 1
+    end
+
+    test 'table with headers and stripes' do
+      input = <<-EOS
+.Table with headers and stripes
+[%header]
+|===
+| Header 1  | Header 2
+| Row 1     | Row 1
+| Row 2     | Row 2
+| Row 3     | Row 3
+^h| Sub-header 4     ^h| Sub-header 4
+.2+^h| Weird sub-header 5 h|12312
+^h| Row 6
+| Row 7     | Row 7
+.3+| Row with rowspan=3 8 h| sdfsdf
+| Row 9 
+| Row 10 
+| Row 11     | Row 11
+.3+| Row 12  | Row 12
+| Row 13
+| Row 14
+|===
+      EOS
+      output = render_embedded_string input
+      assert_xpath '(/table/tbody/tr)[1][@style="background-color: #f8f8f7;"]', output, 0
+      assert_xpath '(/table/tbody/tr)[2][@style="background-color: #f8f8f7;"]', output, 1
+      assert_xpath '(/table/tbody/tr)[3][@style="background-color: #f8f8f7;"]', output, 0
+      assert_xpath '(/table/tbody/tr)[6][@style="background-color: #f8f8f7;"]', output, 0
+      assert_xpath '(/table/tbody/tr)[7][@style="background-color: #f8f8f7;"]', output, 0
+      assert_xpath '(/table/tbody/tr)[9][@style="background-color: #f8f8f7;"]', output, 1
+      assert_xpath '(/table/tbody/tr)[10][@style="background-color: #f8f8f7;"]', output, 1
+      assert_xpath '(/table/tbody/tr)[11][@style="background-color: #f8f8f7;"]', output, 0
+      assert_xpath '(/table/tbody/tr)[12][@style="background-color: #f8f8f7;"]', output, 1
+      assert_xpath '(/table/tbody/tr)[13][@style="background-color: #f8f8f7;"]', output, 1
+      assert_xpath '(/table/tbody/tr)[14][@style="background-color: #f8f8f7;"]', output, 1
+    end
   end
 end


### PR DESCRIPTION
It is already present in `asciidoctor-pdf`. I repeated the logic to match that.
Changed default stripes background color to match `asciidoctor` default styles.
Also added possibility to define own color through `stripesbgcolor` document attribute.

See https://github.com/asciidoctor/asciidoctor-pdf/issues/724 for reference.

Fixes #1365 