### PR TITLE
resolves #2136 validate name of inline macro; cache inline macro rx

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -95,7 +95,6 @@ begin
   require 'yard'
   require 'yard-tomdoc'
   require './lib/asciidoctor'
-  require './lib/asciidoctor/extensions'
 
   # Prevent YARD from breaking command statements in literal paragraphs
   class CommandBlockPostprocessor < Asciidoctor::Extensions::Postprocessor

--- a/lib/asciidoctor.rb
+++ b/lib/asciidoctor.rb
@@ -906,6 +906,10 @@ module Asciidoctor
     #
     LinkInlineMacroRx = /\\?(?:link|mailto):([^\s\[]+)(?:\[((?:\\\]|[^\]])*?)\])/
 
+    # Matches the name of a macro.
+    #
+    MacroNameRx = /^#{CG_WORD}+$/
+
     # Matches a stem (and alternatives, asciimath and latexmath) inline macro, which may span multiple lines.
     #
     # Examples

--- a/lib/asciidoctor/extensions.rb
+++ b/lib/asciidoctor/extensions.rb
@@ -456,22 +456,20 @@ module Extensions
   # InlineMacroProcessor implementations must extend InlineMacroProcessor.
   #--
   # TODO break this out into different pattern types
-  # for example, FormalInlineMacro, ShortInlineMacro (no target) and other patterns
+  # for example, FullInlineMacro, ShortInlineMacro (no target) and other patterns
   # FIXME for inline passthrough, we need to have some way to specify the text as a passthrough
   class InlineMacroProcessor < MacroProcessor
+    @@rx_cache = {}
+
     # Lookup the regexp option, resolving it first if necessary.
     # Once this method is called, the regexp is considered frozen.
     def regexp
-      @config[:regexp] ||= (resolve_regexp @name, @config[:format])
+      @config[:regexp] ||= resolve_regexp @name.to_s, @config[:format]
     end
 
     def resolve_regexp name, format
-      # TODO memoize these regular expressions!
-      if format == :short
-        /\\?#{name}:(){0}\[((?:\\\]|[^\]])*?)\]/
-      else
-        /\\?#{name}:(\S+?)\[((?:\\\]|[^\]])*?)\]/
-      end
+      raise ::ArgumentError, %(invalid name for inline macro: #{name}) unless MacroNameRx.match? name
+      @@rx_cache[[name, format]] ||= /\\?#{name}:#{format == :short ? '(){0}' : '(\S+?)'}\[(|.*?[^\\])\]/
     end
   end
 

--- a/test/extensions_test.rb
+++ b/test/extensions_test.rb
@@ -739,7 +739,7 @@ snippet::12345[]
             named :short_match
             using_format :short
             parse_content_as :text
-            match /@(\w+)/
+            match %r/@(\w+)/
             process do |parent, target, attrs|
               %(target=#{target.inspect}, attributes=#{attrs.inspect})
             end


### PR DESCRIPTION
- validate name of inline macro
- cache inline macro rx between invocations
- remove warning in test suite
- remove unnecessary require in rake build