### PR TITLE
resolves #1694 apply title substitutions to reftext

### DIFF
--- a/lib/asciidoctor/attribute_list.rb
+++ b/lib/asciidoctor/attribute_list.rb
@@ -163,7 +163,7 @@ class AttributeList
           @attributes[%(#{value = value.strip}-option)] = ''
         end
         @attributes[name] = value
-      when 'title'
+      when 'title', 'reftext'
         @attributes[name] = value
       else
         @attributes[name] = single_quoted_value && !value.empty? && @block ? (@block.apply_normal_subs value) : value

--- a/lib/asciidoctor/substitutors.rb
+++ b/lib/asciidoctor/substitutors.rb
@@ -963,6 +963,7 @@ module Substitutors
         if m[0].start_with? RS
           next m[0][1..-1]
         end
+        # NOTE built-in html converter doesn't use reftext
         id = reftext = m[1]
         Inline.new(self, :anchor, reftext, :type => :bibref, :target => id).convert
       }
@@ -978,14 +979,12 @@ module Substitutors
           next m[0][1..-1]
         end
         id = m[1] || m[3]
-        reftext = m[2] || m[4] || %([#{id}])
-        # enable if we want to allow double quoted values
-        #id = id[1, id.length - 2] if (id.start_with? '"') && (id.end_with? '"')
-        #if reftext
-        #  reftext = reftext[1, reftext.length - 2] if (reftext.start_with? '"') && (reftext.end_with? '"')
-        #else
-        #  reftext = %([#{id}])
-        #end
+        # NOTE built-in html converter doesn't use reftext
+        if (reftext = m[2] || m[4])
+          reftext = apply_title_subs reftext
+        else
+          reftext = %([#{id}])
+        end
         Inline.new(self, :anchor, reftext, :type => :ref, :target => id).convert
       }
     end

--- a/test/blocks_test.rb
+++ b/test/blocks_test.rb
@@ -3140,5 +3140,18 @@ $ apt-get install asciidoctor
       refute_nil reftext
       assert_equal 'Debian Install', reftext
     end
+
+    test 'should apply title substitutions to reftext when registering block reference' do
+      input = <<-EOS
+[[generics,Java types with that <T> thing]]
+All about generics.
+      EOS
+
+      doc = document_from_string input
+      reftext = doc.references[:ids]['generics']
+      refute_nil reftext
+      assert_equal 'Java types with that &lt;T&gt; thing', reftext
+      assert_equal 'Java types with that &lt;T&gt; thing', doc.blocks[0].attributes['reftext']
+    end
   end
 end

--- a/test/links_test.rb
+++ b/test/links_test.rb
@@ -227,6 +227,15 @@ context 'Links' do
     end
   end
 
+  test 'inline ref with reftext converted to DocBook' do
+    %w([[tigers,<Tigers>]] anchor:tigers[<Tigers>]).each do |anchor|
+      doc = document_from_string %(Here you can read about tigers.#{anchor}), :backend => :docbook45
+      output = doc.convert :header_footer => false
+      assert_equal '&lt;Tigers&gt;', doc.references[:ids]['tigers']
+      assert_includes output, '<anchor id="tigers" xreflabel="&lt;Tigers&gt;"/>'
+    end
+  end
+
   test 'escaped inline ref' do
     variations = %w([[tigers]] anchor:tigers[])
     variations.each do |anchor|

--- a/test/sections_test.rb
+++ b/test/sections_test.rb
@@ -179,6 +179,21 @@ content
       assert_equal 'Install Procedure', reftext
     end
 
+    test 'should apply title substitutions to reftext when registering section reference' do
+      input = <<-EOS
+[[generics,Java types with that <T> thing]]
+== Generics
+
+content
+      EOS
+
+      doc = document_from_string input
+      reftext = doc.references[:ids]['generics']
+      refute_nil reftext
+      assert_equal 'Java types with that &lt;T&gt; thing', reftext
+      assert_equal 'Java types with that &lt;T&gt; thing', doc.sections[0].attributes['reftext']
+    end
+
     test 'should not overwrite existing id entry in references table' do
       input = <<-EOS
 [#install]


### PR DESCRIPTION
- apply title substitutions to reftext when parsing
- don't apply substitutions to value of reftext attribute enclosed in single quotes
- catalog inline anchors after creating block
- store substituted reftext in ID table and reftext attribute
- use more efficient code to scan for inline anchors
- remove dead code