### PR TITLE
don't track eof state in reader

### DIFF
--- a/lib/asciidoctor/parser.rb
+++ b/lib/asciidoctor/parser.rb
@@ -446,7 +446,7 @@ class Parser
       while parse_block_metadata_line reader, document, attributes, options
         advanced = reader.advance
       end
-      if advanced && !reader.has_more_lines?
+      if advanced && reader.empty?
         # NOTE there are no cases when these attributes are used, but clear them anyway
         attributes.clear
         return


### PR DESCRIPTION
- don't track eof state; recalculate on demand
- split impl of has_more_lines? and eof? between Reader and PreprocessorReader
- swap eof? and empty? alias (use empty? as primary method)