### PR TITLE
resolves #1478 retain block content in items of callout list

### DIFF
--- a/lib/asciidoctor/converter/html5.rb
+++ b/lib/asciidoctor/converter/html5.rb
@@ -416,27 +416,25 @@ Your browser does not support the audio tag.
 
       if node.document.attr? 'icons'
         result << '<table>'
-
-        font_icons = node.document.attr? 'icons', 'font'
-        node.items.each_with_index do |item, i|
-          num = i + 1
-          num_element = if font_icons
-            %(<i class="conum" data-value="#{num}"></i><b>#{num}</b>)
+        font_icons, num = (node.document.attr? 'icons', 'font'), 0
+        node.items.each do |item|
+          num += 1
+          if font_icons
+            num_label = %(<i class="conum" data-value="#{num}"></i><b>#{num}</b>)
           else
-            %(<img src="#{node.icon_uri "callouts/#{num}"}" alt="#{num}"#{@void_element_slash}>)
+            num_label = %(<img src="#{node.icon_uri "callouts/#{num}"}" alt="#{num}"#{@void_element_slash}>)
           end
           result << %(<tr>
-<td>#{num_element}</td>
-<td>#{item.text}</td>
+<td>#{num_label}</td>
+<td>#{item.text}#{item.blocks? ? LF + item.content : ''}</td>
 </tr>)
         end
-
         result << '</table>'
       else
         result << '<ol>'
         node.items.each do |item|
           result << %(<li>
-<p>#{item.text}</p>
+<p>#{item.text}</p>#{item.blocks? ? LF + item.content : ''}
 </li>)
         end
         result << '</ol>'

--- a/lib/asciidoctor/converter/manpage.rb
+++ b/lib/asciidoctor/converter/manpage.rb
@@ -205,10 +205,12 @@ Author(s).
 tab(:);
 r lw(\n(.lu*75u/100u).'
 
-      node.items.each_with_index do |item, index|
-        result << %(\\fB(#{index + 1})\\fP\\h'-2n':T{
-#{manify item.text}
-T})
+      num = 0
+      node.items.each do |item|
+        result << %(\\fB(#{num += 1})\\fP\\h'-2n':T{)
+        result << (manify item.text)
+        result << item.content if item.blocks?
+        result << 'T}'
       end
       result << '.TE'
       result * LF

--- a/test/lists_test.rb
+++ b/test/lists_test.rb
@@ -4062,7 +4062,32 @@ puts doc.render # <2>
     assert_xpath '((//calloutlist)[2]/callout)[2][@arearefs = "CO2-2"]', output, 1
   end
 
-  test 'wip callout list with block content' do
+  test 'callout list retains block content' do
+    input = <<-EOS
+[source, ruby]
+----
+require 'asciidoctor' # <1>
+doc = Asciidoctor::Document.new('Hello, World!') # <2>
+puts doc.render # <3>
+----
+<1> Imports the library
+as a RubyGem
+<2> Creates a new document
+* Scans the lines for known blocks
+* Converts the lines into blocks
+<3> Renders the document
++
+You can write this to file rather than printing to stdout.
+    EOS
+    output = render_embedded_string input
+    assert_xpath '//ol/li', output, 3
+    assert_xpath %((//ol/li)[1]/p[text()="Imports the library\nas a RubyGem"]), output, 1
+    assert_xpath %((//ol/li)[2]//ul), output, 1
+    assert_xpath %((//ol/li)[2]//ul/li), output, 2
+    assert_xpath %((//ol/li)[3]//p), output, 2
+  end
+
+  test 'callout list retains block content when converted to DocBook' do
     input = <<-EOS
 [source, ruby]
 ----


### PR DESCRIPTION
- retain block content in items of callout list when converting to HTML and man page
- update tests
- code formatting