### PR TITLE
don't recognize inline image macro if target has trailing space

### DIFF
--- a/lib/asciidoctor.rb
+++ b/lib/asciidoctor.rb
@@ -877,7 +877,7 @@ module Asciidoctor
     #   icon:github[large]
     #
     # NOTE be as non-greedy as possible by not allowing endline or left square bracket in target
-    ImageInlineMacroRx = /\\?i(?:mage|con):([^:\s\[][^\n\[]*)\[(|#{CC_ALL}*?[^\\])\]/m
+    ImageInlineMacroRx = /\\?i(?:mage|con):([^:\s\[](?:[^\n\[]*[^\s\[])?)\[(|#{CC_ALL}*?[^\\])\]/m
 
     # Matches an indexterm inline macro, which may span multiple lines.
     #
@@ -946,7 +946,7 @@ module Asciidoctor
     #   menu:View[Page Style > No Style]
     #   menu:View[Page Style, No Style]
     #
-    MenuInlineMacroRx = /\\?menu:(#{CG_WORD}|[#{CC_WORD}&][^\[\n]*[^\[\s])\[ *(#{CC_ALL}*?[^\\])?\]/m
+    MenuInlineMacroRx = /\\?menu:(#{CG_WORD}|[#{CC_WORD}&][^\n\[]*[^\s\[])\[ *(#{CC_ALL}*?[^\\])?\]/m
 
     # Matches an implicit menu inline macro.
     #

--- a/test/substitutions_test.rb
+++ b/test/substitutions_test.rb
@@ -788,13 +788,22 @@ context 'Substitutions' do
     end
 
     test 'should not match an inline image macro if target contains an endline character' do
-      para = block_from_string(%(Fear not. There are no image::big\ncats.png[] around here.))
+      para = block_from_string(%(Fear not. There are no image:big\ncats.png[] around here.))
       result = para.sub_macros(para.source)
       assert !result.include?('<img ')
-      assert_includes result, %(image::big\ncats.png[])
+      assert_includes result, %(image:big\ncats.png[])
     end
 
-    test 'a block image macro should not be detected within paragraph text' do
+    test 'should not match an inline image macro if target begins or ends with space character' do
+      ['image: big cats.png[]', 'image:big cats.png []'].each do |input|
+        para = block_from_string %(Fear not. There are no #{input} around here.)
+        result = para.sub_macros(para.source)
+        assert !result.include?('<img ')
+        assert_includes result, input
+      end
+    end
+
+    test 'should not detect a block image macro found inline' do
       para = block_from_string(%(Not an inline image macro image::tiger.png[].))
       result = para.sub_macros(para.source)
       assert !result.include?('<img ')


### PR DESCRIPTION
- don't recognize inline image macro if target has trailing space
- fix test for inline image macro with newline in target
- swap order of space and open square bracket in regexp