### PR TITLE
keep track of when alt text is auto-generated

### DIFF
--- a/lib/asciidoctor.rb
+++ b/lib/asciidoctor.rb
@@ -1070,6 +1070,10 @@ module Asciidoctor
     #
     EscapedSpaceRx = /\\([ \t\n])/
 
+    # Detects if text is a candidate for replacements.
+    #
+    ReplaceableTextRx = /(?:[;\(']|--|\.\.\.)/
+
     # Matches a whitespace delimiter, a sequence of spaces, tabs, and/or newlines.
 	# Matches the parsing rules of %w strings in Ruby.
     #

--- a/lib/asciidoctor/abstract_block.rb
+++ b/lib/asciidoctor/abstract_block.rb
@@ -148,9 +148,17 @@ class AbstractBlock < AbstractNode
 
   # Public: Returns the converted alt text for this block image.
   #
-  # Returns the [String] value of the alt attribute with XML special character substitutions applied.
+  # Returns the [String] value of the alt attribute with XML special character
+  # and replacement substitutions applied.
   def alt
-    sub_replacements(sub_specialchars(attr 'alt'))
+    if (text = @attributes['alt'])
+      if text == @attributes['default-alt']
+        sub_specialchars text
+      else
+        text = sub_specialchars text
+        (ReplaceableTextRx.match? text) ? (sub_replacements text) : text
+      end
+    end
   end
 
   # Public: Determine whether this Block contains block content

--- a/lib/asciidoctor/parser.rb
+++ b/lib/asciidoctor/parser.rb
@@ -551,7 +551,7 @@ class Parser
                 if blk_ctx == :image
                   block.document.register :images, target
                   # NOTE style is the value of the first positional attribute in the block attribute line
-                  attributes['alt'] ||= style || ((Helpers.basename target, true).tr '_-', ' ')
+                  attributes['alt'] ||= style || (attributes['default-alt'] = Helpers.basename(target, true).tr('_-', ' '))
                   unless (scaledwidth = attributes.delete 'scaledwidth').nil_or_empty?
                     # NOTE assume % units if not specified
                     attributes['scaledwidth'] = (TrailingDigitsRx.match? scaledwidth) ? %(#{scaledwidth}%) : scaledwidth

--- a/lib/asciidoctor/substitutors.rb
+++ b/lib/asciidoctor/substitutors.rb
@@ -661,7 +661,7 @@ module Substitutors
         target = m[1]
         @document.register(:images, target) unless type == 'icon'
         attrs = parse_attributes(m[2], posattrs, :unescape_input => true)
-        attrs['alt'] ||= Helpers.basename(target, true).tr('_-', ' ')
+        attrs['alt'] ||= (attrs['default-alt'] = Helpers.basename(target, true).tr('_-', ' '))
         Inline.new(self, :image, nil, :type => type, :target => target, :attributes => attrs).convert
       }
     end

--- a/test/blocks_test.rb
+++ b/test/blocks_test.rb
@@ -1666,13 +1666,16 @@ image::images/tiger.png[Tiger]
       assert_includes result, %(<phrase>#{expected}</phrase>)
     end
 
-    test "can render block image with auto-generated alt text" do
+    test 'should auto-generate alt text for block image if alt text is not specified' do
       input = <<-EOS
-image::images/tiger.png[]
+image::images/lions-and-tigers.png[]
       EOS
 
-      output = render_embedded_string input
-      assert_xpath '/*[@class="imageblock"]//img[@src="images/tiger.png"][@alt="tiger"]', output, 1
+      image = block_from_string input
+      assert_equal 'lions and tigers', (image.attr 'alt')
+      assert_equal 'lions and tigers', (image.attr 'default-alt')
+      output = image.convert
+      assert_xpath '/*[@class="imageblock"]//img[@src="images/lions-and-tigers.png"][@alt="lions and tigers"]', output, 1
     end
 
     test "can render block image with alt text and height and width" do


### PR DESCRIPTION
- store generated alt text in dedicated attribute
- don't apply replacements to auto-generated alt text
- add test to assert behavior