### PR TITLE
resolves #1797 resolve attributes for short inline macros if requested

### DIFF
--- a/lib/asciidoctor/extensions.rb
+++ b/lib/asciidoctor/extensions.rb
@@ -468,9 +468,9 @@ module Extensions
     def resolve_regexp name, format
       # TODO memoize these regular expressions!
       if format == :short
-        %r(\\?#{name}:\[((?:\\\]|[^\]])*?)\])
+        /\\?#{name}:(){0}\[((?:\\\]|[^\]])*?)\]/
       else
-        %r(\\?#{name}:(\S+?)\[((?:\\\]|[^\]])*?)\])
+        /\\?#{name}:(\S+?)\[((?:\\\]|[^\]])*?)\]/
       end
     end
   end


### PR DESCRIPTION
- resolve attributes for short inline macros if content model is attributes
- don't attempt to parse an empty attribute string
- use text between square brackets as fallback value for target for backwards compat
- overlay parsed attributes on top of default attributes
- use abbreviated regexp delimiters
- add additional tests for various permutations of the inline macro
