### PR TITLE
resolves #2089 include docfile in warning when stylesheet cannot be read

### DIFF
--- a/lib/asciidoctor.rb
+++ b/lib/asciidoctor.rb
@@ -1514,7 +1514,7 @@ module Asciidoctor
               stylesheet_src = doc.normalize_system_path stylesheet_src
             end
             stylesheet_dst = doc.normalize_system_path stylesheet, stylesoutdir, (doc.safe >= SafeMode::SAFE ? outdir : nil)
-            unless stylesheet_src == stylesheet_dst || (stylesheet_content = doc.read_asset stylesheet_src).nil?
+            if stylesheet_src != stylesheet_dst && (stylesheet_content = doc.read_asset stylesheet_src, :warn_on_failure => true, :label => 'stylesheet')
               ::File.open(stylesheet_dst, 'w') {|f| f.write stylesheet_content }
             end
           end

--- a/lib/asciidoctor/abstract_node.rb
+++ b/lib/asciidoctor/abstract_node.rb
@@ -461,7 +461,7 @@ class AbstractNode
       end
     else
       target = normalize_system_path target, opts[:start], nil, :target_name => (opts[:label] || 'asset')
-      data = read_asset target, :normalize => opts[:normalize], :warn_on_failure => (opts.fetch :warn_on_failure, true)
+      data = read_asset target, :normalize => opts[:normalize], :warn_on_failure => (opts.fetch :warn_on_failure, true), :label => opts[:label]
     end
     data
   end
@@ -479,19 +479,18 @@ class AbstractNode
   #
   # Returns the [String] content of the file at the specified path, or nil
   # if the file does not exist.
-  def read_asset(path, opts = {})
+  def read_asset path, opts = {}
     # remap opts for backwards compatibility
     opts = { :warn_on_failure => (opts != false) } unless ::Hash === opts
     if ::File.readable? path
       if opts[:normalize]
-        Helpers.normalize_lines_from_string(::IO.read(path)) * EOL
+        Helpers.normalize_lines_from_string(::IO.read path) * EOL
       else
         # QUESTION should we chomp or rstrip content?
-        ::IO.read(path)
+        ::IO.read path
       end
-    else
-      warn %(asciidoctor: WARNING: file does not exist or cannot be read: #{path}) if opts[:warn_on_failure]
-      nil
+    elsif opts[:warn_on_failure]
+      warn %(asciidoctor: WARNING: #{(attr 'docfile') || '<stdin>'}: #{opts[:label] || 'file'} does not exist or cannot be read: #{path})
     end
   end
 

--- a/lib/asciidoctor/converter/html5.rb
+++ b/lib/asciidoctor/converter/html5.rb
@@ -67,7 +67,7 @@ module Asciidoctor
           result << %(<link rel="stylesheet" href="#{node.normalize_web_path((node.attr 'stylesheet'), (node.attr 'stylesdir', ''))}"#{slash}>)
         else
           result << %(<style>
-#{node.read_asset node.normalize_system_path((node.attr 'stylesheet'), (node.attr 'stylesdir', '')), :warn_on_failure => true}
+#{node.read_asset node.normalize_system_path((node.attr 'stylesheet'), (node.attr 'stylesdir', '')), :warn_on_failure => true, :label => 'stylesheet'}
 </style>)
         end
       end


### PR DESCRIPTION
- add docfile to warning message emitted when stylesheet cannot be read
- warn when stylesheet to copy cannot be read
- allow label to be passed to read_asset method
- refer to missing file as a stylesheet