### PR TITLE
encode spaces in URI

### DIFF
--- a/lib/asciidoctor/abstract_node.rb
+++ b/lib/asciidoctor/abstract_node.rb
@@ -329,7 +329,7 @@ class AbstractNode
   # Returns A String reference or data URI for the target image
   def image_uri(target_image, asset_dir_key = 'imagesdir')
     if (doc = @document).safe < SafeMode::SECURE && (doc.attr? 'data-uri')
-      if (Helpers.uriish? target_image) ||
+      if ((Helpers.uriish? target_image) && (target_image = uri_encode_spaces target_image)) ||
           (asset_dir_key && (images_base = doc.attr asset_dir_key) && (Helpers.uriish? images_base) &&
           (target_image = normalize_web_path target_image, images_base, false))
         if doc.attr? 'allow-uri-read'
@@ -497,10 +497,19 @@ class AbstractNode
   # Returns the resolved [String] path
   def normalize_web_path(target, start = nil, preserve_uri_target = true)
     if preserve_uri_target && (Helpers.uriish? target)
-      target
+      uri_encode_spaces target
     else
       (@path_resolver ||= PathResolver.new).web_path target, start
     end
+  end
+
+  # Internal: URI encode spaces in a String
+  #
+  # str - the String to encode
+  #
+  # Returns the String with all spaces replaced with %20.
+  def uri_encode_spaces str
+    (str.include? ' ') ? (str.gsub ' ', '%20') : str
   end
 
   # Public: Resolve and normalize a secure path from the target and start paths

--- a/test/blocks_test.rb
+++ b/test/blocks_test.rb
@@ -1847,6 +1847,15 @@ image::http://asciidoc.org/images/tiger.png[Tiger]
       assert_xpath '/*[@class="imageblock"]//img[@src="http://asciidoc.org/images/tiger.png"][@alt="Tiger"]', output, 1
     end
 
+    test 'should encode spaces in image target if value is a URI' do
+      input = <<-EOS
+image::http://example.org/svg?digraph=digraph G { a -> b; }[diagram]
+      EOS
+
+      output = render_embedded_string input
+      assert_xpath %(/*[@class="imageblock"]//img[@src="http://example.org/svg?digraph=digraph%20G%20{%20a%20-#{decode_char 62}%20b;%20}"]), output, 1
+    end
+
     test 'can resolve image relative to imagesdir' do
       input = <<-EOS
 :imagesdir: images


### PR DESCRIPTION
- encode spaces in a qualified URI in addition to a relative path
- ensures image_uri and similar methods always returns path with URI encoded spaces