### PR TITLE
resolves #2204 use [ \t] instead of \p{Blank} to match spaces

### DIFF
--- a/lib/asciidoctor.rb
+++ b/lib/asciidoctor.rb
@@ -389,13 +389,14 @@ module Asciidoctor
       CC_ALL   = '.'
       CC_ALNUM = '[:alnum:]'
       CG_ALNUM = '[[:alnum:]]'
-      CG_BLANK = '[[:blank:]]'
       CC_EOL   = '$'
       if ::RUBY_MIN_VERSION_1_9
+        CG_BLANK = '[[:blank:]]'
         CC_WORD = '[:word:]'
         CG_WORD = '[[:word:]]'
       else
         # NOTE Ruby 1.8 cannot match word characters beyond the ASCII range; if you need this feature, upgrade!
+        CG_BLANK = '[ \t]'
         CC_WORD = '[:alnum:]_'
         CG_WORD = '[[:alnum:]_]'
       end
@@ -422,15 +423,16 @@ module Asciidoctor
     #   v1.0, 2013-01-01: Ring in the new year release
     #   1.0, Jan 01, 2013
     #
-    RevisionInfoLineRx = /^(?:\D*(.*?),)?(?:\s*(?!:)(.*?))(?:\s*(?!^):\s*(.*))?$/
+    RevisionInfoLineRx = /^(?:\D*(.*?),)?(?: *(?!:)(.*?))(?: *(?!^): *(.*))?$/
 
     # Matches the title and volnum in the manpage doctype.
     #
     # Examples
     #
+    #   = asciidoctor(1)
     #   = asciidoctor ( 1 )
     #
-    ManpageTitleVolnumRx = /^(.*)\((.*)\)$/
+    ManpageTitleVolnumRx = /^(.+?) *\( *(.+?) *\)$/
 
     # Matches the name and purpose in the manpage doctype.
     #
@@ -438,7 +440,7 @@ module Asciidoctor
     #
     #   asciidoctor - converts AsciiDoc source files to HTML, DocBook and other formats
     #
-    ManpageNamePurposeRx = /^(.*?)#{CG_BLANK}+-#{CG_BLANK}+(.*)$/
+    ManpageNamePurposeRx = /^(.+?) +- +(.+)$/
 
     ## Preprocessor directives
 
@@ -462,7 +464,7 @@ module Asciidoctor
     #
     #   "{asciidoctor-version}" >= "0.1.0"
     #
-    EvalExpressionRx = /^(.+?)#{CG_BLANK}*([=!><]=|[><])#{CG_BLANK}*(.+)$/
+    EvalExpressionRx = /^(.+?) *([=!><]=|[><]) *(.+)$/
 
     # Matches an include preprocessor directive.
     #
@@ -501,7 +503,7 @@ module Asciidoctor
     #                collapsing the line breaks and indentation to
     #                a single space.
     #
