### PR TITLE
resolves #2183 don't crash if substitution list resolves to nil

### DIFF
--- a/lib/asciidoctor.rb
+++ b/lib/asciidoctor.rb
@@ -514,7 +514,7 @@ module Asciidoctor
     #
     #   pass:[text]
     #
-    AttributeEntryPassMacroRx = /^pass:([a-z,]*)\[(.*)\]$/
+    AttributeEntryPassMacroRx = /^pass:([a-z]+(?:,[a-z]+)*)?\[(.*)\]$/
 
     # Matches an inline attribute reference.
     #
@@ -920,7 +920,7 @@ module Asciidoctor
     #   asciimath:[x != 0]
     #   latexmath:[\sqrt{4} = 2]
     #
-    StemInlineMacroRx = /\\?(stem|(?:latex|ascii)math):([a-z,]*)\[(#{CC_ALL}*?[^\\])\]/m
+    StemInlineMacroRx = /\\?(stem|(?:latex|ascii)math):([a-z]+(?:,[a-z]+)*)?\[(#{CC_ALL}*?[^\\])\]/m
 
     # Matches a menu inline macro.
     #
@@ -961,7 +961,8 @@ module Asciidoctor
     #   $$text$$
     #   pass:quotes[text]
     #
-    PassInlineMacroRx = /(?:(?:(\\?)\[([^\]]+?)\])?(\\{0,2})(\+{2,3}|\$\$)(#{CC_ALL}*?)\4|(\\?)pass:([a-z,]*)\[(|#{CC_ALL}*?[^\\])\])/m
+    # NOTE we have to support an empty pass:[] for compatibility with AsciiDoc Python
+    PassInlineMacroRx = /(?:(?:(\\?)\[([^\]]+?)\])?(\\{0,2})(\+{2,3}|\$\$)(#{CC_ALL}*?)\4|(\\?)pass:([a-z]+(?:,[a-z]+)*)?\[(|#{CC_ALL}*?[^\\])\])/m
 
     # Matches an xref (i.e., cross-reference) inline macro, which may span multiple lines.
     #

--- a/lib/asciidoctor/document.rb
+++ b/lib/asciidoctor/document.rb
@@ -895,9 +895,9 @@ class Document < AbstractBlock
   # value - The String attribute value on which to perform substitutions
   #
   # Returns The String value with substitutions performed
-  def apply_attribute_value_subs(value)
-    if (m = AttributeEntryPassMacroRx.match(value))
-      m[1].empty? ? m[2] : (apply_subs m[2], (resolve_pass_subs m[1]))
+  def apply_attribute_value_subs value
+    if AttributeEntryPassMacroRx =~ value
+      $1 ? (apply_subs $2, (resolve_pass_subs $1)) : $2
     else
       apply_header_subs value
     end

--- a/lib/asciidoctor/substitutors.rb
+++ b/lib/asciidoctor/substitutors.rb
@@ -216,7 +216,7 @@ module Substitutors
           next m[0][1..-1]
         end
 
-        @passthroughs[pass_key = @passthroughs.size] = {:text => (unescape_brackets m[8]), :subs => (m[7].nil_or_empty? ? [] : (resolve_pass_subs m[7]))}
+        @passthroughs[pass_key = @passthroughs.size] = {:text => (unescape_brackets m[8]), :subs => (m[7] ? (resolve_pass_subs m[7]) : [])}
       end
 
       %(#{preceding}#{PASS_START}#{pass_key}#{PASS_END})
@@ -292,12 +292,7 @@ module Substitutors
         type = ((default_stem_type = document.attributes['stem']).nil_or_empty? ? 'asciimath' : default_stem_type).to_sym
       end
       content = unescape_brackets m[3]
-      if m[2].nil_or_empty?
-        subs = (@document.basebackend? 'html') ? BASIC_SUBS : []
-      else
-        subs = resolve_pass_subs m[2]
-      end
-
+      subs = m[2] ? (resolve_pass_subs m[2]) : ((@document.basebackend? 'html') ? BASIC_SUBS : [])
       @passthroughs[pass_key = @passthroughs.size] = {:text => content, :subs => subs, :type => type}
       %(#{PASS_START}#{pass_key}#{PASS_END})
     } if (text.include? ':') && ((text.include? 'stem:') || (text.include? 'math:'))
@@ -1268,9 +1263,10 @@ module Substitutors
   # returns An Array of Symbols representing the substitution operation
   def resolve_subs subs, type = :block, defaults = nil, subject = nil
     return [] if subs.nil_or_empty?
+    # QUESTION should we store candidates as a Set instead of an Array?
     candidates = nil
-    modifiers_present = SubModifierSniffRx.match? subs
     subs = subs.delete ' ' if subs.include? ' '
+    modifiers_present = SubModifierSniffRx.match? subs
     subs.split(',').each do |key|
       modifier_operation = nil
       if modifiers_present
@@ -1317,8 +1313,8 @@ module Substitutors
         candidates += resolved_keys
       end
     end
-    # weed out invalid options and remove duplicates (first wins)
-    # TODO may be use a set instead?
+    return [] unless candidates
+    # weed out invalid options and remove duplicates (order is preserved; first occurence wins)
     resolved = candidates & SUB_OPTIONS[type]
     unless (candidates - resolved).empty?
       invalid = candidates - resolved

--- a/test/attributes_test.rb
+++ b/test/attributes_test.rb
@@ -213,6 +213,13 @@ EOS
       assert_equal '&lt;&gt;&amp;', doc.attributes['xml-busters']
     end
 
+    test 'should not recognize pass macro with invalid substitution list in attribute value' do
+      [',', '42', 'a,'].each do |subs|
+        doc = document_from_string %(:pass-fail: pass:#{subs}[whale])
+        assert_equal %(pass:#{subs}[whale]), doc.attributes['pass-fail']
+      end
+    end
+
     test "attribute is treated as defined until it's not" do
       input = <<-EOS
 :holygrail:

--- a/test/blocks_test.rb
+++ b/test/blocks_test.rb
@@ -2970,6 +2970,19 @@ part intro paragraph
   end
 
   context 'Substitutions' do
+    test 'processor should not crash if subs are empty' do
+      input = <<-EOS
+[subs=","]
+....
+content
+....
+      EOS
+
+      doc = document_from_string input
+      block = doc.blocks.first
+      assert_equal [], block.subs
+    end
+
     test 'should be able to append subs to default block substitution list' do
       input = <<-EOS
 :application: Asciidoctor

--- a/test/substitutions_test.rb
+++ b/test/substitutions_test.rb
@@ -1387,6 +1387,14 @@ EOS
       assert_equal '<strong><html5></strong>', result
     end
 
+    test 'should not recognize pass macro with invalid subsitution list' do
+      [',', '42', 'a,'].each do |subs|
+        para = block_from_string %(pass:#{subs}[foobar])
+        result = para.extract_passthroughs para.source
+        assert_equal %(pass:#{subs}[foobar]), result
+      end
+    end
+
     test 'should allow content of inline pass macro to be empty' do
       para = block_from_string 'pass:[]'
       result = para.extract_passthroughs para.source
@@ -1545,6 +1553,20 @@ EOS
         input = 'stem:[C = \alpha + \beta Y^{\gamma} + \epsilon]'
         para = block_from_string input, :attributes => {'stem' => 'latexmath'}
         assert_equal '\(C = \alpha + \beta Y^{\gamma} + \epsilon\)', para.content
+      end
+
+      test 'should apply substitutions specified on stem macro' do
+        input = 'stem:c,a[sqrt(x) <=> {solve-for-x}]'
+        para = block_from_string input, :attributes => {'stem' => 'asciimath', 'solve-for-x' => '13'}
+        assert_equal '\$sqrt(x) &lt;=&gt; 13\$', para.content
+      end
+
+      test 'should not recognize stem macro with invalid substitution list' do
+        [',', '42', 'a,'].each do |subs|
+          input = %(stem:#{subs}[x^2])
+          para = block_from_string input, :attributes => {'stem' => 'asciimath'}
+          assert_equal %(stem:#{subs}[x^2]), para.content
+        end
       end
     end
   end


### PR DESCRIPTION
- don't crash if resolve_subs resolves nil value
- make match for substitution list on pass and stem macro more strict
- use optional match group to capture subs for pass and stem macro