### PR TITLE
resolves #2112 sanitize content of authors meta tag in HTML output

### DIFF
--- a/lib/asciidoctor/converter/html5.rb
+++ b/lib/asciidoctor/converter/html5.rb
@@ -49,7 +49,7 @@ module Asciidoctor
       result << %(<meta name="application-name" content="#{node.attr 'app-name'}"#{slash}>) if node.attr? 'app-name'
       result << %(<meta name="description" content="#{node.attr 'description'}"#{slash}>) if node.attr? 'description'
       result << %(<meta name="keywords" content="#{node.attr 'keywords'}"#{slash}>) if node.attr? 'keywords'
-      result << %(<meta name="author" content="#{node.attr 'authors'}"#{slash}>) if node.attr? 'authors'
+      result << %(<meta name="author" content="#{((authors = node.attr 'authors').include? '<') ? (authors.gsub XmlSanitizeRx, '') : authors}"#{slash}>) if node.attr? 'authors'
       result << %(<meta name="copyright" content="#{node.attr 'copyright'}"#{slash}>) if node.attr? 'copyright'
       result << %(<title>#{node.doctitle :sanitize => true, :use_fallback => true}</title>)
 

--- a/test/document_test.rb
+++ b/test/document_test.rb
@@ -1494,6 +1494,18 @@ content
       assert_xpath '//articleinfo/authorinitials[text() = "DW"]', output, 1
     end
 
+    test 'should sanitize content of HTML meta authors tag' do
+      input = <<-EOS
+= Document Title
+:author: pass:n[http://example.org/community/team.html[Ze *Product* team]]
+
+content
+      EOS
+
+      output = render_string input
+      assert_xpath '//meta[@name="author"][@content="Ze Product team"]', output, 1
+    end
+
     test 'should include multiple authors in HTML output' do
       input = <<-EOS
 = Document Title

--- a/test/parser_test.rb
+++ b/test/parser_test.rb
@@ -492,6 +492,19 @@ Kismet Chameleon; Johnny Bravo; Lazarus het_Draeke
     assert_equal 'het Draeke', doc.attributes['lastname_3']
   end
 
+  test 'removes formatting before partitioning author defined using author attribute' do
+    input = <<-EOS
+:author: pass:n[http://example.org/community/team.html[Ze_**Project** team]]
+    EOS
+
+    doc = empty_document
+    parse_header_metadata input, doc
+    assert_equal 1, doc.attributes['authorcount']
+    assert_equal '<a href="http://example.org/community/team.html">Ze <strong>Project</strong> team</a>', doc.attributes['authors']
+    assert_equal 'Ze Project', doc.attributes['firstname']
+    assert_equal 'team', doc.attributes['lastname']
+  end
+
   test "parse rev number date remark" do
     input = <<-EOS
 Ryan Waldron


### PR DESCRIPTION
- sanitize content of authors meta tag in HTML output
- sanitize value of author and authors attribute before partitioning
- consolidate author metadata assignment
- add tests