### PR TITLE
no double quotes in xref macro

### DIFF
--- a/lib/asciidoctor.rb
+++ b/lib/asciidoctor.rb
@@ -986,7 +986,7 @@ module Asciidoctor
     #
     # NOTE special characters have already been escaped, hence the entity references
     # NOTE { is included in start characters to support target that begins with attribute reference in title content
-    XrefInlineMacroRx = %r(\\?(?:&lt;&lt;([#{CC_WORD}/.:{"]#{CC_ALL}*?)&gt;&gt;|xref:([#{CC_WORD}/.:{"]#{CC_ALL}*?)\[(#{CC_ALL}*?[^\\])?\]))m
+    XrefInlineMacroRx = %r(\\?(?:&lt;&lt;([#{CC_WORD}/.:{]#{CC_ALL}*?)&gt;&gt;|xref:([#{CC_WORD}/.:{]#{CC_ALL}*?)\[(#{CC_ALL}*?[^\\])?\]))m
 
     ## Layout
 

--- a/lib/asciidoctor/substitutors.rb
+++ b/lib/asciidoctor/substitutors.rb
@@ -991,9 +991,8 @@ module Substitutors
           next m[0][1..-1]
         end
         if m[1]
-          id, reftext = m[1].split(',', 2).map {|it| it.strip }
-          id = id[1, id.length - 2] if (id.start_with? '"') && (id.end_with? '"')
-          reftext = reftext[1, reftext.length - 2] if reftext && (reftext.start_with? '"') && (reftext.end_with? '"')
+          id, reftext = m[1].split ',', 2
+          reftext = reftext.lstrip if reftext
         else
           id, reftext = m[2], m[3]
           reftext = reftext.gsub ESC_R_SB, R_SB if reftext && (reftext.include? R_SB)

--- a/test/links_test.rb
+++ b/test/links_test.rb
@@ -287,7 +287,7 @@ context 'Links' do
   end
 
   test 'xref using angled bracket syntax with quoted label' do
-    assert_xpath '//a[@href="#tigers"][text() = "About Tigers"]', render_string('<<tigers,"About Tigers">>'), 1
+    assert_xpath %q(//a[@href="#tigers"][text() = '"About Tigers"']), render_string('<<tigers,"About Tigers">>'), 1
   end
 
   test 'xref using angled bracket syntax with path sans extension' do
@@ -366,7 +366,7 @@ context 'Links' do
   test 'xref with escaped text' do
     # when \x0 was used as boundary character for passthrough, it was getting stripped
     # now using unicode marks as boundary characters, which resolves issue
-    input = 'See the <<tigers , `[tigers]`>> section for data about tigers'
+    input = 'See the <<tigers, `+[tigers]+`>> section for data about tigers'
     output = render_embedded_string input
     assert_xpath %(//a[@href="#tigers"]/code[text()="[tigers]"]), output, 1
   end


### PR DESCRIPTION
- don't allow double quotes around id
- don't strip double quotes around reftext
- update relevant tests