### PR TITLE
resolves #2324 coerce group name to symbol when registering extension

### DIFF
--- a/lib/asciidoctor/extensions.rb
+++ b/lib/asciidoctor/extensions.rb
@@ -1425,7 +1425,7 @@ module Extensions
       unless args.empty?
         raise ::ArgumentError, %(Wrong number of arguments (#{argc} for 1..2))
       end
-      groups[name] = resolved_group
+      groups[name.to_sym] = resolved_group
     end
 
     # Public: Unregister all statically-registered extension groups.

--- a/test/extensions_test.rb
+++ b/test/extensions_test.rb
@@ -228,11 +228,22 @@ context 'Extensions' do
 
     test 'should register extension block' do
       begin
-        Asciidoctor::Extensions.register(:sample) do
+        Asciidoctor::Extensions.register :sample do
         end
         refute_nil Asciidoctor::Extensions.groups
         assert_equal 1, Asciidoctor::Extensions.groups.size
         assert Asciidoctor::Extensions.groups[:sample].is_a? Proc
+      ensure
+        Asciidoctor::Extensions.unregister_all
+      end
+    end
+
+    test 'should coerce group name to symbol when registering' do
+      begin
+        Asciidoctor::Extensions.register 'sample', SampleExtensionGroup
+        refute_nil Asciidoctor::Extensions.groups
+        assert_equal 1, Asciidoctor::Extensions.groups.size
+        assert_equal SampleExtensionGroup, Asciidoctor::Extensions.groups[:sample]
       ensure
         Asciidoctor::Extensions.unregister_all
       end


### PR DESCRIPTION
- group names of extensions are stored internally as symbols
- group name can be specified as symbol or string when registering or unregistering extension