### PR TITLE
resolves #2202 don't match link macro with two colons

### DIFF
--- a/lib/asciidoctor.rb
+++ b/lib/asciidoctor.rb
@@ -853,8 +853,8 @@ module Asciidoctor
     #   image:filename.png[More [Alt\] Text] (alt text becomes "More [Alt] Text")
     #   icon:github[large]
     #
-    # NOTE be as non-greedy as possible while allowing spaces in the filename
-    ImageInlineMacroRx = /\\?i(?:mage|con):([^:\s\[][^\[\n]*)\[(|#{CC_ALL}*?[^\\])\]/m
+    # NOTE be as non-greedy as possible by not allowing endline or left square bracket in target
+    ImageInlineMacroRx = /\\?i(?:mage|con):([^:\s\[][^\n\[]*)\[(|#{CC_ALL}*?[^\\])\]/m
 
     # Matches an indexterm inline macro, which may span multiple lines.
     #
@@ -907,7 +907,8 @@ module Asciidoctor
     #   link:path[label]
     #   mailto:doc.writer@example.com[]
     #
-    LinkInlineMacroRx = /\\?(?:link|mailto):([^\s\[]\S*?)\[(|#{CC_ALL}*?[^\\])\]/m
+    # NOTE be as non-greedy as possible by not allowing space or left square bracket in target
+    LinkInlineMacroRx = /\\?(?:link|(mailto)):(|[^:\s\[][^\s\[]*)\[(|#{CC_ALL}*?[^\\])\]/m
 
     # Matches the name of a macro.
     #

--- a/lib/asciidoctor/substitutors.rb
+++ b/lib/asciidoctor/substitutors.rb
@@ -825,12 +825,12 @@ module Substitutors
         # alias match for Ruby 1.8.7 compat
         m = $~
         # honor the escape
-        if (captured = m[0]).start_with? RS
-          next captured[1..-1]
+        if m[0].start_with? RS
+          next m[0][1..-1]
         end
-        target = (mailto = captured.start_with? 'mailto:') ? %(mailto:#{m[1]}) : m[1]
+        target = (mailto = m[1]) ? %(mailto:#{m[2]}) : m[2]
         attrs, link_opts = nil, { :type => :link }
-        unless (text = m[2]).empty?
+        unless (text = m[3]).empty?
           text = text.gsub ESC_R_SB, R_SB if text.include? R_SB
           if use_link_attrs && ((text.start_with? '"') || ((text.include? ',') && (mailto || (text.include? '='))))
             attrs = parse_attributes text, []
@@ -869,7 +869,7 @@ module Substitutors
         if text.empty?
           # mailto is a special case, already processed
           if mailto
-            text = m[1]
+            text = m[2]
           else
             text = (doc_attrs.key? 'hide-uri-scheme') ? (target.sub UriSniffRx, '') : target
             if attrs

--- a/test/links_test.rb
+++ b/test/links_test.rb
@@ -60,6 +60,19 @@ context 'Links' do
     assert_match '<ulink url="http://example.com">[bracket1]</ulink>', doc.convert, 1
   end
 
+  test 'link macro with empty target' do
+    input = 'Link to link:[this page].'
+    output = render_embedded_string input
+    assert_xpath '//a', output, 1
+    assert_xpath '//a[@href=""]', output, 1
+  end
+
+  test 'should not recognize link macro with double colons' do
+    input = 'The link::http://example.org[example domain] is reserved for tests and documentation.'
+    output = render_embedded_string input
+    assert_includes output, 'link::http://example.org[example domain]'
+  end
+
   test 'qualified url surrounded by angled brackets' do
     assert_xpath '//a[@href="http://asciidoc.org"][text()="http://asciidoc.org"]', render_string('<http://asciidoc.org> is the project page for AsciiDoc.'), 1
   end


### PR DESCRIPTION
- don't match link macro with two colons
- allow target of link macro to be empty