### PR TITLE
use raise with exception class instead of fail

### DIFF
--- a/lib/asciidoctor/document.rb
+++ b/lib/asciidoctor/document.rb
@@ -1035,7 +1035,7 @@ class Document < AbstractBlock
 
     # QUESTION should we add processors that execute before conversion begins?
     unless @converter
-      fail %(asciidoctor: FAILED: missing converter for backend '#{backend}'. Processing aborted.)
+      raise ::NotImplementedError, %(asciidoctor: FAILED: missing converter for backend '#{backend}'. Processing aborted.)
     end
 
     if doctype == 'inline'

--- a/lib/asciidoctor/helpers.rb
+++ b/lib/asciidoctor/helpers.rb
@@ -5,7 +5,7 @@ module Helpers
   #
   # Attempts to load the library specified in the first argument using the
   # Kernel#require. Rescues the LoadError if the library is not available and
-  # passes a message to Kernel#fail if on_failure is :abort or Kernel#warn if
+  # passes a message to Kernel#raise if on_failure is :abort or Kernel#warn if
   # on_failure is :warn to communicate to the user that processing is being
   # aborted or functionality is disabled, respectively. If a gem_name is
   # specified, the message communicates that a required gem is not installed.
@@ -17,7 +17,7 @@ module Helpers
   # on_failure - a Symbol that indicates how to handle a load failure (:abort, :warn, :ignore) (default: :abort)
   #
   # returns The return value of Kernel#require if the library is available and can be, or was previously, loaded.
-  # Otherwise, Kernel#fail is called with an appropriate message if on_failure is :abort.
+  # Otherwise, Kernel#raise is called with an appropriate message if on_failure is :abort.
   # Otherwise, Kernel#warn is called with an appropriate message and nil returned if on_failure is :warn.
   # Otherwise, nil is returned.
   def self.require_library name, gem_name = true, on_failure = :abort
@@ -27,14 +27,14 @@ module Helpers
       gem_name = name if gem_name == true
       case on_failure
       when :abort
-        fail %(asciidoctor: FAILED: required gem '#{gem_name}' is not installed. Processing aborted.)
+        raise ::LoadError, %(asciidoctor: FAILED: required gem '#{gem_name}' is not installed. Processing aborted.)
       when :warn
         warn %(asciidoctor: WARNING: optional gem '#{gem_name}' is not installed. Functionality disabled.)
       end
     else
       case on_failure
       when :abort
-        fail %(asciidoctor: FAILED: #{e.message.chomp '.'}. Processing aborted.)
+        raise ::LoadError, %(asciidoctor: FAILED: #{e.message.chomp '.'}. Processing aborted.)
       when :warn
         warn %(asciidoctor: WARNING: #{e.message.chomp '.'}. Functionality disabled.)
       end

--- a/test/document_test.rb
+++ b/test/document_test.rb
@@ -2251,10 +2251,10 @@ asciidoctor - converts AsciiDoc source files to HTML, DocBook and other formats
 = Document Title
 text
       EOS
-      exception = assert_raises RuntimeError do
-        Asciidoctor.render(input, :backend => "unknownBackend")
+      exception = assert_raises NotImplementedError do
+        Asciidoctor.convert input, :backend => 'unknownBackend'
       end
-      assert_match(/missing converter for backend 'unknownBackend'/, exception.message)
+      assert_includes exception.message, 'missing converter for backend \'unknownBackend\''
     end
   end
 


### PR DESCRIPTION
- fail is just an alias for raise
- use a specific exception class for better flow control
- use LoadError when raising from rescued LoadError
- use NotImplementedError if converter is not set to bypass load rescue