### PR TITLE
continue to read blocks after skipped content within delimited block

### DIFF
--- a/lib/asciidoctor/parser.rb
+++ b/lib/asciidoctor/parser.rb
@@ -1100,8 +1100,10 @@ class Parser
   #
   # Returns nothing.
   def self.parse_blocks(reader, parent)
-    while (block = next_block reader, parent)
-      parent << block
+    while reader.has_more_lines?
+      if (block = next_block reader, parent)
+        parent << block
+      end
     end
   end
 

--- a/test/blocks_test.rb
+++ b/test/blocks_test.rb
@@ -237,6 +237,24 @@ not this text
       assert_xpath '/*[@class="exampleblock"]', result, 1
       assert_xpath '/*[@class="exampleblock"]//*[normalize-space(text())="not this text"]', result, 1
     end
+
+    # NOTE this test verifies the nil return value of Parser#next_block
+    test 'should not drop content that follows skipped content inside a delimited block' do
+      input = <<-EOS
+====
+paragraph
+
+[comment#idname]
+skip
+
+paragraph
+====
+      EOS
+      result = render_embedded_string input
+      assert_xpath '/*[@class="exampleblock"]', result, 1
+      assert_xpath '/*[@class="exampleblock"]//*[@class="paragraph"]', result, 2
+      assert_xpath '//*[@class="paragraph"][@id="idname"]', result, 0
+    end
   end
 
   context 'Quote and Verse Blocks' do


### PR DESCRIPTION
- within a delimited block, continue to read blocks after content is skipped
- add missing test for scenario