### PR TITLE
change default text for inter-document xref

### DIFF
--- a/lib/asciidoctor/converter/html5.rb
+++ b/lib/asciidoctor/converter/html5.rb
@@ -1025,7 +1025,7 @@ Your browser does not support the video tag.
     def inline_anchor node
       case node.type
       when :xref
-        unless (text = node.text)
+        unless (text = node.text) || (text = node.attributes['path'])
           if AbstractNode === (ref = node.document.catalog[:refs][refid = node.attributes['refid']])
             text = ref.xreftext((@xrefstyle ||= node.document.attributes['xrefstyle'])) || %([#{refid}])
           else

--- a/test/links_test.rb
+++ b/test/links_test.rb
@@ -380,7 +380,7 @@ anchor:foo[b[a\]r]text'
 
   test 'xref using angled bracket syntax with path sans extension' do
     doc = document_from_string '<<tigers#>>', :header_footer => false
-    assert_xpath '//a[@href="tigers.html"][text() = "[tigers]"]', doc.render, 1
+    assert_xpath '//a[@href="tigers.html"][text() = "tigers.html"]', doc.render, 1
   end
 
   test 'inter-document xref should not truncate after period if path has no extension' do
@@ -412,12 +412,12 @@ anchor:foo[b[a\]r]text'
 
   test 'xref using angled bracket syntax with path and extension' do
     doc = document_from_string '<<tigers.adoc#>>', :header_footer => false
-    assert_xpath '//a[@href="tigers.html"][text() = "[tigers]"]', doc.render, 1
+    assert_xpath '//a[@href="tigers.html"][text() = "tigers.html"]', doc.render, 1
   end
 
   test 'xref using angled bracket syntax with path and fragment' do
     doc = document_from_string '<<tigers#about>>', :header_footer => false
-    assert_xpath '//a[@href="tigers.html#about"][text() = "[tigers#about]"]', doc.render, 1
+    assert_xpath '//a[@href="tigers.html#about"][text() = "tigers.html"]', doc.render, 1
   end
 
   test 'xref using angled bracket syntax with path, fragment and text' do


### PR DESCRIPTION
- use path without fragment as default text instead of [refid]