### PR TITLE
resolves #1516 add option to exclude tags when including file

### DIFF
--- a/lib/asciidoctor.rb
+++ b/lib/asciidoctor.rb
@@ -484,7 +484,7 @@ module Asciidoctor
     #     log(e);
     #   }
     #   // end::try-catch[]
-    TagDirectiveRx = /\b(?:tag|end)::\S+\[\]$/
+    TagDirectiveRx = /\b(?:tag|(end))::(\S+)\[\](?: -->)?$/
 
     ## Attribute entries and references
 

--- a/test/fixtures/mismatched-end-tag.adoc
+++ b/test/fixtures/mismatched-end-tag.adoc
@@ -1,0 +1,7 @@
+//tag::a[]
+a
+//tag::b[]
+b
+//end::a[]
+//end::b[]
+c

--- a/test/fixtures/tagged-class-enclosed.rb
+++ b/test/fixtures/tagged-class-enclosed.rb
@@ -1,0 +1,26 @@
+#tag::all[]
+class Dog
+  #tag::init[]
+  def initialize breed
+    @breed = breed
+  end
+  #end::init[]
+  #tag::bark[]
+
+  def bark
+    #tag::bark-beagle[]
+    if @breed == 'beagle'
+      'woof woof woof woof woof'
+    #end::bark-beagle[]
+    #tag::bark-other[]
+    else
+      'woof woof'
+    #end::bark-other[]
+    #tag::bark-all[]
+    #tag::bark-all[]
+    end
+    #end::bark-all[]
+  end
+  #end::bark[]
+end
+#end::all[]

--- a/test/fixtures/tagged-class.rb
+++ b/test/fixtures/tagged-class.rb
@@ -1,0 +1,23 @@
+class Dog
+  #tag::init[]
+  def initialize breed
+    @breed = breed
+  end
+  #end::init[]
+  #tag::bark[]
+
+  def bark
+    #tag::bark-beagle[]
+    if @breed == 'beagle'
+      'woof woof woof woof woof'
+    #end::bark-beagle[]
+    #tag::bark-other[]
+    else
+      'woof woof'
+    #end::bark-other[]
+    #tag::bark-all[]
+    end
+    #end::bark-all[]
+  end
+  #end::bark[]
+end


### PR DESCRIPTION
- in addition to including tags, add option to exclude tags using !name syntax
- introduce wildcard for including all (\*) or excluding all (!*) tags
- introduce wildcard for selecting non-tagged lines (**)
- don't select nested tags with wildcard if ancestor tag is excluded
- warn if a mismatched or unexpected end tag is found
- improve efficiency of detecting and processing tag directives
- maintain a tag stack for handling nested tags
- skip call to push_include if selected lines array is empty
- ignore tag and tags attribute if empty (previously caused an infinite loop)
- add tests for excluding tags