### PR TITLE
preprocess second line of setext discrete heading

### DIFF
--- a/lib/asciidoctor/parser.rb
+++ b/lib/asciidoctor/parser.rb
@@ -649,7 +649,7 @@ class Parser
         break
 
       elsif (style == 'float' || style == 'discrete') && (Compliance.underline_style_section_titles ?
-          (is_section_title? this_line, (reader.peek_line true)) : !indented && (is_section_title? this_line))
+          (is_section_title? this_line, reader.peek_line) : !indented && (is_single_line_section_title? this_line))
         reader.unshift_line this_line
         float_id, float_reftext, float_title, float_level, _ = parse_section_title(reader, document)
         attributes['reftext'] = float_reftext if float_reftext
@@ -1600,7 +1600,7 @@ class Parser
       return
     elsif reader.has_more_lines?
       Compliance.underline_style_section_titles ?
-          is_section_title?(*reader.peek_lines(2, style ? style == 'comment' : false)) :
+          is_section_title?(*reader.peek_lines(2, style && style == 'comment')) :
           is_single_line_section_title?(reader.peek_line)
     end
   end

--- a/test/sections_test.rb
+++ b/test/sections_test.rb
@@ -671,6 +671,18 @@ not in section
       assert doc.catalog[:ids].has_key?('_independent_heading')
     end
 
+    test 'should preprocess second line of setext floating title' do
+      input = <<-EOS
+[discrete]
+Heading Title
+ifdef::asciidoctor[]
+-------------
+endif::[]
+      EOS
+      result = render_embedded_string input
+      assert_xpath '//h2', result, 1
+    end
+
     test 'can assign explicit id to floating title' do
       input = <<-EOS
 [[unchained]]

--- a/test/sections_test.rb
+++ b/test/sections_test.rb
@@ -570,8 +570,8 @@ blah blah
     end
   end
 
-  context 'Floating Title' do
-    test 'should create floating title if style is float' do
+  context 'Discrete Heading' do
+    test 'should create discrete heading instead of section if style is float' do
       input = <<-EOS
 [float]
 = Independent Heading!
@@ -588,7 +588,7 @@ not in section
       assert_xpath '/h1/following-sibling::*[@class="paragraph"]/p[text()="not in section"]', output, 1
     end
 
-    test 'should create floating title if style is discrete' do
+    test 'should create discrete heading instead of section if style is discrete' do
       input = <<-EOS
 [discrete]
 === Independent Heading!
@@ -606,7 +606,7 @@ not in section
       assert_xpath '/h3/following-sibling::*[@class="paragraph"]/p[text()="not in section"]', output, 1
     end
 
-    test 'should generate id for floating title from converted title' do
+    test 'should generate id for discrete heading from converted title' do
       input = <<-EOS
 [discrete]
 === {sp}Heading{sp}
@@ -620,7 +620,7 @@ not in section
       assert_xpath '/h3[@class="discrete"][@id="_heading"][text()=" Heading "]', output, 1
     end
 
-    test 'should create floating title if style is float with shorthand role and id' do
+    test 'should create discrete heading if style is float with shorthand role and id' do
       input = <<-EOS
 [float.independent#first]
 = Independent Heading!
@@ -637,7 +637,7 @@ not in section
       assert_xpath '/h1/following-sibling::*[@class="paragraph"]/p[text()="not in section"]', output, 1
     end
 
-    test 'should create floating title if style is discrete with shorthand role and id' do
+    test 'should create discrete heading if style is discrete with shorthand role and id' do
       input = <<-EOS
 [discrete.independent#first]
 = Independent Heading!
@@ -654,7 +654,7 @@ not in section
       assert_xpath '/h1/following-sibling::*[@class="paragraph"]/p[text()="not in section"]', output, 1
     end
 
-    test 'floating title should be a block with context floating_title' do
+    test 'discrete heading should be a block with context floating_title' do
       input = <<-EOS
 [float]
 === Independent Heading!
@@ -663,15 +663,15 @@ not in section
       EOS
 
       doc = document_from_string input
-      floatingtitle = doc.blocks.first
-      assert floatingtitle.is_a?(Asciidoctor::Block)
-      assert floatingtitle.context != :section
-      assert_equal :floating_title, floatingtitle.context
-      assert_equal '_independent_heading', floatingtitle.id
+      heading = doc.blocks.first
+      assert heading.is_a?(Asciidoctor::Block)
+      assert heading.context != :section
+      assert_equal :floating_title, heading.context
+      assert_equal '_independent_heading', heading.id
       assert doc.catalog[:ids].has_key?('_independent_heading')
     end
 
-    test 'should preprocess second line of setext floating title' do
+    test 'should preprocess second line of setext discrete heading' do
       input = <<-EOS
 [discrete]
 Heading Title
@@ -683,7 +683,7 @@ endif::[]
       assert_xpath '//h2', result, 1
     end
 
-    test 'can assign explicit id to floating title' do
+    test 'can assign explicit id to discrete heading' do
       input = <<-EOS
 [[unchained]]
 [float]
@@ -693,12 +693,12 @@ not in section
       EOS
 
       doc = document_from_string input
-      floating_title = doc.blocks.first
-      assert_equal 'unchained', floating_title.id
+      heading = doc.blocks.first
+      assert_equal 'unchained', heading.id
       assert doc.catalog[:ids].has_key?('unchained')
     end
 
-    test 'should not include floating title in toc' do
+    test 'should not include discrete heading in toc' do
       input = <<-EOS
 :toc:
 
@@ -716,7 +716,7 @@ not in section
       assert_xpath %(//*[@id="toc"]//a[text()="Miss Independent"]), output, 0
     end
 
-    test 'should not set id on floating title if sectids attribute is unset' do
+    test 'should not set id on discrete heading if sectids attribute is unset' do
       input = <<-EOS
 [float]
 === Independent Heading!
@@ -730,7 +730,7 @@ not in section
       assert_xpath '/h3[@class="float"]', output, 1
     end
 
-    test 'should use explicit id for floating title if specified' do
+    test 'should use explicit id for discrete heading if specified' do
       input = <<-EOS
 [[free]]
 [float]
@@ -745,7 +745,7 @@ not in section
       assert_xpath '/h2[@class="float"]', output, 1
     end
 
-    test 'should add role to class attribute on floating title' do
+    test 'should add role to class attribute on discrete heading' do
       input = <<-EOS
 [float, role="isolated"]
 == Independent Heading!
@@ -872,7 +872,7 @@ Master section text.
       assert_xpath '//*[@class="sect1"]/h2[text() = "Section in Master"]', output, 1
     end
 
-    test 'level offset should be added to floating title' do
+    test 'level offset should be added to discrete heading' do
       input = <<-EOS
 = Master Document
 Doc Writer
@@ -880,11 +880,11 @@ Doc Writer
 :leveloffset: 1
 
 [float]
-= Floating Title
+= Discrete Heading
       EOS
 
       output = render_string input
-      assert_xpath '//h2[@class="float"][text() = "Floating Title"]', output, 1
+      assert_xpath '//h2[@class="float"][text() = "Discrete Heading"]', output, 1
     end
 
     test 'should be able to reset level offset' do


### PR DESCRIPTION
 - preprocess second line of setext discrete heading
- use is_single_line_section_title? if setext section titles are disabled
- change "floating title" to "discrete heading" in test suite

