### PR TITLE
resolves #560 and #1562 catalog bibliography anchors and capture reftext

### DIFF
--- a/lib/asciidoctor.rb
+++ b/lib/asciidoctor.rb
@@ -830,13 +830,16 @@ module Asciidoctor
     #
     InlineAnchorRx = /(\\)?(?:\[\[([#{CC_ALPHA}_:][#{CC_WORD}:.-]*)(?:, *(.+?))?\]\]|anchor:([#{CC_ALPHA}_:][#{CC_WORD}:.-]*)\[(?:\]|(.*?[^\\])\]))/
 
-    # Matches a bibliography anchor anywhere inline.
+    # Scans for a non-escaped anchor (i.e., id + optional reference text) in the flow of text.
+    InlineAnchorScanRx = /(?:^|[^\\\[])\[\[([#{CC_ALPHA}_:][#{CC_WORD}:.-]*)(?:, *(.+?))?\]\]|(?:^|[^\\])anchor:([#{CC_ALPHA}_:][#{CC_WORD}:.-]*)\[(?:\]|(.*?[^\\])\])/
+
+    # Matches a bibliography anchor at the start of the list item text (in a bibliography list).
     #
     # Examples
     #
-    #   [[[Foo]]]
+    #   [[[Fowler_1997]]] Fowler M. ...
     #
-    InlineBiblioAnchorRx = /\\?\[\[\[([#{CC_ALPHA}_:][#{CC_WORD}:.-]*)\]\]\]/
+    InlineBiblioAnchorRx = /^\[\[\[([#{CC_ALPHA}_:][#{CC_WORD}:.-]*)(?:, *(.+?))?\]\]\]/
 
     # Matches an inline e-mail address.
     #

--- a/lib/asciidoctor/converter/docbook5.rb
+++ b/lib/asciidoctor/converter/docbook5.rb
@@ -520,8 +520,7 @@ module Asciidoctor
       when :link
         %(<link xl:href="#{node.target}">#{node.text}</link>)
       when :bibref
-        target = node.target
-        %(<anchor#{common_attributes target, nil, "[#{target}]"}/>[#{target}])
+        %(<anchor#{common_attributes node.target, nil, (text = node.text)}/>#{text})
       else
         warn %(asciidoctor: WARNING: unknown anchor type: #{node.type.inspect})
       end

--- a/lib/asciidoctor/converter/html5.rb
+++ b/lib/asciidoctor/converter/html5.rb
@@ -1046,7 +1046,7 @@ Your browser does not support the video tag.
         attrs << %( target="#{window = node.attr 'window'}"#{window == '_blank' || (node.option? 'noopener') ? ' rel="noopener"' : ''}) if node.attr? 'window', nil, false
         %(<a href="#{target}"#{attrs.join}>#{node.text}</a>)
       when :bibref
-        %(<a id="#{target}"></a>[#{target}])
+        %(<a id="#{target}"></a>#{node.text})
       else
         warn %(asciidoctor: WARNING: unknown anchor type: #{node.type.inspect})
       end

--- a/lib/asciidoctor/parser.rb
+++ b/lib/asciidoctor/parser.rb
@@ -634,8 +634,9 @@ class Parser
         elsif UnorderedListRx.match? this_line
           reader.unshift_line this_line
           block = next_item_list(reader, :ulist, parent)
-          unless style
-            attributes['style'] = 'bibliography' if Section === parent && parent.sectname == 'bibliography'
+          if (style || (Section === parent && parent.sectname)) == 'bibliography'
+            attributes['style'] = 'bibliography' unless style
+            block.items.each {|item| catalog_inline_biblio_anchor item.instance_variable_get(:@text), document }
           end
           break
 
@@ -1188,7 +1189,7 @@ class Parser
   # Internal: Catalog any callouts found in the text, but don't process them
   #
   # text     - The String of text in which to look for callouts
-  # document - The current document on which the callouts are stored
+  # document - The current document in which the callouts are stored
   #
   # Returns A Boolean indicating whether callouts were found
   def self.catalog_callouts(text, document)
@@ -1206,23 +1207,34 @@ class Parser
   # Internal: Catalog any inline anchors found in the text, but don't process them
   #
   # text     - The String text in which to look for inline anchors
-  # document - The current document on which the references are stored
+  # document - The current document in which the references are stored
   #
   # Returns nothing
   def self.catalog_inline_anchors text, document
-    text.scan(InlineAnchorRx) do
-      # honor the escape
-      next if $1
-      if (id = $2)
-        reftext = $3
+    text.scan(InlineAnchorScanRx) do
+      if (id = $1)
+        reftext = $2
       else
-        id = $4
-        if (reftext = $5) && (reftext.include? ']')
+        id = $3
+        if (reftext = $4) && (reftext.include? ']')
           reftext = reftext.gsub '\]', ']'
         end
       end
       document.register :ids, [id, reftext]
     end if (text.include? '[[') || (text.include? 'or:')
+    nil
+  end
+
+  # Internal: Catalog any bibliography inline anchors found in the text, but don't process them
+  #
+  # text     - The String text in which to look for inline bibliography anchors
+  # document - The current document in which the references are stored
+  #
+  # Returns nothing
+  def self.catalog_inline_biblio_anchor text, document
+    if InlineBiblioAnchorRx =~ text
+      document.register :ids, [$1, %([#{$2 || $1}])]
+    end
     nil
   end
 

--- a/lib/asciidoctor/substitutors.rb
+++ b/lib/asciidoctor/substitutors.rb
@@ -945,16 +945,9 @@ module Substitutors
 
   # Internal: Substitute normal and bibliographic anchors
   def sub_inline_anchors(text, found = nil)
-    if (!found || found[:square_bracket]) && text.include?('[[[')
-      text = text.gsub(InlineBiblioAnchorRx) {
-        # alias match for Ruby 1.8.7 compat
-        m = $~
-        # honor the escape
-        if m[0].start_with? RS
-          next m[0][1..-1]
-        end
-        id = reftext = m[1]
-        Inline.new(self, :anchor, reftext, :type => :bibref, :target => id).convert
+    if @context == :list_item && @parent.style == 'bibliography'
+      text = text.sub(InlineBiblioAnchorRx) {
+        Inline.new(self, :anchor, %([#{$2 || $1}]), :type => :bibref, :target => $1).convert
       }
     end
 

--- a/test/links_test.rb
+++ b/test/links_test.rb
@@ -277,6 +277,11 @@ context 'Links' do
     end
   end
 
+  test 'does not match bibliography anchor in prose when scanning for inline anchor' do
+    doc = document_from_string 'Use [[[label]]] to assign a label to a bibliography entry.'
+    refute doc.catalog[:ids].key?('label')
+  end
+
   test 'repeating inline anchor macro with empty reftext' do
     input = 'anchor:one[] anchor:two[] anchor:three[]'
     result = render_inline_string input

--- a/test/substitutions_test.rb
+++ b/test/substitutions_test.rb
@@ -921,14 +921,6 @@ foofootnote:[+http://example.com+]barfootnote:[+http://acme.com+]baz
       assert_equal 'foo<footnote><simpara>http://example.com</simpara></footnote>bar<footnote><simpara>http://acme.com</simpara></footnote>baz', result
     end
 
-    test 'a footnote macro may contain a bibliographic anchor macro' do
-      para = block_from_string('text footnote:[a [[[b\]\]\] c]')
-      assert_equal %(text <sup class="footnote">[<a id="_footnoteref_1" class="footnote" href="#_footnote_1" title="View footnote.">1</a>]</sup>), para.sub_macros(para.source)
-      assert_equal 1, para.document.catalog[:footnotes].size
-      footnote1 = para.document.catalog[:footnotes][0]
-      assert_equal 'a <a id="b"></a>[b] c', footnote1.text
-    end
-
     test 'should increment index of subsequent footnote macros' do
       para = block_from_string("Sentence text footnote:[An example footnote.]. Sentence text footnote:[Another footnote.].")
       assert_equal %(Sentence text <sup class="footnote">[<a id="_footnoteref_1" class="footnote" href="#_footnote_1" title="View footnote.">1</a>]</sup>. Sentence text <sup class="footnote">[<a id="_footnoteref_2" class="footnote" href="#_footnote_2" title="View footnote.">2</a>]</sup>.), para.sub_macros(para.source)


### PR DESCRIPTION
- scan for bibliography anchors in bibliography list and save in document catalog
- don't scan for or convert bibliography anchors elsewhere in the document
- don't allow a bibliography anchor to be escaped
- allow reftext to be specified for bibliography anchors
- use reftext, if specified, as label in front of bibliography entry
- use reftext, if specified, for text of xref that refers to bibliography entry
- use a dedicated rx to scan for normal inline anchors
- don't catch a bibliography when scanning for normal inline anchors
- add tests