### PR TITLE
Added Norwegian Nynorsk translation and updated Norwegian Bokmål translation

### DIFF
--- a/data/locale/attributes.adoc
+++ b/data/locale/attributes.adoc
@@ -309,24 +309,46 @@ ifeval::["{lang}" == "nl"]
 :warning-caption: Waarschuwing
 endif::[]
 //
-// Norwegian, courtesy of Aslak Knutsen <aslak@4fs.no>
-ifeval::["{lang}" == "no"]
+// Norwegian Bokmål, courtesy of Aslak Knutsen <aslak@4fs.no>, with updates from Karl Ove Hufthammer <karl@huftis.org>
+ifeval::["{lang}" == "nb"]
 :appendix-caption: Vedlegg
-:caution-caption: Forsiktig
+:caution-caption: OBS
+:chapter-label: Kapittel
 :example-caption: Eksempel
 :figure-caption: Figur
 :important-caption: Viktig
 :last-update-label: Sist oppdatert
-//:listing-caption:
+//:listing-caption: Programkode
 :manname-title: NAVN
-:note-caption: Notat
-//:preface-title:
+:note-caption: Merk
+//:preface-title: Forord
 :table-caption: Tabell
 :tip-caption: Tips
-:toc-title: Innholdsfortegnelse
+:toc-title: Innhold
 :untitled-label: Navnløs
 :version-label: Versjon
 :warning-caption: Advarsel
+endif::[]
+//
+// Norwegian Nynorsk, courtesy of Karl Ove Hufthammer <karl@huftis.org>
+ifeval::["{lang}" == "nn"]
+:appendix-caption: Vedlegg
+:caution-caption: OBS
+:chapter-label: Kapittel
+:example-caption: Eksempel
+:figure-caption: Figur
+:important-caption: Viktig
+:last-update-label: Sist oppdatert
+//:listing-caption: Programkode
+:manname-title: NAMN
+:note-caption: Merk
+//:preface-title: Forord
+:table-caption: Tabell
+:tip-caption: Tips
+:toc-title: Innhald
+:untitled-label: Namnlaus
+:version-label: Versjon
+:warning-caption: Åtvaring
 endif::[]
 //
 // Polish translation, courtesy of Łukasz Dziedziul <l.dziedziul@gmail.com>


### PR DESCRIPTION
This adds support for Norwegian Nynorsk (language code: nn).
It also updates the Norwegian Bokmål translation, by adding a
few missing translations (chapter-label, listing-caption, preface-title)
and improving a few of the existing ones by making them more
idiomatic and consistent with other software (notable the babel
package in LaTeX).

Note that the language code for Norwegian Bokmål has been
corrected from ‘no’ to ‘nb’. There are only two written Norwegian
languages, Norwegian Bokmål (language code: nb) and
Norwegian Nynorsk (language code: nn). The older ‘no’ language
code should not be used for either of the written Norwegian
languages, only for spoken Norwegian.