### PR TITLE
resolves #2165 enclose menu caret in tag

### DIFF
--- a/data/stylesheets/asciidoctor-default.css
+++ b/data/stylesheets/asciidoctor-default.css
@@ -121,8 +121,11 @@ strong strong{font-weight:400}
 kbd{font-family:"Droid Sans Mono","DejaVu Sans Mono",monospace;display:inline-block;color:rgba(0,0,0,.8);font-size:.65em;line-height:1.45;background-color:#f7f7f7;border:1px solid #ccc;-webkit-border-radius:3px;border-radius:3px;-webkit-box-shadow:0 1px 0 rgba(0,0,0,.2),0 0 0 .1em white inset;box-shadow:0 1px 0 rgba(0,0,0,.2),0 0 0 .1em #fff inset;margin:0 .15em;padding:.2em .5em;vertical-align:middle;position:relative;top:-.1em;white-space:nowrap}
 .keyseq kbd:first-child{margin-left:0}
 .keyseq kbd:last-child{margin-right:0}
-.menuseq,.menu{color:#000}
-.menuseq{word-spacing:-.025em}
+.menuseq,.menuref{color:#000}
+.menuseq b:not(.caret),.menuref{font-weight:inherit}
+.menuseq{word-spacing:-.02em}
+.menuseq b.caret{font-size:1.25em;line-height:.8}
+.menuseq i.caret{font-weight:bold;text-align:center;width:.45em}
 b.button:before,b.button:after{position:relative;top:-1px;font-weight:400}
 b.button:before{content:"[";padding:0 3px 0 2px}
 b.button:after{content:"]";padding:0 2px 0 3px}

--- a/lib/asciidoctor/converter/html5.rb
+++ b/lib/asciidoctor/converter/html5.rb
@@ -1119,13 +1119,15 @@ Your browser does not support the video tag.
     end
 
     def inline_menu node
+      caret = (node.document.attr? 'icons', 'font') ? '&#160;<i class="fa fa-angle-right caret"></i> ' : '&#160;<b class="caret">&#8250;</b> '
+      submenu_joiner = %(</b>#{caret}<b class="submenu">)
       menu = node.attr 'menu'
       if !(submenus = node.attr 'submenus').empty?
-        %(<span class="menuseq"><span class="menu">#{menu}</span>&#160;&#9656; <span class="submenu">#{submenus * '</span>&#160;&#9656; <span class="submenu">'}</span>&#160;&#9656; <span class="menuitem">#{node.attr 'menuitem'}</span></span>)
+        %(<span class="menuseq"><b class="menu">#{menu}</b>#{caret}<b class="submenu">#{submenus * submenu_joiner}</b>#{caret}<b class="menuitem">#{node.attr 'menuitem'}</b></span>)
       elsif (menuitem = node.attr 'menuitem')
-        %(<span class="menuseq"><span class="menu">#{menu}</span>&#160;&#9656; <span class="menuitem">#{menuitem}</span></span>)
+        %(<span class="menuseq"><b class="menu">#{menu}</b>#{caret}<b class="menuitem">#{menuitem}</b></span>)
       else
-        %(<span class="menu">#{menu}</span>)
+        %(<b class="menuref">#{menu}</b>)
       end
     end
 

--- a/test/substitutions_test.rb
+++ b/test/substitutions_test.rb
@@ -1191,7 +1191,7 @@ EOS
     context 'Menu macro' do
       test 'should process menu using macro sytnax' do
         para = block_from_string('menu:File[]', :attributes => {'experimental' => ''})
-        assert_equal %q{<span class="menu">File</span>}, para.sub_macros(para.source)
+        assert_equal %q{<b class="menuref">File</b>}, para.sub_macros(para.source)
       end
 
       test 'should process menu for docbook backend' do
@@ -1201,7 +1201,12 @@ EOS
 
       test 'should process menu with menu item using macro syntax' do
         para = block_from_string('menu:File[Save As&#8230;]', :attributes => {'experimental' => ''})
-        assert_equal %q{<span class="menuseq"><span class="menu">File</span>&#160;&#9656; <span class="menuitem">Save As&#8230;</span></span>}, para.sub_macros(para.source)
+        assert_equal %q{<span class="menuseq"><b class="menu">File</b>&#160;<b class="caret">&#8250;</b> <b class="menuitem">Save As&#8230;</b></span>}, para.sub_macros(para.source)
+      end
+
+      test 'should process menu with menu item using macro syntax when fonts icons are enabled' do
+        para = block_from_string('menu:Tools[More Tools &gt; Extensions]', :attributes => {'experimental' => '', 'icons' => 'font'})
+        assert_equal %q{<span class="menuseq"><b class="menu">Tools</b>&#160;<i class="fa fa-angle-right caret"></i> <b class="submenu">More Tools</b>&#160;<i class="fa fa-angle-right caret"></i> <b class="menuitem">Extensions</b></span>}, para.sub_macros(para.source)
       end
 
       test 'should process menu with menu item for docbook backend' do
@@ -1211,7 +1216,7 @@ EOS
 
       test 'should process menu with menu item in submenu using macro syntax' do
         para = block_from_string('menu:Tools[Project &gt; Build]', :attributes => {'experimental' => ''})
-        assert_equal %q{<span class="menuseq"><span class="menu">Tools</span>&#160;&#9656; <span class="submenu">Project</span>&#160;&#9656; <span class="menuitem">Build</span></span>}, para.sub_macros(para.source)
+        assert_equal %q{<span class="menuseq"><b class="menu">Tools</b>&#160;<b class="caret">&#8250;</b> <b class="submenu">Project</b>&#160;<b class="caret">&#8250;</b> <b class="menuitem">Build</b></span>}, para.sub_macros(para.source)
       end
 
       test 'should process menu with menu item in submenu for docbook backend' do
@@ -1221,17 +1226,17 @@ EOS
 
       test 'should process menu with menu item in submenu using macro syntax and comma delimiter' do
         para = block_from_string('menu:Tools[Project, Build]', :attributes => {'experimental' => ''})
-        assert_equal %q{<span class="menuseq"><span class="menu">Tools</span>&#160;&#9656; <span class="submenu">Project</span>&#160;&#9656; <span class="menuitem">Build</span></span>}, para.sub_macros(para.source)
+        assert_equal %q{<span class="menuseq"><b class="menu">Tools</b>&#160;<b class="caret">&#8250;</b> <b class="submenu">Project</b>&#160;<b class="caret">&#8250;</b> <b class="menuitem">Build</b></span>}, para.sub_macros(para.source)
       end
 
       test 'should process menu with menu item using inline syntax' do
         para = block_from_string('"File &gt; Save As&#8230;"', :attributes => {'experimental' => ''})
-        assert_equal %q{<span class="menuseq"><span class="menu">File</span>&#160;&#9656; <span class="menuitem">Save As&#8230;</span></span>}, para.sub_macros(para.source)
+        assert_equal %q{<span class="menuseq"><b class="menu">File</b>&#160;<b class="caret">&#8250;</b> <b class="menuitem">Save As&#8230;</b></span>}, para.sub_macros(para.source)
       end
 
       test 'should process menu with menu item in submenu using inline syntax' do
         para = block_from_string('"Tools &gt; Project &gt; Build"', :attributes => {'experimental' => ''})
-        assert_equal %q{<span class="menuseq"><span class="menu">Tools</span>&#160;&#9656; <span class="submenu">Project</span>&#160;&#9656; <span class="menuitem">Build</span></span>}, para.sub_macros(para.source)
+        assert_equal %q{<span class="menuseq"><b class="menu">Tools</b>&#160;<b class="caret">&#8250;</b> <b class="submenu">Project</b>&#160;<b class="caret">&#8250;</b> <b class="menuitem">Build</b></span>}, para.sub_macros(para.source)
       end
 
       test 'inline syntax should not closing quote of XML attribute' do
@@ -1241,12 +1246,12 @@ EOS
 
       test 'should process menu macro with items containing multibyte characters' do
         para = block_from_string('menu:视图[放大, 重置]', :attributes => {'experimental' => ''})
-        assert_equal %q{<span class="menuseq"><span class="menu">视图</span>&#160;&#9656; <span class="submenu">放大</span>&#160;&#9656; <span class="menuitem">重置</span></span>}, para.sub_macros(para.source)
+        assert_equal %q{<span class="menuseq"><b class="menu">视图</b>&#160;<b class="caret">&#8250;</b> <b class="submenu">放大</b>&#160;<b class="caret">&#8250;</b> <b class="menuitem">重置</b></span>}, para.sub_macros(para.source)
       end if ::RUBY_MIN_VERSION_1_9
 
       test 'should process inline menu with items containing multibyte characters' do
         para = block_from_string('"视图 &gt; 放大 &gt; 重置"', :attributes => {'experimental' => ''})
-        assert_equal %q{<span class="menuseq"><span class="menu">视图</span>&#160;&#9656; <span class="submenu">放大</span>&#160;&#9656; <span class="menuitem">重置</span></span>}, para.sub_macros(para.source)
+        assert_equal %q{<span class="menuseq"><b class="menu">视图</b>&#160;<b class="caret">&#8250;</b> <b class="submenu">放大</b>&#160;<b class="caret">&#8250;</b> <b class="menuitem">重置</b></span>}, para.sub_macros(para.source)
       end if ::RUBY_MIN_VERSION_1_9
     end
   end


### PR DESCRIPTION
- allow menu caret to be styled independently by encosing in tag
- switch default caret to &#8250;
- use character from Font Awesome for caret if font-based icons are enabled