### PR TITLE
refactor regexps for macros and directives

### DIFF
--- a/lib/asciidoctor.rb
+++ b/lib/asciidoctor.rb
@@ -364,8 +364,8 @@ module Asciidoctor
   # contents between square brackets, ignoring escaped closing brackets
   # (closing brackets prefixed with a backslash '\' character)
   #
-  #   Pattern: (?:\[((?:\\\]|[^\]])*?)\])
-  #   Matches: [enclosed text here] or [enclosed [text\] here]
+  #   Pattern: \[(|.*?[^\\])\]
+  #   Matches: [enclosed text] and [enclosed [text\]], not [enclosed text \\] or [\\] (as these require a trailing space)
   #
   #(pseudo)module Rx
 
@@ -473,7 +473,7 @@ module Asciidoctor
     #   include::chapter1.ad[]
     #   include::example.txt[lines=1;2;5..10]
     #
-    IncludeDirectiveRx = /^(\\)?include::([^\[]+)\[(.*?)\]$/
+    IncludeDirectiveRx = /^(\\)?include::(.+?)\[(.*)\]$/
 
     # Matches a trailing tag directive in an include file.
     #
@@ -790,7 +790,7 @@ module Asciidoctor
     #
     #--
     # NOTE we've relaxed the match for target to accomodate the short format (e.g., name::[attrlist])
-    GenericBlockMacroRx = /^(#{CG_WORD}+)::(\S*?)\[((?:\\\]|[^\]])*?)\]$/
+    GenericBlockMacroRx = /^(#{CG_WORD}+)::(\S*?)\[(.*)\]$/
 
     # Matches an image, video or audio block macro.
     #
@@ -799,7 +799,7 @@ module Asciidoctor
     #   image::filename.png[Caption]
     #   video::http://youtube.com/12345[Cats vs Dogs]
     #
-    MediaBlockMacroRx = /^(image|video|audio)::(.+?)\[((?:\\\]|[^\]])*?)\]$/
+    MediaBlockMacroRx = /^(image|video|audio)::(.+?)\[(.*)\]$/
 
     # Matches the TOC block macro.
     #
@@ -808,7 +808,7 @@ module Asciidoctor
     #   toc::[]
     #   toc::[levels=2]
     #
-    TocBlockMacroRx = /^toc::\[(.*?)\]$/
+    TocBlockMacroRx = /^toc::\[(.*)\]$/
 
     ## Inline macros
 
@@ -835,7 +835,7 @@ module Asciidoctor
     #
     #   doc.writer@example.com
     #
-    EmailInlineMacroRx = /([\\>:\/])?#{CG_WORD}[#{CC_WORD}.%+-]*@#{CG_ALNUM}[#{CC_ALNUM}.-]*\.#{CG_ALPHA}{2,4}\b/
+    EmailInlineRx = /([\\>:\/])?#{CG_WORD}[#{CC_WORD}.%+-]*@#{CG_ALNUM}[#{CC_ALNUM}.-]*\.#{CG_ALPHA}{2,4}\b/
 
     # Matches an inline footnote macro, which is allowed to span multiple lines.
     #
@@ -855,7 +855,7 @@ module Asciidoctor
     #   image:filename.png[More [Alt\] Text] (alt text becomes "More [Alt] Text")
     #   icon:github[large]
     #
-    ImageInlineMacroRx = /\\?(?:image|icon):([^:\[][^\[]*)\[((?:\\\]|[^\]])*?)\]/
+    ImageInlineMacroRx = /\\?i(?:mage|con):([^:\[].*?)\[(|#{CC_ALL}*?[^\\])\]/m
 
     # Matches an indexterm inline macro, which may span multiple lines.
     #
@@ -878,7 +878,7 @@ module Asciidoctor
     #   kbd:[Ctrl,T]
     #   btn:[Save]
     #
-    KbdBtnInlineMacroRx = /\\?(?:kbd|btn):\[((?:\\\]|[^\]])+?)\]/
+    KbdBtnInlineMacroRx = /\\?(?:kbd|btn):\[(.*?[^\\])\]/
 
     # Matches the delimiter used for kbd value.
     #
@@ -897,7 +897,7 @@ module Asciidoctor
     #   http://github.com[GitHub]
     #
     # FIXME revisit! the main issue is we need different rules for implicit vs explicit
-    LinkInlineRx = %r{(^|link:|&lt;|[\s>\(\)\[\];])(\\?(?:https?|file|ftp|irc)://[^\s\[\]<]*[^\s.,\[\]<])(?:\[((?:\\\]|[^\]])*?)\])?}
+    LinkInlineRx = %r{(^|link:|&lt;|[\s>\(\)\[\];])(\\?(?:https?|file|ftp|irc)://[^\s\[\]<]*[^\s.,\[\]<])(?:\[(|#{CC_ALL}*?[^\\])\])?}m
 
     # Match a link or e-mail inline macro.
     #
@@ -906,7 +906,7 @@ module Asciidoctor
     #   link:path[label]
     #   mailto:doc.writer@example.com[]
     #
-    LinkInlineMacroRx = /\\?(?:link|mailto):([^\s\[]+)(?:\[((?:\\\]|[^\]])*?)\])/
+    LinkInlineMacroRx = /\\?(?:link|mailto):([^\s\[]\S*?)\[(|#{CC_ALL}*?[^\\])\]/m
 
     # Matches the name of a macro.
     #

--- a/lib/asciidoctor/substitutors.rb
+++ b/lib/asciidoctor/substitutors.rb
@@ -901,7 +901,7 @@ module Substitutors
     end
 
     if result.include? '@'
-      result = result.gsub(EmailInlineMacroRx) {
+      result = result.gsub(EmailInlineRx) {
         # alias match for Ruby 1.8.7 compat
         m = $~
         address = m[0]

--- a/test/links_test.rb
+++ b/test/links_test.rb
@@ -34,6 +34,10 @@ context 'Links' do
     assert_xpath "//a[@href='http://asciidoc.org'][text() = '[Ascii]Doc']", render_string("We're parsing http://asciidoc.org[[Ascii\\]Doc] markup")
   end
 
+  test 'qualified url with backslash label' do
+    assert_xpath "//a[@href='https://google.com'][text() = 'Google for \\']", render_string("I advise you to https://google.com[Google for +\\+]")
+  end
+
   test 'qualified url with label using link macro' do
     assert_xpath "//a[@href='http://asciidoc.org'][text() = 'AsciiDoc']", render_string("We're parsing link:http://asciidoc.org[AsciiDoc] markup")
   end

--- a/test/substitutions_test.rb
+++ b/test/substitutions_test.rb
@@ -8,7 +8,7 @@ end
 # - test negatives
 # - test role on every quote type
 context 'Substitutions' do
-  BACKSLASH = '\\'
+  BACKSLASH = %(\x5c)
   context 'Dispatcher' do
     test 'apply normal substitutions' do
       para = block_from_string("[blue]_http://asciidoc.org[AsciiDoc]_ & [red]*Ruby*\n&#167; Making +++<u>documentation</u>+++ together +\nsince (C) {inception_year}.")
@@ -1142,6 +1142,11 @@ EOS
         assert_equal %q{<kbd>F3</kbd>}, para.sub_macros(para.source)
       end
 
+      test 'kbd macro with single backslash key' do
+        para = block_from_string("kbd:[#{BACKSLASH} ]", :attributes => {'experimental' => ''})
+        assert_equal %q(<kbd>\</kbd>), para.sub_macros(para.source)
+      end
+
       test 'kbd macro with single key, docbook backend' do
         para = block_from_string('kbd:[F3]', :backend => 'docbook', :attributes => {'experimental' => ''})
         assert_equal %q{<keycap>F3</keycap>}, para.sub_macros(para.source)
@@ -1180,6 +1185,11 @@ EOS
       test 'kbd macro with key combination containing escaped bracket' do
         para = block_from_string('kbd:[Ctrl + \]]', :attributes => {'experimental' => ''})
         assert_equal %q{<span class="keyseq"><kbd>Ctrl</kbd>+<kbd>]</kbd></span>}, para.sub_macros(para.source)
+      end
+
+      test 'kbd macro with key combination ending in backslash' do
+        para = block_from_string("kbd:[Ctrl + #{BACKSLASH} ]", :attributes => {'experimental' => ''})
+        assert_equal %q(<span class="keyseq"><kbd>Ctrl</kbd>+<kbd>\\</kbd></span>), para.sub_macros(para.source)
       end
 
       test 'kbd macro with key combination, docbook backend' do


### PR DESCRIPTION
- simplify match of attrlist for inline macro to \[(|.*?[^\\])\]
  * trailing backslash only supported if followed by space or escaped using a passthrough
- simplify match for attrlist on block macro to \[(.*)\]
- use non-greedy matches instead of exclusion-based matches
- use multiline flag instead of exclusions to match over lines
- rename EmailInlineMacroRx to EmailInlineRx
- add more tests for backslash in attrlist
- allow content of inline pass macro to be empty