-    AttributeEntryRx = /^:(!?\w.*?):(?:#{CG_BLANK}+(.*))?$/
+    AttributeEntryRx = /^:(!?\w.*?):(?:[ \t]+(.*))?$/
 
     # Matches invalid characters in an attribute name.
     InvalidAttributeNameCharsRx = /[^\w\-]/
@@ -541,7 +543,7 @@ module Asciidoctor
     #   [[idname]]
     #   [[idname,Reference Text]]
     #
-    BlockAnchorRx = /^\[\[(?:|([#{CC_ALPHA}:_][#{CC_WORD}:.-]*)(?:,#{CG_BLANK}*(.+))?)\]\]$/
+    BlockAnchorRx = /^\[\[(?:|([#{CC_ALPHA}:_][#{CC_WORD}:.-]*)(?:, *(.+))?)\]\]$/
 
     # Matches an attribute list above a block element.
     #
@@ -556,12 +558,12 @@ module Asciidoctor
     #   # as attribute reference
     #   [{lead}]
     #
-    BlockAttributeListRx = /^\[(|#{CG_BLANK}*[#{CC_WORD}\{,.#"'%].*)\]$/
+    BlockAttributeListRx = /^\[(|[#{CC_WORD}\{,.#"'%].*)\]$/
 
     # A combined pattern that matches either a block anchor or a block attribute list.
     #
     # TODO this one gets hit a lot, should be optimized as much as possible
-    BlockAttributeLineRx = /^\[(|#{CG_BLANK}*[#{CC_WORD}\{,.#"'%].*|\[(?:|[#{CC_ALPHA}:_][#{CC_WORD}:.-]*(?:,#{CG_BLANK}*.+)?)\])\]$/
+    BlockAttributeLineRx = /^\[(?:|[#{CC_WORD}\{,.#"'%].*|\[(?:|[#{CC_ALPHA}:_][#{CC_WORD}:.-]*(?:, *.+)?)\])\]$/
 
     # Matches a title above a block.
     #
@@ -569,7 +571,7 @@ module Asciidoctor
     #
     #   .Title goes here
     #
-    BlockTitleRx = /^\.([^\s.].*)$/
+    BlockTitleRx = /^\.([^ \t.].*)$/
 
     # Matches an admonition label at the start of a paragraph.
     #
@@ -578,7 +580,7 @@ module Asciidoctor
     #   NOTE: Just a little note.
     #   TIP: Don't forget!
     #
-    AdmonitionParagraphRx = /^(#{ADMONITION_STYLES.to_a * '|'}):#{CG_BLANK}/
+    AdmonitionParagraphRx = /^(#{ADMONITION_STYLES.to_a * '|'}):[ \t]+/
 
     # Matches a literal paragraph, which is a line of text preceded by at least one space.
     #
@@ -586,7 +588,7 @@ module Asciidoctor
     #
     #   <SPACE>Foo
     #   <TAB>Foo
-    LiteralParagraphRx = /^(#{CG_BLANK}+.*)$/
+    LiteralParagraphRx = /^([ \t]+.*)$/
 
     # Matches a comment block.
     #
@@ -621,7 +623,7 @@ module Asciidoctor
     # match[1] is the delimiter, whose length determines the level
     # match[2] is the title itself
     # match[3] is an inline anchor, which becomes the section id
-    AtxSectionRx = /^(={1,6}|\#{1,6})#{CG_BLANK}+(.+?)(?:#{CG_BLANK}+\1)?$/
+    AtxSectionRx = /^(={1,6}|\#{1,6})[ \t]+(.+?)(?:[ \t]+\1)?$/
 
     # Matches the restricted section name for a two-line (Setext-style) section title.
     # The name cannot begin with a dot and has at least one alphanumeric character.
@@ -634,7 +636,7 @@ module Asciidoctor
     #   Section Title [[idname]]
     #   Section Title [[idname,Reference Text]]
     #
-    InlineSectionAnchorRx = /^(.*?)#{CG_BLANK}+(\\)?\[\[([#{CC_ALPHA}:_][#{CC_WORD}:.-]*)(?:,#{CG_BLANK}*(.+))?\]\]$/
+    InlineSectionAnchorRx = /^(.*?) +(\\)?\[\[([#{CC_ALPHA}:_][#{CC_WORD}:.-]*)(?:, *(.+))?\]\]$/
 
     # Matches invalid characters in a section id.
     #
@@ -655,7 +657,7 @@ module Asciidoctor
     # Detects the start of any list item.
     #
     # NOTE we only have to check as far as the blank character because we know it means non-whitespace follows.
-    AnyListRx = /^(?:#{CG_BLANK}*(?:-|([*.\u2022])\1{0,4}|\d+\.|[a-zA-Z]\.|[IVXivx]+\))#{CG_BLANK}|#{CG_BLANK}*.*?(?::{2,4}|;;)(?:$|#{CG_BLANK})|<?\d+>#{CG_BLANK})/
+    AnyListRx = /^(?:[ \t]*(?:-|([*.\u2022])\1{0,4}|\d+\.|[a-zA-Z]\.|[IVXivx]+\))[ \t]|[ \t]*.*?(?::{2,4}|;;)(?:$|[ \t])|<?\d+>[ \t])/
 
     # Matches an unordered list item (one level for hyphens, up to 5 levels for asterisks).
     #
@@ -665,7 +667,7 @@ module Asciidoctor
     #   - Foo
     #
     # NOTE we know trailing (.*) will match at least one character because we strip trailing spaces
-    UnorderedListRx = /^#{CG_BLANK}*(-|\*{1,5}|\u2022{1,5})#{CG_BLANK}+(.*)$/
+    UnorderedListRx = /^[ \t]*(-|\*{1,5}|\u2022{1,5})[ \t]+(.*)$/
 
     # Matches an ordered list item (explicit numbering or up to 5 consecutive dots).
     #
@@ -681,7 +683,7 @@ module Asciidoctor
     #
     # NOTE leading space match is not always necessary, but is used for list reader
     # NOTE we know trailing (.*) will match at least one character because we strip trailing spaces
-    OrderedListRx = /^#{CG_BLANK}*(\.{1,5}|\d+\.|[a-zA-Z]\.|[IVXivx]+\))#{CG_BLANK}+(.*)$/
+    OrderedListRx = /^[ \t]*(\.{1,5}|\d+\.|[a-zA-Z]\.|[IVXivx]+\))[ \t]+(.*)$/
 
     # Matches the ordinals for each type of ordered list.
     OrderedListMarkerRxMap = {
@@ -718,15 +720,15 @@ module Asciidoctor
     # NOTE negative match for comment line is intentional since that isn't handled when looking for next list item
     # TODO check for line comment when scanning lines instead of in regex
     #
-    DescriptionListRx = %r(^(?!//)#{CG_BLANK}*(.*?)(:{2,4}|;;)(?:#{CG_BLANK}+(.*))?$)
+    DescriptionListRx = %r(^(?!//)[ \t]*(.*?)(:{2,4}|;;)(?:[ \t]+(.*))?$)
 
     # Matches a sibling description list item (which does not include the type in the key).
     DescriptionListSiblingRx = {
       # (?:.*?[^:])? - a non-capturing group which grabs longest sequence of characters that doesn't end w/ colon
-      '::' => %r(^(?!//)#{CG_BLANK}*((?:.*[^:])?)(::)(?:#{CG_BLANK}+(.*))?$),
-      ':::' => %r(^(?!//)#{CG_BLANK}*((?:.*[^:])?)(:::)(?:#{CG_BLANK}+(.*))?$),
-      '::::' => %r(^(?!//)#{CG_BLANK}*((?:.*[^:])?)(::::)(?:#{CG_BLANK}+(.*))?$),
-      ';;' => %r(^(?!//)#{CG_BLANK}*(.*)(;;)(?:#{CG_BLANK}+(.*))?$)
+      '::' => %r(^(?!//)[ \t]*((?:.*[^:])?)(::)(?:[ \t]+(.*))?$),
+      ':::' => %r(^(?!//)[ \t]*((?:.*[^:])?)(:::)(?:[ \t]+(.*))?$),
+      '::::' => %r(^(?!//)[ \t]*((?:.*[^:])?)(::::)(?:[ \t]+(.*))?$),
+      ';;' => %r(^(?!//)[ \t]*(.*)(;;)(?:[ \t]+(.*))?$)
     }
 
     # Matches a callout list item.
@@ -736,7 +738,7 @@ module Asciidoctor
     #   <1> Foo
     #
     # NOTE we know trailing (.*) will match at least one character because we strip trailing spaces
-    CalloutListRx = /^<?(\d+)>#{CG_BLANK}+(.*)$/
+    CalloutListRx = /^<?(\d+)>[ \t]+(.*)$/
 
     # Detects a potential callout list item.
     CalloutListSniffRx = /^<?\d+>/
@@ -782,8 +784,8 @@ module Asciidoctor
     #   2.3+<.>m
     #
     # FIXME use step-wise scan (or treetop) rather than this mega-regexp
-    CellSpecStartRx = /^#{CG_BLANK}*(?:(\d+(?:\.\d*)?|(?:\d*\.)?\d+)([*+]))?([<^>](?:\.[<^>]?)?|(?:[<^>]?\.)?[<^>])?([a-z])?$/
-    CellSpecEndRx = /#{CG_BLANK}+(?:(\d+(?:\.\d*)?|(?:\d*\.)?\d+)([*+]))?([<^>](?:\.[<^>]?)?|(?:[<^>]?\.)?[<^>])?([a-z])?$/
+    CellSpecStartRx = /^[ \t]*(?:(\d+(?:\.\d*)?|(?:\d*\.)?\d+)([*+]))?([<^>](?:\.[<^>]?)?|(?:[<^>]?\.)?[<^>])?([a-z])?$/
+    CellSpecEndRx = /[ \t]+(?:(\d+(?:\.\d*)?|(?:\d*\.)?\d+)([*+]))?([<^>](?:\.[<^>]?)?|(?:[<^>]?\.)?[<^>])?([a-z])?$/
 
     # Block macros
 
@@ -826,7 +828,7 @@ module Asciidoctor
     #   anchor:idname[]
     #   anchor:idname[Reference Text]
     #
-    InlineAnchorRx = /\\?(?:\[\[([#{CC_ALPHA}:_][#{CC_WORD}:.-]*)(?:,#{CG_BLANK}*(.+?))?\]\]|anchor:([#{CC_ALPHA}:_][#{CC_WORD}:.-]*)\[(?:\]|(.*?[^\\])\]))/
+    InlineAnchorRx = /\\?(?:\[\[([#{CC_ALPHA}:_][#{CC_WORD}:.-]*)(?:, *(.+?))?\]\]|anchor:([#{CC_ALPHA}:_][#{CC_WORD}:.-]*)\[(?:\]|(.*?[^\\])\]))/
 
     # Matches a bibliography anchor anywhere inline.
     #
@@ -893,7 +895,7 @@ module Asciidoctor
     #   Ctrl + Alt+T
     #   Ctrl,T
     #
-    KbdDelimiterRx = /(?:\+|,)(?=#{CG_BLANK}*[^\1])/
+    KbdDelimiterRx = /(?:\+|,)(?= *[^\1])/
 
     # Matches an implicit link and some of the link inline macro.
     #
@@ -905,7 +907,7 @@ module Asciidoctor
     #   link:https://github.com[]
     #
     # FIXME revisit! the main issue is we need different rules for implicit vs explicit
-    LinkInlineRx = %r((^|link:|&lt;|[\s>\(\)\[\];])(\\?(?:https?|file|ftp|irc)://[^\s\[\]<]*[^\s.,\[\]<])(?:\[(|#{CC_ALL}*?[^\\])\])?)m
+    LinkInlineRx = %r((^|link:|#{CG_BLANK}|&lt;|[>\(\)\[\];])(\\?(?:https?|file|ftp|irc)://[^\s\[\]<]*[^\s.,\[\]<])(?:\[(|#{CC_ALL}*?[^\\])\])?)m
 
     # Match a link or e-mail inline macro.
     #
@@ -939,7 +941,7 @@ module Asciidoctor
     #   menu:View[Page Style > No Style]
     #   menu:View[Page Style, No Style]
     #
-    MenuInlineMacroRx = /\\?menu:(#{CG_WORD}|[#{CC_WORD}&].*?\S)\[\s*(#{CC_ALL}*?[^\\])?\]/m
+    MenuInlineMacroRx = /\\?menu:(#{CG_WORD}|[#{CC_WORD}&].*?\S)\[ *(#{CC_ALL}*?[^\\])?\]/m
 
     # Matches an implicit menu inline macro.
     #
@@ -1060,7 +1062,7 @@ module Asciidoctor
     #
     #   three\ blind\ mice
     #
-    EscapedSpaceRx = /\\(\s)/
+    EscapedSpaceRx = /\\([ \t\n])/
 
     # Matches a whitespace delimiter, a sequence of spaces, tabs, and/or newlines.
 	# Matches the parsing rules of %w strings in Ruby.
@@ -1070,8 +1072,8 @@ module Asciidoctor
     #   one two	 three   four
     #   five	six
     #
-    # TODO change to /(?<!\\)\s+/ after dropping support for Ruby 1.8.7
-    SpaceDelimiterRx = /([^\\])\s+/
+    # TODO change to /(?<!\\)[ \t\n]+/ after dropping support for Ruby 1.8.7
+    SpaceDelimiterRx = /([^\\])[ \t\n]+/
 
     # Matches a + or - modifier in a subs list
     #

--- a/lib/asciidoctor/attribute_list.rb
+++ b/lib/asciidoctor/attribute_list.rb
@@ -28,7 +28,7 @@ class AttributeList
   BoundaryRxs = {
     '"' => /.*?[^\\](?=")/,
     '\'' => /.*?[^\\](?=')/,
-    ',' => /.*?(?=#{CG_BLANK}*(,|$))/
+    ',' => /.*?(?=[ \t]*(,|$))/
   }
 
   # Public: Regular expressions for unescaping quoted characters
@@ -41,12 +41,12 @@ class AttributeList
   # TODO named attributes cannot contain dash characters
   NameRx = /#{CG_WORD}[#{CC_WORD}\-.]*/
 
-  BlankRx = /#{CG_BLANK}+/
+  BlankRx = /[ \t]+/
 
   # Public: Regular expressions for skipping blanks and delimiters
   SkipRxs = {
     :blank => BlankRx,
-    ',' => /#{CG_BLANK}*(,|$)/
+    ',' => /[ \t]*(,|$)/
   }
 
   def initialize source, block = nil, delimiter = ','

--- a/lib/asciidoctor/parser.rb
+++ b/lib/asciidoctor/parser.rb
@@ -180,9 +180,9 @@ class Parser
   #
   # returns Nothing
   def self.parse_manpage_header(reader, document)
-    if (m = ManpageTitleVolnumRx.match(document.attributes['doctitle']))
-      document.attributes['mantitle'] = document.sub_attributes(m[1].rstrip.downcase)
-      document.attributes['manvolnum'] = m[2].strip
+    if ManpageTitleVolnumRx =~ document.attributes['doctitle']
+      document.attributes['mantitle'] = document.sub_attributes $1.downcase
+      document.attributes['manvolnum'] = $2
     else
       warn %(asciidoctor: ERROR: #{reader.prev_line_info}: malformed manpage title)
       # provide sensible fallbacks
@@ -195,7 +195,7 @@ class Parser
     if is_next_line_section?(reader, {})
       name_section = initialize_section(reader, document, {})
       if name_section.level == 1
-        name_section_buffer = reader.read_lines_until(:break_on_blank_lines => true).join(' ').squeeze(' ')
+        name_section_buffer = reader.read_lines_until(:break_on_blank_lines => true).join ' '
         if (m = ManpageNamePurposeRx.match(name_section_buffer))
           document.attributes['manname'] = document.sub_attributes m[1]
           document.attributes['manpurpose'] = m[2]
@@ -758,9 +758,8 @@ class Parser
             adjust_indentation! lines if indented && style == 'normal'
             block = Block.new(parent, :paragraph, :content_model => :simple, :source => lines, :attributes => attributes)
           elsif (ADMONITION_STYLE_LEADERS.include? ch0) && (this_line.include? ':') && (admonition_match = AdmonitionParagraphRx.match this_line)
-            lines[0] = admonition_match.post_match.lstrip
-            attributes['style'] = admonition_match[1]
-            attributes['name'] = admonition_name = admonition_match[1].downcase
+            lines[0] = admonition_match.post_match
+            attributes['name'] = admonition_name = (attributes['style'] = admonition_match[1]).downcase
             attributes['caption'] ||= document.attributes[%(#{admonition_name}-caption)]
             block = Block.new(parent, :admonition, :content_model => :simple, :source => lines, :attributes => attributes)
           elsif md_syntax && ch0 == '>' && this_line.start_with?('> ')

--- a/test/attributes_test.rb
+++ b/test/attributes_test.rb
@@ -1028,7 +1028,7 @@ content
       assert_xpath '//*[@class="title"]/strong[text()="title"]', output, 1
     end
 
-    test 'attribute list may begin with space' do
+    test 'attribute list may not begin with space' do
       input = <<-EOS
 [ quote]
 ____
@@ -1037,8 +1037,8 @@ ____
       EOS
 
       doc = document_from_string input
-      qb = doc.blocks.first
-      assert_equal 'quote', qb.style
+      b1 = doc.blocks.first
+      assert_equal ['[ quote]'], b1.lines
     end
 
     test 'attribute list may begin with comma' do
@@ -1361,7 +1361,7 @@ paragraph
       assert_equal 'coolio', subsec.id
     end
 
-    test "trailing block attributes tranfer to the following section" do
+    test "trailing block attributes transfer to the following section" do
       input = <<-EOS
 [[one]]
 

--- a/test/links_test.rb
+++ b/test/links_test.rb
@@ -127,6 +127,10 @@ context 'Links' do
     assert_xpath '//a[@href="http://asciidoc.org"][text()="AsciiDoc"]', render_string(')http://asciidoc.org[AsciiDoc] project page.'), 1
   end
 
+  test 'qualified url following no-break space' do
+    assert_xpath '//a[@href="http://asciidoc.org"][text()="AsciiDoc"]', render_string(%(#{[0xa0].pack 'U1'}http://asciidoc.org[AsciiDoc] project page.)), 1
+  end if ::RUBY_MIN_VERSION_1_9
+
   test 'qualified url following smart apostrophe' do
     output = render_embedded_string("l&#8217;http://www.irit.fr[IRIT]")
     assert_match(/l&#8217;<a href=/, output)


### PR DESCRIPTION
- use [ \t] (or just space) instead of \p{Blank}
- use CG_BLANK in front of bare URL
- use regexp to strip whitespace for text that follows label of admonition paragraph
- disallow tabs in certain places
- don't allow contents of block attribute list to begin with space
- optimize manpage header processing
- only match space, tab and newline when splitting attributes