### PR TITLE
refactor sub_attributes

### DIFF
--- a/lib/asciidoctor/reader.rb
+++ b/lib/asciidoctor/reader.rb
@@ -845,7 +845,7 @@ class PreprocessorReader < Reader
     if ((expanded_target = target).include? ATTR_REF_HEAD) &&
         (expanded_target = @document.sub_attributes target, :attribute_missing => 'drop-line').empty?
       shift
-      if @document.attributes.fetch('attribute-missing', Compliance.attribute_missing) == 'skip'
+      if (@document.attributes['attribute-missing'] || Compliance.attribute_missing) == 'skip'
         unshift %(Unresolved directive in #{@path} - include::#{target}[#{attrlist}])
       end
       true

--- a/test/attributes_test.rb
+++ b/test/attributes_test.rb
@@ -675,6 +675,28 @@ Line 2: {set:a!}This line should appear in the output.
       refute_match(/\{set:a!\}/, output)
     end
 
+    test 'should drop line that only contains attribute assignment' do
+      input = <<-EOS
+Line 1
+{set:a}
+Line 2
+      EOS
+
+      output = render_embedded_string input
+      assert_xpath %(//p[text()="Line 1\nLine 2"]), output, 1
+    end
+
+    test 'should drop line that only contains unresolved attribute when attribute-missing is drop' do
+      input = <<-EOS
+Line 1
+{unresolved}
+Line 2
+      EOS
+
+      output = render_embedded_string input, :attributes => { 'attribute-missing' => 'drop' }
+      assert_xpath %(//p[text()="Line 1\nLine 2"]), output, 1
+    end
+
     test "substitutes inside unordered list items" do
       html = render_string(":foo: bar\n* snort at the {foo}\n* yawn")
       result = Nokogiri::HTML(html)

--- a/test/document_test.rb
+++ b/test/document_test.rb
@@ -1656,7 +1656,7 @@ asciidoctor - converts AsciiDoc source files to HTML, DocBook and other formats
       input = <<-EOS
 = {app}(1)
 :doctype: manpage
-:app: asciidoctor
+:app: Asciidoctor
 
 == NAME
 


### PR DESCRIPTION
- use single gsub pass
- remove dropped lines, if any, in post-processing step
- cache compliance values correctly
- optimize for single-line case
- add missing guards to check for attribute reference head
