### PR TITLE
resolves #2061 encode double quotes in image alt text

### DIFF
--- a/lib/asciidoctor/converter/base.rb
+++ b/lib/asciidoctor/converter/base.rb
@@ -51,5 +51,11 @@ module Asciidoctor
     def skip node
       nil
     end
+
+    # QUESTION does this method belong somewhere else?
+    def encode_alt_text node, val, to_attr = false
+      val = node.sub_specialchars val if (val.include? '<') || (val.include? '&') || (val.include? '>')
+      to_attr && (val.include? '"') ? (val.gsub '"', '&quot;') : val
+    end
   end
 end

--- a/lib/asciidoctor/converter/docbook5.rb
+++ b/lib/asciidoctor/converter/docbook5.rb
@@ -202,7 +202,7 @@ module Asciidoctor
 <imageobject>
 <imagedata fileref="#{node.image_uri(node.attr 'target')}"#{width_attribute}#{depth_attribute}#{scale_attribute}#{align_attribute}/>
 </imageobject>
-<textobject><phrase>#{node.attr 'alt'}</phrase></textobject>
+<textobject><phrase>#{encode_alt_text node, (node.attr 'alt')}</phrase></textobject>
 </mediaobject>)
 
       if node.title?

--- a/lib/asciidoctor/converter/html5.rb
+++ b/lib/asciidoctor/converter/html5.rb
@@ -555,13 +555,13 @@ Your browser does not support the audio tag.
       if ((node.attr? 'format', 'svg', false) || (target.include? '.svg')) && node.document.safe < SafeMode::SECURE &&
           ((svg = (node.option? 'inline')) || (obj = (node.option? 'interactive')))
         if svg
-          img = (read_svg_contents node, target) || %(<span class="alt">#{node.attr 'alt'}</span>)
+          img = (read_svg_contents node, target) || %(<span class="alt">#{encode_alt_text node, (node.attr 'alt')}</span>)
         elsif obj
-          fallback = (node.attr? 'fallback') ? %(<img src="#{node.image_uri(node.attr 'fallback')}" alt="#{node.attr 'alt'}"#{width_attr}#{height_attr}#{@void_element_slash}>) : %(<span class="alt">#{node.attr 'alt'}</span>)
+          fallback = (node.attr? 'fallback') ? %(<img src="#{node.image_uri(node.attr 'fallback')}" alt="#{encode_alt_text node, (node.attr 'alt'), true}"#{width_attr}#{height_attr}#{@void_element_slash}>) : %(<span class="alt">#{encode_alt_text node, (node.attr 'alt')}</span>)
           img = %(<object type="image/svg+xml" data="#{node.image_uri target}"#{width_attr}#{height_attr}>#{fallback}</object>)
         end
       end
-      img ||= %(<img src="#{node.image_uri target}" alt="#{node.attr 'alt'}"#{width_attr}#{height_attr}#{@void_element_slash}>)
+      img ||= %(<img src="#{node.image_uri target}" alt="#{encode_alt_text node, (node.attr 'alt'), true}"#{width_attr}#{height_attr}#{@void_element_slash}>)
       if node.attr? 'link'
         window_attr = %( target="#{window = node.attr 'window'}"#{window == '_blank' || (node.option? 'noopener') ? ' rel="noopener"' : ''}) if node.attr? 'window'
         img = %(<a class="image" href="#{node.attr 'link'}"#{window_attr}>#{img}</a>)

--- a/test/blocks_test.rb
+++ b/test/blocks_test.rb
@@ -1638,20 +1638,20 @@ image::images/tiger.png[Tiger]
 
     test 'alt text is escaped in HTML backend' do
       input = <<-EOS
-image::images/open.png[File > Open]
+image::images/open.png[Select "File > Open"]
       EOS
 
       output = render_embedded_string input
-      assert_match(/File &gt; Open/, output)
+      assert_match(/Select &quot;File &gt; Open&quot;/, output)
     end
 
     test 'alt text is escaped in DocBook backend' do
       input = <<-EOS
-image::images/open.png[File > Open]
+image::images/open.png[Select "File > Open"]
       EOS
 
       output = render_embedded_string input, :backend => :docbook
-      assert_match(/File &gt; Open/, output)
+      assert_match(/Select "File &gt; Open"/, output)
     end
 
     test "can render block image with auto-generated alt text" do


### PR DESCRIPTION
- encode double quote characters in image alt text when used in attribute value
- defer encoding characters in alt text to converter
- process image attributes after creating image block