### PR TITLE
Adds a warning if verbose is set and xref is not found

### DIFF
--- a/lib/asciidoctor/substitutors.rb
+++ b/lib/asciidoctor/substitutors.rb
@@ -1023,11 +1023,13 @@ module Substitutors
           end
         # handles: id or Section Title
         else
+          if !(@document.catalog[:ids].key? fragment)
+            warn %(asciidoctor: WARNING: could not resolve xref: #{fragment}) if $VERBOSE
           # resolve fragment as reftext if it's not a known ID and resembles reftext (includes space or has uppercase char)
-          if !(@document.catalog[:ids].key? fragment) &&
-              ((fragment.include? ' ') || fragment.downcase != fragment) &&
+            if ((fragment.include? ' ') || fragment.downcase != fragment) &&
               (resolved_id = @document.catalog[:ids].key fragment)
-            fragment = resolved_id
+              fragment = resolved_id
+            end
           end
           refid, target = fragment, %(##{fragment})
         end

--- a/lib/asciidoctor/substitutors.rb
+++ b/lib/asciidoctor/substitutors.rb
@@ -1023,12 +1023,13 @@ module Substitutors
           end
         # handles: id or Section Title
         else
-          if !(@document.catalog[:ids].key? fragment)
-            warn %(asciidoctor: WARNING: could not resolve xref: #{fragment}) if $VERBOSE
           # resolve fragment as reftext if it's not a known ID and resembles reftext (includes space or has uppercase char)
+          unless @document.catalog[:ids].key? fragment
             if ((fragment.include? ' ') || fragment.downcase != fragment) &&
-              (resolved_id = @document.catalog[:ids].key fragment)
+                (resolved_id = @document.catalog[:ids].key fragment)
               fragment = resolved_id
+            elsif $VERBOSE
+              warn %(asciidoctor: WARNING: invalid reference: #{fragment})
             end
           end
           refid, target = fragment, %(##{fragment})

--- a/test/substitutions_test.rb
+++ b/test/substitutions_test.rb
@@ -1842,26 +1842,27 @@ foo&#8201;&#8212;&#8201;'
       assert_equal [:specialcharacters, :quotes, :attributes, :replacements, :macros, :post_replacements], block.subs
     end
 
-    test 'should print a warning if verbose flag is set and xref is not found' do
-      xref = 'testing1'
+    test 'should warn if verbose flag is set and reference is not found' do
       input = <<-EOS
-[[testing]]
-== Section 1
+[#foobar]
+== Foobar
 
-== Section 2
+== Section B
 
-See <<#{xref}>>.
+See <<foobaz>>.
 EOS
-      old_verbose = $VERBOSE
-      $VERBOSE = true
-      warnings = nil
-      redirect_streams do |out, err|
-        render_string input
-        warnings = err.string
+      begin
+        old_verbose, $VERBOSE = $VERBOSE, true
+        warnings = redirect_streams do |_, err|
+          render_embedded_string input
+          err.string
+        end
+        $VERBOSE = old_verbose
+        refute warnings.empty?
+        assert_includes warnings, 'asciidoctor: WARNING: invalid reference: foobaz'
+      ensure
+        $VERBOSE = old_verbose
       end
-      $VERBOSE = old_verbose
-      assert !warnings.empty?
-      assert_match(/asciidoctor: WARNING: could not resolve xref: #{xref}/, warnings.chomp)
     end
   end
 

--- a/test/substitutions_test.rb
+++ b/test/substitutions_test.rb
@@ -1841,6 +1841,28 @@ foo&#8201;&#8212;&#8201;'
       block.lock_in_subs
       assert_equal [:specialcharacters, :quotes, :attributes, :replacements, :macros, :post_replacements], block.subs
     end
+
+    test 'should print a warning if verbose flag is set and xref is not found' do
+      xref = 'testing1'
+      input = <<-EOS
+[[testing]]
+== Section 1
+
+== Section 2
+
+See <<#{xref}>>.
+EOS
+      old_verbose = $VERBOSE
+      $VERBOSE = true
+      warnings = nil
+      redirect_streams do |out, err|
+        render_string input
+        warnings = err.string
+      end
+      $VERBOSE = old_verbose
+      assert !warnings.empty?
+      assert_match(/asciidoctor: WARNING: could not resolve xref: #{xref}/, warnings.chomp)
+    end
   end
 
   # TODO move to helpers_test.rb


### PR DESCRIPTION
The warning has the following form:
asciidoctor: WARNING: could not resolve xref:

closes #2268