### PR TITLE
use textlabel instead of caption to store textual label of admonition

### DIFF
--- a/lib/asciidoctor/converter/html5.rb
+++ b/lib/asciidoctor/converter/html5.rb
@@ -364,20 +364,20 @@ MathJax.Hub.Config({
       id_attr = node.id ? %( id="#{node.id}") : nil
       name = node.attr 'name'
       title_element = node.title? ? %(<div class="title">#{node.title}</div>\n) : nil
-      caption = if node.document.attr? 'icons'
+      if node.document.attr? 'icons'
         if (node.document.attr? 'icons', 'font') && !(node.attr? 'icon')
-          %(<i class="fa icon-#{name}" title="#{node.caption}"></i>)
+          label = %(<i class="fa icon-#{name}" title="#{node.attr 'textlabel'}"></i>)
         else
-          %(<img src="#{node.icon_uri name}" alt="#{node.caption}"#{@void_element_slash}>)
+          label = %(<img src="#{node.icon_uri name}" alt="#{node.attr 'textlabel'}"#{@void_element_slash}>)
         end
       else
-        %(<div class="title">#{node.caption}</div>)
+        label = %(<div class="title">#{node.attr 'textlabel'}</div>)
       end
       %(<div#{id_attr} class="admonitionblock #{name}#{(role = node.role) && " #{role}"}">
 <table>
 <tr>
 <td class="icon">
-#{caption}
+#{label}
 </td>
 <td class="content">
 #{title_element}#{node.content}
@@ -392,7 +392,7 @@ MathJax.Hub.Config({
       id_attribute = node.id ? %( id="#{node.id}") : nil
       classes = ['audioblock', node.role].compact
       class_attribute = %( class="#{classes * ' '}")
-      title_element = node.title? ? %(<div class="title">#{node.captioned_title}</div>\n) : nil
+      title_element = node.title? ? %(<div class="title">#{node.title}</div>\n) : nil
       start_t = node.attr 'start', nil, false
       end_t = node.attr 'end', nil, false
       time_anchor = (start_t || end_t) ? %(#t=#{start_t}#{end_t ? ',' : nil}#{end_t}) : nil
@@ -946,7 +946,7 @@ Your browser does not support the audio tag.
       id_attribute = node.id ? %( id="#{node.id}") : nil
       classes = ['videoblock', node.role].compact
       class_attribute = %( class="#{classes * ' '}")
-      title_element = node.title? ? %(\n<div class="title">#{node.captioned_title}</div>) : nil
+      title_element = node.title? ? %(\n<div class="title">#{node.title}</div>) : nil
       width_attribute = (node.attr? 'width') ? %( width="#{node.attr 'width'}") : nil
       height_attribute = (node.attr? 'height') ? %( height="#{node.attr 'height'}") : nil
       case node.attr 'poster'

--- a/lib/asciidoctor/converter/manpage.rb
+++ b/lib/asciidoctor/converter/manpage.rb
@@ -185,7 +185,7 @@ Author(s).
 .nr an-break-flag 1
 .br
 .ps +1
-.B #{node.caption}#{node.title? ? "\\fP #{manify node.title}" : nil}
+.B #{node.attr 'textlabel'}#{node.title? ? "\\fP: #{manify node.title}" : nil}
 .ps -1
 .br
 #{resolve_content node}
@@ -576,7 +576,7 @@ allbox tab(:);'
       end_param = (node.attr? 'end', nil, false) ? %(&end=#{node.attr 'end'}) : nil
       result = []
       result << %(.sp
-.B #{manify node.captioned_title}
+.B #{manify node.title}
 .br) if node.title?
       result << %(<#{node.media_uri(node.attr 'target')}#{start_param}#{end_param}> (video))
       result * LF

--- a/lib/asciidoctor/section.rb
+++ b/lib/asciidoctor/section.rb
@@ -33,6 +33,9 @@ class Section < AbstractBlock
   # Public: Get the state of the numbered attribute at this section (need to preserve for creating TOC)
   attr_accessor :numbered
 
+  # Public: Get the caption for this section (only relevant for appendices)
+  attr_reader :caption
+
   # Public: Initialize an Asciidoctor::Section object.
   #
   # parent - The parent Asciidoc Object.

--- a/lib/asciidoctor/table.rb
+++ b/lib/asciidoctor/table.rb
@@ -38,6 +38,9 @@ class Table < AbstractBlock
   # Public: Boolean specifies whether this table has a header row
   attr_accessor :has_header_option
 
+  # Public: Get the caption for this table
+  attr_reader :caption
+
   def initialize parent, attributes
     super parent, :table
     @rows = Rows.new

--- a/test/blocks_test.rb
+++ b/test/blocks_test.rb
@@ -608,20 +608,6 @@ You just write.
       assert !doc.attributes.has_key?('example-number')
     end
 
-    test 'explicit caption is set on block even if block has no title' do
-      input = <<-EOS
-[caption="Look!"]
-====
-Just write.
-====
-      EOS
-
-      doc = document_from_string input
-      assert_equal 'Look!', doc.blocks.first.caption
-      output = doc.render
-      refute_match(/Look/, output)
-    end
-
     test 'automatic caption can be turned off and on and modified' do
       input = <<-EOS
 .first example


### PR DESCRIPTION
- use textlabel to store the textual label for the admonition type
- don't transfer caption attribute to caption property if block does not have a title
- route calls to caption method on admonition block to textlabel attribute
- formatting