### PR TITLE
resolves #2323 don't warn if src stylesheet can't be read and dest exists

### DIFF
--- a/lib/asciidoctor.rb
+++ b/lib/asciidoctor.rb
@@ -1536,9 +1536,11 @@ module Asciidoctor
               # NOTE in this case, copycss is a source location (but cannot be a URI)
               stylesheet_src = doc.normalize_system_path stylesheet_src
             end
-            stylesheet_dst = doc.normalize_system_path stylesheet, stylesoutdir, (doc.safe >= SafeMode::SAFE ? outdir : nil)
-            if stylesheet_src != stylesheet_dst && (stylesheet_content = doc.read_asset stylesheet_src, :warn_on_failure => true, :label => 'stylesheet')
-              ::IO.write stylesheet_dst, stylesheet_content
+            stylesheet_dest = doc.normalize_system_path stylesheet, stylesoutdir, (doc.safe >= SafeMode::SAFE ? outdir : nil)
+            # NOTE don't warn if src can't be read and dest already exists (see #2323)
+            if stylesheet_src != stylesheet_dest && (stylesheet_data = doc.read_asset stylesheet_src,
+                :warn_on_failure => !(::File.file? stylesheet_dest), :label => 'stylesheet')
+              ::IO.write stylesheet_dest, stylesheet_data
             end
           end
 


### PR DESCRIPTION
- change warning to preserve legacy scenario