### PR TITLE
resolves #2107 calculate relative path correctly

### DIFF
--- a/lib/asciidoctor/abstract_node.rb
+++ b/lib/asciidoctor/abstract_node.rb
@@ -561,11 +561,6 @@ class AbstractNode
         :target_name => asset_name, :recover => autocorrect)
   end
 
-  # Public: Calculate the relative path to this absolute filename from the Document#base_dir
-  #def relative_path(filename)
-  #  (@path_resolver ||= PathResolver.new).relative_path filename, @document.base_dir
-  #end
-
   # Public: Check whether the specified String is a URI by
   # matching it against the Asciidoctor::UriSniffRx regex.
   #

--- a/lib/asciidoctor/path_resolver.rb
+++ b/lib/asciidoctor/path_resolver.rb
@@ -458,16 +458,16 @@ class PathResolver
 
   # Public: Calculate the relative path to this absolute filename from the specified base directory
   #
-  # If either the filename or the base_directory are not absolute paths, no work is done.
+  # If either the filename or the base_directory are not absolute paths, or the
+  # filename is not contained within the base directory, no work is done.
   #
-  # filename       - An absolute file name as a String
-  # base_directory - An absolute base directory as a String
+  # filename       - [String] an absolute filename.
+  # base_directory - [String] an absolute base directory.
   #
-  # Return the relative path String of the filename calculated from the base directory
+  # Return the [String] relative path of the filename calculated from the base directory.
   def relative_path filename, base_directory
-    if (is_root? filename) && (is_root? base_directory)
-      offset = (base_directory.end_with? @file_separator) ? base_directory.length : base_directory.length + 1
-      filename[offset..-1]
+    if (is_root? filename) && (filename.start_with? base_directory)
+      filename.slice base_directory.length + 1, filename.length
     else
       filename
     end

--- a/lib/asciidoctor/reader.rb
+++ b/lib/asciidoctor/reader.rb
@@ -874,9 +874,9 @@ class PreprocessorReader < Reader
           replace_next_line %(Unresolved directive in #{@path} - include::#{target}[#{raw_attributes}])
           return true
         end
-        # NOTE relpath is the path relative to the outermost document (or base_dir, if set)
-        #relpath = @document.relative_path inc_path
-        relpath = PathResolver.new.relative_path inc_path, @document.base_dir
+        # NOTE relpath is the path relative to the root document (or base_dir, if set)
+        # QUESTION should we move relative_path method to Document
+        relpath = (@path_resolver ||= PathResolver.new).relative_path inc_path, @document.base_dir
       end
 
       inc_linenos, inc_tags, attributes = nil, nil, {}
@@ -1060,8 +1060,7 @@ class PreprocessorReader < Reader
     end
 
     if path
-      @includes << Helpers.rootname(path)
-      @path = path
+      @includes << Helpers.rootname(@path = path)
     else
       @path = '<stdin>'
     end

--- a/test/paths_test.rb
+++ b/test/paths_test.rb
@@ -248,6 +248,13 @@ context 'Path Resolver' do
       assert_equal 'part1/chapter1/section1.adoc', @resolver.relative_path(filename, JAIL)
     end
 
+    test 'should resolve relative path to filename if does not share common root with base directory' do
+      filename = '/docs/partials'
+      base_dir = '/home/user/docs'
+      result = @resolver.relative_path filename, base_dir
+      assert_equal filename, result
+    end
+
     test 'should resolve relative path relative to base dir in unsafe mode' do
       base_dir = fixture_path 'base'
       doc = empty_document :base_dir => base_dir, :safe => Asciidoctor::SafeMode::UNSAFE


### PR DESCRIPTION
- return filename as relative path if filename doesn't share common root with base directory
- add test for scenario