### PR TITLE
drop skipped content inside a delimited block

### DIFF
--- a/lib/asciidoctor/parser.rb
+++ b/lib/asciidoctor/parser.rb
@@ -444,13 +444,12 @@ class Parser
     if options.fetch :parse_metadata, true
       # read lines until there are no more metadata lines to read
       while parse_block_metadata_line reader, document, attributes, options
+        # discard the line just processed
         advanced = reader.advance
+        reader.skip_blank_lines
       end
-      if advanced && reader.empty?
-        # NOTE there are no cases when these attributes are used, but clear them anyway
-        attributes.clear
-        return
-      end
+      # QUESTION should we clear the attributes? no known cases when it's necessary
+      return if advanced && reader.empty?
     end
 
     if (extensions = document.extensions)

--- a/test/blocks_test.rb
+++ b/test/blocks_test.rb
@@ -85,6 +85,23 @@ second paragraph
       assert_xpath '//p', output, 2
     end
 
+    test 'comment block between paragraphs offset by blank lines inside delimited block' do
+      input = <<-EOS
+====
+first paragraph
+
+////
+block comment
+////
+
+second paragraph
+====
+      EOS
+      output = render_embedded_string input
+      refute_match(/block comment/, output)
+      assert_xpath '//p', output, 2
+    end
+
     test 'adjacent comment block between paragraphs' do
       input = <<-EOS
 first paragraph


### PR DESCRIPTION
- drop skipped content inside of creating empty paragraphs
- add missing test for scenario