### PR TITLE
Fix for #1121 - Introduce four tilde syntax for open blocks and deprecate '--'

### DIFF
--- a/lib/asciidoctor.rb
+++ b/lib/asciidoctor.rb
@@ -287,7 +287,9 @@ module Asciidoctor
   VERBATIM_STYLES = ['literal', 'listing', 'source', 'verse'].to_set
 
   DELIMITED_BLOCKS = {
+    # DEPRECATED: The two hyphen syntax for open blocks is deprecated - tildes should be used instead as these allow nesting of open blocks.
     '--'   => [:open, ['comment', 'example', 'literal', 'listing', 'pass', 'quote', 'sidebar', 'source', 'verse', 'admonition', 'abstract', 'partintro'].to_set],
+    '~~~~' => [:open, ['comment', 'example', 'literal', 'listing', 'pass', 'quote', 'sidebar', 'source', 'verse', 'admonition', 'abstract', 'partintro'].to_set],
     '----' => [:listing, ['literal', 'source'].to_set],
     '....' => [:literal, ['listing', 'source'].to_set],
     '====' => [:example, ['admonition'].to_set],

--- a/lib/asciidoctor/parser.rb
+++ b/lib/asciidoctor/parser.rb
@@ -953,10 +953,11 @@ class Parser
   def self.is_delimited_block? line, return_match_data = false
     # highly optimized for best performance
     return unless (line_len = line.length) > 1 && DELIMITED_BLOCK_LEADERS.include?(line.slice 0, 2)
-    # catches open block
+    # catches (deprecated) "two hyphen" syntax for open blocks
     if line_len == 2
       tip = line
       tl = 2
+      warn %(asciidoctor: WARNING: 2 hyphen open block syntax is deprecated, use tildes instead - e.g. "~~~~" )
     else
       # catches all other delimited blocks, including fenced code
       if line_len <= 4


### PR DESCRIPTION
Doing this as a monkey patch right now, so getting it into the core of asciidoctor would be good. Don't know what your take on deprecation is though - should there be a warning? I've added one for now, but can take it out.

Fixes #1121