### PR TITLE
permit leading, trailing, and repeat operators in target of preprocessor conditional

### DIFF
--- a/lib/asciidoctor.rb
+++ b/lib/asciidoctor.rb
@@ -467,7 +467,7 @@ module Asciidoctor
     #   endif::basebackend-html[]
     #   endif::[]
     #
-    ConditionalDirectiveRx = /^(\\)?(ifdef|ifndef|ifeval|endif)::(\S*?(?:([,+])\S+?)?)\[(.+)?\]$/
+    ConditionalDirectiveRx = /^(\\)?(ifdef|ifndef|ifeval|endif)::(\S*?(?:([,+])\S*?)?)\[(.+)?\]$/
 
     # Matches a restricted (read as safe) eval expression.
     #

--- a/test/reader_test.rb
+++ b/test/reader_test.rb
@@ -1526,6 +1526,24 @@ endif::holygrail+swallow[]
         assert_equal '', (lines * ::Asciidoctor::EOL)
       end
 
+      test 'ifdef should permit leading, trailing, and repeat operators' do
+        {
+          'asciidoctor,' => 'content',
+          ',asciidoctor' => 'content',
+          'asciidoctor+' => '',
+          '+asciidoctor' => '',
+          'asciidoctor,,asciidoctor-version' => 'content',
+          'asciidoctor++asciidoctor-version' => ''
+        }.each do |condition, expected|
+          input = <<-EOS
+ifdef::#{condition}[]
+content
+endif::[]
+          EOS
+          assert_equal expected, (document_from_string input, :parse => false).reader.read
+        end
+      end
+
       test 'ifndef with undefined attribute includes block' do
         input = <<-EOS
 ifndef::holygrail[]


### PR DESCRIPTION

- permit target to begin or end with operator
- don't drop empty conditions as these should be considered
- only call target.empty? once
- optimize conditional stack size check
- add tests