### PR TITLE
resolves #858 Add possibility to use figure number or text in link

### DIFF
--- a/lib/asciidoctor/parser.rb
+++ b/lib/asciidoctor/parser.rb
@@ -97,6 +97,7 @@ class Parser
         document << new_section if new_section
       end
     end
+    document.apply_section_label_subs
 
     document
   end
@@ -1609,16 +1610,32 @@ class Parser
       section.sectname = %(sect#{section.level})
     end
 
-    # generate an id if one was not embedded or specified as anchor above section title
-    id = (section.id ||= (attributes['id'] || (Section.generate_id section.title, document)))
-
-    # TODO sub reftext
-    document.register(:ids, [id, (attributes['reftext'] || section.title)]) if id
+    register_section_ids section, attributes
 
     section.update_attributes(attributes)
     reader.skip_blank_lines
 
     section
+  end
+
+  # Internal: Registers section ids and their origin for use in internal references
+  #
+  # The ids registered here are later substituted by using the :id_origins entry.
+  # See Document#apply_section_label_subs
+  #
+  # section - the section who's ids get registered
+  # attributes - a Hash of attributes to assign to this section (default: {})
+  def self.register_section_ids section, attributes
+    document = section.document
+    # generate an id if one was not embedded or specified as anchor above section title
+    id = (section.id ||= (attributes['id'] || (Section.generate_id section.title, document)))
+
+    # should section-label get a default value? {sectnum} {secttitle}
+    reftext = attributes['reftext'] || document.attributes['section-label'] || section.title
+    if id
+      document.register(:ids, [id, reftext ])
+      document.register(:id_origins, [id, section])
+    end
   end
 
   # Internal: Checks if the next line on the Reader is a section title

--- a/lib/asciidoctor/substitutors.rb
+++ b/lib/asciidoctor/substitutors.rb
@@ -344,7 +344,7 @@ module Substitutors
       text.gsub SpecialCharsRx, SpecialCharsTr
     end
   else
-    def sub_specialchars text 
+    def sub_specialchars text
       text.gsub(SpecialCharsRx) { SpecialCharsTr[$&] }
     end
   end
@@ -480,6 +480,12 @@ module Substitutors
           end
         elsif doc_attrs.key?(key = m[2].downcase)
           doc_attrs[key]
+        elsif (section_subs = opts[:section_reftext])
+          if 'sectnum' == m[2].downcase
+            section_subs[:sectnum]
+          elsif 'secttitle' == m[2].downcase
+            section_subs[:secttitle]
+          end
         elsif INTRINSIC_ATTRIBUTES.key? key
           INTRINSIC_ATTRIBUTES[key]
         else

--- a/test/sections_test.rb
+++ b/test/sections_test.rb
@@ -1,4 +1,4 @@
-# encoding: UTF-8
+# encoding: utf-8
 unless defined? ASCIIDOCTOR_PROJECT_DIR
   $: << File.dirname(__FILE__); $:.uniq!
   require 'test_helper'
@@ -214,6 +214,122 @@ content
       refute_nil reftext
       assert_equal 'First Install', reftext
     end
+  end
+
+  test 'should sub section number for {sectnum} in section-label' do
+    input = <<-EOS
+:sectnums:
+:section-label: {sectnum}
+== First Install
+EOS
+    doc = document_from_string input
+    reftext = doc.references[:ids]['_first_install']
+    refute_nil reftext
+    assert_equal '1.', reftext
+  end
+
+  test 'should sub section title for {secttitle} in section-label' do
+    input = <<-EOS
+:sectnums:
+:section-label: {secttitle}
+== First Install
+EOS
+    doc = document_from_string input
+    reftext = doc.references[:ids]['_first_install']
+    refute_nil reftext
+    assert_equal 'First Install', reftext
+  end
+
+  test 'should sub sectnum and secttitle in local section reftext' do
+    input = <<-EOS
+:sectnums:
+:section-label: {secttitle}
+[reftext="{sectnum} {secttitle}"]
+== First Install
+EOS
+    doc = document_from_string input
+    reftext = doc.references[:ids]['_first_install']
+    refute_nil reftext
+    assert_equal '1. First Install', reftext
+  end
+
+  test 'should sub with correct sectnum for section-label' do
+    input = <<-EOS
+:sectnums:
+:section-label: {sectnum} {secttitle}
+
+
+== First Install
+content
+
+
+== Second Section
+
+
+=== Subsection One
+content
+
+
+=== Subsection Two
+content
+EOS
+    doc = document_from_string input
+    reftext = doc.references[:ids]['_subsection_two']
+    refute_nil reftext
+    assert_equal '2.2. Subsection Two', reftext
+  end
+
+  test 'should sub with correct sectnum for subsection reftext' do
+    input = <<-EOS
+:sectnums:
+:section-label: {secttitle}
+
+
+== First Install
+content
+
+
+== Second Section
+
+
+=== Subsection One
+content
+
+
+[reftext="{sectnum} {secttitle}"]
+=== Subsection Two
+content
+EOS
+    doc = document_from_string input
+    reftext = doc.references[:ids]['_subsection_two']
+    refute_nil reftext
+    assert_equal '2.2. Subsection Two', reftext
+  end
+
+  test 'should sub if only reftext and no section-label attribute is set' do
+    input = <<-EOS
+:sectnums:
+
+
+== First Install
+content
+
+
+== Second Section
+
+
+=== Subsection One
+content
+
+
+[reftext="{sectnum} {secttitle}"]
+=== Subsection Two
+content
+EOS
+    doc = document_from_string input
+    reftext = doc.references[:ids]['_subsection_two']
+    refute_nil reftext
+    assert_equal '2.2. Subsection Two', reftext
   end
 
   context "document title (level 0)" do


### PR DESCRIPTION
- saves origin section of ids when set
- reftext gets subbed after document parsing is complete
  and sectnums are set correctly
- introduces new attribute :section-label: for reftext substitution
  :section-label: {sectnum} {secttitle}

I tried a different approach for the section numbers that doesn't requires to set the sectnums earlier than before.
@mojavelinux Please have a look and give me feedback, this would make https://github.com/asciidoctor/asciidoctor/pull/1921 obsolete.