### PR TITLE
substitute replacements in alt text of block image

### DIFF
--- a/lib/asciidoctor/abstract_block.rb
+++ b/lib/asciidoctor/abstract_block.rb
@@ -150,7 +150,7 @@ class AbstractBlock < AbstractNode
   #
   # Returns the [String] value of the alt attribute with XML special character substitutions applied.
   def alt_text
-    sub_specialchars attr('alt')
+    sub_replacements(sub_specialchars(attr 'alt'))
   end
 
   # Public: Determine whether this Block contains block content


### PR DESCRIPTION
- substitute replacements in alt text of block image
- improve tests for substitutions in alt text of block image