### PR TITLE
resolves #1660 be more precise about splitting kbd characters

### DIFF
--- a/lib/asciidoctor.rb
+++ b/lib/asciidoctor.rb
@@ -902,17 +902,6 @@ module Asciidoctor
     #
     KbdBtnInlineMacroRx = /(\\)?(kbd|btn):\[(#{CC_ALL}*?[^\\])\]/m
 
-    # Matches the delimiter used for kbd value.
-    #
-    # Examples
-    #
-    #   Ctrl + Alt + T
-    #   Ctrl+,
-    #   Ctrl,T
-    #   Ctrl,+
-    #
-    KbdDelimiterRx = /[+,]/
-
     # Matches an implicit link and some of the link inline macro.
     #
     # Examples

--- a/lib/asciidoctor/substitutors.rb
+++ b/lib/asciidoctor/substitutors.rb
@@ -536,14 +536,13 @@ module Substitutors
             if (keys = $3.strip).include? R_SB
               keys = keys.gsub ESC_R_SB, R_SB
             end
-            if keys.length > 1 && (delim = keys[KbdDelimiterRx])
-              # NOTE handle special case of Ctrl++ or Ctrl,,
+            if keys.length > 1 && (delim_idx = (delim_idx = keys.index ',', 1) ?
+                [delim_idx, (keys.index '+', 1)].compact.min : (keys.index '+', 1))
+              delim = keys.slice delim_idx, 1
+              # NOTE handle special case where keys ends with delimiter (e.g., Ctrl++ or Ctrl,,)
               if keys.end_with? delim
-                keys = keys.split(delim, -1).map {|key| key.strip }
-                if keys[-1].empty?
-                  keys.pop
-                  keys[-1] = delim if keys[-1].empty?
-                end
+                keys = (keys.chop.split delim, -1).map {|key| key.strip }
+                keys[-1] = %(#{keys[-1]}#{delim})
               else
                 keys = keys.split(delim).map {|key| key.strip }
               end

--- a/test/substitutions_test.rb
+++ b/test/substitutions_test.rb
@@ -1256,6 +1256,16 @@ EOS
         para = block_from_string("kbd:[Ctrl + #{BACKSLASH} ]", :attributes => {'experimental' => ''})
         assert_equal %q(<span class="keyseq"><kbd>Ctrl</kbd>+<kbd>\\</kbd></span>), para.sub_macros(para.source)
       end
+
+      test 'kbd macro looks for delimiter beyond first character' do
+        para = block_from_string('kbd:[,te]', :attributes => {'experimental' => ''})
+        assert_equal %q(<kbd>,te</kbd>), para.sub_macros(para.source)
+      end
+
+      test 'kbd macro restores trailing delimiter as key value' do
+        para = block_from_string('kbd:[te,]', :attributes => {'experimental' => ''})
+        assert_equal %q(<kbd>te,</kbd>), para.sub_macros(para.source)
+      end
     end
 
     context 'Menu macro' do


### PR DESCRIPTION
- don't use delimiter at start or end of keys value
- locate delimiter using index instead of regexp
- add additional tests for kbd macro