### PR TITLE
use refute in place of assert ! in test suite

### DIFF
--- a/test/attributes_test.rb
+++ b/test/attributes_test.rb
@@ -362,12 +362,12 @@ content
         assert_equal val, doc.attributes[key]
       end
 
-      assert !doc.attributes.key?('backend-html5')
-      assert !doc.attributes.key?('backend-html5-doctype-article')
-      assert !doc.attributes.key?('basebackend-html')
-      assert !doc.attributes.key?('basebackend-html-doctype-article')
-      assert !doc.attributes.key?('doctype-article')
-      assert !doc.attributes.key?('filetype-html')
+      refute doc.attributes.key?('backend-html5')
+      refute doc.attributes.key?('backend-html5-doctype-article')
+      refute doc.attributes.key?('basebackend-html')
+      refute doc.attributes.key?('basebackend-html-doctype-article')
+      refute doc.attributes.key?('doctype-article')
+      refute doc.attributes.key?('filetype-html')
     end
 
     test 'backend attributes defined in document options overrides backend attribute in document' do
@@ -420,7 +420,7 @@ content
 
     test 'set_attribute should set attribute if key is not locked' do
       doc = empty_document
-      assert !(doc.attr? 'foo')
+      refute doc.attr? 'foo'
       res = doc.set_attribute 'foo', 'baz'
       assert res
       assert_equal 'baz', (doc.attr 'foo')
@@ -430,7 +430,7 @@ content
       doc = empty_document :attributes => { 'foo' => 'bar' }
       assert_equal 'bar', (doc.attr 'foo')
       res = doc.set_attribute 'foo', 'baz'
-      assert !res
+      refute res
       assert_equal 'bar', (doc.attr 'foo')
     end
 
@@ -439,7 +439,7 @@ content
       assert_equal '', (doc.attr 'backend-html5')
       res = doc.set_attribute 'backend', 'docbook5'
       assert res
-      assert !(doc.attr? 'backend-html5')
+      refute doc.attr? 'backend-html5'
       assert_equal '', (doc.attr 'backend-docbook5')
     end
 
@@ -467,10 +467,10 @@ toc toc-placement!                        |   |content     |macro        |nil
         raw_attrs, toc, toc_position, toc_placement, toc_class = expect
         attrs = Hash[*raw_attrs.split.map {|e| e.include?('=') ? e.split('=', 2) : [e, ''] }.flatten]
         doc = document_from_string '', :attributes => attrs
-        toc ? (assert doc.attr?('toc', toc)) : (assert !doc.attr?('toc'))
-        toc_position ? (assert doc.attr?('toc-position', toc_position)) : (assert !doc.attr?('toc-position'))
-        toc_placement ? (assert doc.attr?('toc-placement', toc_placement)) : (assert !doc.attr?('toc-placement'))
-        toc_class ? (assert doc.attr?('toc-class', toc_class)) : (assert !doc.attr?('toc-class'))
+        toc ? (assert doc.attr?('toc', toc)) : (refute doc.attr?('toc'))
+        toc_position ? (assert doc.attr?('toc-position', toc_position)) : (refute doc.attr?('toc-position'))
+        toc_placement ? (assert doc.attr?('toc-placement', toc_placement)) : (refute doc.attr?('toc-placement'))
+        toc_class ? (assert doc.attr?('toc-class', toc_class)) : (refute doc.attr?('toc-class'))
       end
     end
   end
@@ -1116,7 +1116,7 @@ paragraph
 
       doc = document_from_string input
       para = doc.blocks.first
-      assert !para.attributes.has_key?('id')
+      refute para.attributes.has_key?('id')
     end
 
     test 'role? returns true if role is assigned' do
@@ -1140,7 +1140,7 @@ A paragraph
       p = doc.blocks.first
       assert p.role?('lead')
       p2 = doc.blocks.last
-      assert !p2.role?('final')
+      refute p2.role?('final')
     end
 
     test 'has_role? can check for precense of role name' do
@@ -1151,7 +1151,7 @@ A paragraph
 
       doc = document_from_string input
       p = doc.blocks.first
-      assert !p.role?('lead')
+      refute p.role?('lead')
       assert p.has_role?('lead')
     end
 
@@ -1265,7 +1265,7 @@ A normal paragraph
       assert res
       assert_equal 'role2', para.attributes['role']
       assert para.has_role? 'role2'
-      assert !para.has_role?('role1')
+      refute para.has_role?('role1')
     end
 
     test 'roles are removed when last role is removed using remove_role' do
@@ -1293,7 +1293,7 @@ A normal paragraph
       refute res
       assert_equal 'role1', para.attributes['role']
       assert para.has_role? 'role1'
-      assert !para.has_role?('role2')
+      refute para.has_role?('role2')
     end
 
     test 'roles are not changed when using remove_role if the node has no roles' do
@@ -1305,7 +1305,7 @@ A normal paragraph
       res = para.remove_role 'role1'
       refute res
       assert_equal nil, para.attributes['role']
-      assert !para.has_role?('role1')
+      refute para.has_role?('role1')
     end
 
     test 'option can be specified in first position of block style using shorthand syntax' do
@@ -1344,7 +1344,7 @@ content
       section = doc.blocks[0]
       refute_nil section
       assert_equal :section, section.context
-      assert !section.special
+      refute section.special
       output = doc.convert
       assert_css 'section', output, 1
       assert_css 'section#idname', output, 1

--- a/test/blocks_test.rb
+++ b/test/blocks_test.rb
@@ -150,7 +150,7 @@ block comment
       EOS
 
       output = render_embedded_string input
-      assert !output.strip.empty?, "Line should be emitted => #{input.rstrip}"
+      refute_empty output.strip, "Line should be emitted => #{input.rstrip}"
     end
 
     test 'preprocessor directives should not be processed within comment block within block metadata' do
@@ -640,7 +640,7 @@ You just write.
       assert_nil doc.blocks[0].number
       output = doc.render
       assert_xpath '(//*[@class="exampleblock"])[1]/*[@class="title"][text()="Look! Writing Docs with AsciiDoc"]', output, 1
-      assert !doc.attributes.has_key?('example-number')
+      refute doc.attributes.has_key?('example-number')
     end
 
     test 'automatic caption can be turned off and on and modified' do
@@ -1162,7 +1162,7 @@ This is a passthrough block.
       EOS
 
       block = block_from_string input
-      assert !block.nil?
+      refute_nil block
       assert_equal 1, block.lines.size
       assert_equal 'This is a passthrough block.', block.source
     end
@@ -1437,7 +1437,7 @@ section paragraph
       assert_xpath '//*[@id="content"]/h1[text()="Section Title"]', output, 1
       assert_xpath '//*[@class="paragraph"]', output, 1
       assert_xpath '//*[@class="paragraph"]/*[@class="title"][text()="Block title"]', output, 1
-      assert !errors.empty?
+      refute_empty errors
       assert_match(/only book doctypes can contain level 0 sections/, errors)
     end
 
@@ -1468,7 +1468,7 @@ Block content
 
       output = render_embedded_string input
       assert output.include?('Block content')
-      assert !output.include?('[]')
+      refute output.include?('[]')
     end
 
     test 'empty block anchor should not appear in output' do
@@ -1481,7 +1481,7 @@ Block content
 
       output = render_embedded_string input
       assert output.include?('Block content')
-      assert !output.include?('[[]]')
+      refute output.include?('[[]]')
     end
   end
 
@@ -1761,7 +1761,7 @@ image::images/tiger.png[Tiger]
       output = doc.render
       assert_xpath '//*[@class="imageblock"]//img[@src="images/tiger.png"][@alt="Tiger"]', output, 1
       assert_xpath '//*[@class="imageblock"]/*[@class="title"][text() = "Voila! The AsciiDoc Tiger"]', output, 1
-      assert !doc.attributes.has_key?('figure-number')
+      refute doc.attributes.has_key?('figure-number')
     end
 
     test 'can align image in DocBook backend' do
@@ -1844,7 +1844,7 @@ image::{bogus}[]
       EOS
 
       output, warnings = redirect_streams {|_, err| [(render_embedded_string input), err.string] }
-      assert output.strip.empty?
+      assert_empty output.strip
       assert_includes warnings, 'dropping line containing reference to missing attribute'
     end
 
@@ -1856,7 +1856,7 @@ image::{bogus}[]
       EOS
 
       output, warnings = redirect_streams {|_, err| [(render_embedded_string input), err.string] }
-      assert output.strip.empty?
+      assert_empty output.strip
       assert_includes warnings, 'dropping line containing reference to missing attribute'
     end
 
@@ -1872,7 +1872,7 @@ image::{bogus}[]
       output, warnings = redirect_streams {|_, err| [(render_embedded_string input), err.string] }
       assert_css 'img', output, 0
       assert_css 'h2', output, 1
-      assert !output.include?('== Section Title')
+      refute output.include?('== Section Title')
       assert_includes warnings, 'dropping line containing reference to missing attribute'
     end
 
@@ -2686,7 +2686,7 @@ public class Printer {
       assert_match(/\.<em>out<\/em>\./, output, 1)
       assert_match(/\*asterisks\*/, output, 1)
       assert_match(/<strong>bold<\/strong>/, output, 1)
-      assert !output.include?(Asciidoctor::Substitutors::PASS_START)
+      refute output.include?(Asciidoctor::Substitutors::PASS_START)
     end
 
     test 'should link to CodeRay stylesheet if source-highlighter is coderay and linkcss is set' do
@@ -2778,7 +2778,7 @@ puts HTML::Pipeline.new(filters, {}).call(input)[:output]
 :source-highlighter: coderay
       EOS
       doc = document_from_string input, :safe => Asciidoctor::SafeMode::SERVER
-      assert doc.attributes['source-highlighter'].nil?
+      assert_nil doc.attributes['source-highlighter']
     end
   end
 
@@ -3186,7 +3186,7 @@ content
       block = doc.blocks.first
       assert_nil block.id
       assert_nil(block.attr 'reftext')
-      assert !doc.catalog[:ids].has_key?('illegal$id')
+      refute doc.catalog[:ids].has_key?('illegal$id')
     end
 
     test 'should not recognize block anchor that starts with digit' do

--- a/test/converter_test.rb
+++ b/test/converter_test.rb
@@ -167,25 +167,25 @@ Sidebar content
         caches = Asciidoctor::Converter::TemplateConverter.caches
         if defined? ::ThreadSafe::Cache
           assert caches[:templates].is_a?(::ThreadSafe::Cache)
-          assert !caches[:templates].empty?
+          refute_empty caches[:templates]
           paragraph_template_before = caches[:templates].values.find {|t| File.basename(t.file) == 'block_paragraph.html.haml' }
-          assert !paragraph_template_before.nil?
+          refute_nil paragraph_template_before
 
           # should use cache
           doc = Asciidoctor::Document.new [], :template_dir => template_dir
           template_converter = doc.converter.find_converter('paragraph')
           paragraph_template_after = template_converter.templates['paragraph']
-          assert !paragraph_template_after.nil?
+          refute_nil paragraph_template_after
           assert paragraph_template_before.eql?(paragraph_template_after)
 
           # should not use cache
           doc = Asciidoctor::Document.new [], :template_dir => template_dir, :template_cache => false
           template_converter = doc.converter.find_converter('paragraph')
           paragraph_template_after = template_converter.templates['paragraph']
-          assert !paragraph_template_after.nil?
-          assert !paragraph_template_before.eql?(paragraph_template_after)
+          refute_nil paragraph_template_after
+          refute paragraph_template_before.eql?(paragraph_template_after)
         else
-          assert caches.empty?
+          assert_empty caches
         end
       ensure
         # clean up
@@ -199,10 +199,10 @@ Sidebar content
       caches = { :scans => {}, :templates => {} }
       doc = Asciidoctor::Document.new [], :template_dir => template_dir, :template_cache => caches
       doc.converter
-      assert !caches[:scans].empty?
-      assert !caches[:templates].empty?
+      refute_empty caches[:scans]
+      refute_empty caches[:templates]
       paragraph_template = caches[:templates].values.find {|t| File.basename(t.file) == 'block_paragraph.html.haml' }
-      assert !paragraph_template.nil?
+      refute_nil paragraph_template
       assert paragraph_template.is_a? ::Tilt::HamlTemplate
     end
 
@@ -231,7 +231,7 @@ Sidebar content
         assert selected.is_a? Asciidoctor::Converter::TemplateConverter
         template = selected.templates[node_name]
         assert template.is_a? Tilt::ERBTemplate
-        assert !(template.is_a? Tilt::ErubisTemplate)
+        refute template.is_a? Tilt::ErubisTemplate
         assert template.instance_variable_get('@engine').is_a? ::ERB
         assert_equal %(block_#{node_name}.html.erb), File.basename(selected.templates[node_name].file)
       end

--- a/test/document_test.rb
+++ b/test/document_test.rb
@@ -18,7 +18,7 @@ context 'Document' do
       assert_equal 'header', doc.header.sectname
       assert_equal 14, doc.blocks.size
       assert_equal :preamble, doc.blocks[0].context
-      assert doc.blocks[1].context == :section
+      assert_equal :section, doc.blocks[1].context
 
       # verify compat-mode is set when atx-style doctitle is used
       result = doc.blocks[0].convert
@@ -61,9 +61,9 @@ context 'Document' do
       assert_equal Asciidoctor::SafeMode::SECURE, doc.attr('safe-mode-level')
       assert_equal 'secure', doc.attr('safe-mode-name')
       assert doc.attr?('safe-mode-secure')
-      assert !doc.attr?('safe-mode-unsafe')
-      assert !doc.attr?('safe-mode-safe')
-      assert !doc.attr?('safe-mode-server')
+      refute doc.attr?('safe-mode-unsafe')
+      refute doc.attr?('safe-mode-safe')
+      refute doc.attr?('safe-mode-server')
     end
 
     test 'safe mode level can be set in the constructor' do
@@ -105,8 +105,8 @@ context 'Document' do
 :sectnums!:
       EOS
       doc = document_from_string input, :backend => 'docbook'
-      assert !doc.attr?('toc')
-      assert !doc.attr?('sectnums')
+      refute doc.attr?('toc')
+      refute doc.attr?('sectnums')
     end
 
     test 'noheader attribute should suppress info element when converting to DocBook' do
@@ -127,7 +127,7 @@ content
 :numbered!:
       EOS
       doc = document_from_string input, :backend => 'docbook'
-      assert !doc.attr?('sectnums')
+      refute doc.attr?('sectnums')
     end
   end
 
@@ -169,7 +169,7 @@ preamble
       EOS
       doc = Asciidoctor.load(input, :safe => Asciidoctor::SafeMode::SAFE)
       assert_equal 'Document Title', doc.doctitle
-      assert !doc.attr?('docfile')
+      refute doc.attr?('docfile')
       assert_equal doc.base_dir, doc.attr('docdir')
     end
 
@@ -182,7 +182,7 @@ preamble
       EOS
       doc = Asciidoctor.load(input, :safe => Asciidoctor::SafeMode::SAFE)
       assert_equal 'Document Title', doc.doctitle
-      assert !doc.attr?('docfile')
+      refute doc.attr?('docfile')
       assert_equal doc.base_dir, doc.attr('docdir')
     end
 
@@ -195,14 +195,14 @@ preamble
       EOS
       doc = Asciidoctor.load(input.lines.entries, :safe => Asciidoctor::SafeMode::SAFE)
       assert_equal 'Document Title', doc.doctitle
-      assert !doc.attr?('docfile')
+      refute doc.attr?('docfile')
       assert_equal doc.base_dir, doc.attr('docdir')
     end
 
     test 'should accept attributes as array' do
 	  # NOTE there's a tab character before idseparator
       doc = Asciidoctor.load('text', :attributes => %w(toc sectnums   source-highlighter=coderay idprefix	idseparator=-))
-      assert doc.attributes.is_a?(Hash)
+      assert_kind_of Hash, doc.attributes
       assert doc.attr?('toc')
       assert_equal '', doc.attr('toc')
       assert doc.attr?('sectnums')
@@ -217,7 +217,7 @@ preamble
 
     test 'should accept attributes as empty array' do
       doc = Asciidoctor.load('text', :attributes => [])
-      assert doc.attributes.is_a?(Hash)
+      assert_kind_of Hash, doc.attributes
     end
 
     test 'should accept attributes as string' do
@@ -225,7 +225,7 @@ preamble
 source-highlighter=coderay
 idprefix
 idseparator=-')
-      assert doc.attributes.is_a?(Hash)
+      assert_kind_of Hash, doc.attributes
       assert doc.attr?('toc')
       assert_equal '', doc.attr('toc')
       assert doc.attr?('sectnums')
@@ -240,7 +240,7 @@ idseparator=-')
 
     test 'should accept values containing spaces in attributes string' do
       doc = Asciidoctor.load('text', :attributes => %(idprefix idseparator=-   note-caption=Note\\ to\\\tself toc))
-      assert doc.attributes.is_a?(Hash)
+      assert_kind_of Hash, doc.attributes
       assert doc.attr?('idprefix')
       assert_equal '', doc.attr('idprefix')
       assert doc.attr?('idseparator')
@@ -251,12 +251,12 @@ idseparator=-')
 
     test 'should accept attributes as empty string' do
       doc = Asciidoctor.load('text', :attributes => '')
-      assert doc.attributes.is_a?(Hash)
+      assert_kind_of Hash, doc.attributes
     end
 
     test 'should accept attributes as nil' do
       doc = Asciidoctor.load('text', :attributes => nil)
-      assert doc.attributes.is_a?(Hash)
+      assert_kind_of Hash, doc.attributes
     end
 
     test 'should accept attributes if hash like' do
@@ -275,7 +275,7 @@ idseparator=-')
       end
 
       doc = Asciidoctor.load('text', :attributes => Hashish.new)
-      assert doc.attributes.is_a?(Hash)
+      assert_kind_of Hash, doc.attributes
       assert doc.attributes.has_key?('toc')
     end
 
@@ -546,9 +546,9 @@ term without description::
       result = doc.find_by
       refute_nil result
       assert_equal 3, result.size
-      assert Asciidoctor::Document === result[0]
-      assert Asciidoctor::List === result[1]
-      assert Asciidoctor::ListItem === result[2]
+      assert_kind_of Asciidoctor::Document, result[0]
+      assert_kind_of Asciidoctor::List, result[1]
+      assert_kind_of Asciidoctor::ListItem, result[2]
     end
   end
 
@@ -557,7 +557,7 @@ term without description::
       sample_input_path = fixture_path('sample.asciidoc')
 
       output = Asciidoctor.convert_file sample_input_path, :header_footer => true, :to_file => false
-      assert !output.empty?
+      refute_empty output
       assert_xpath '/html', output, 1
       assert_xpath '/html/head', output, 1
       assert_xpath '/html/body', output, 1
@@ -569,12 +569,12 @@ term without description::
       sample_input_path = fixture_path('sample.asciidoc')
 
       output = Asciidoctor.convert_file sample_input_path, :header_footer => true, :to_file => false
-      assert !output.empty?
+      refute_empty output
       lines = output.split("\n")
-      assert lines.size == output.split(/\r\n|\r|\n/).size
+      assert_equal lines.size, output.split(/\r\n|\r|\n/).size
       raw_lengths = lines.map(&:length)
       trimmed_lengths = lines.map {|line| line.rstrip.length }
-      assert raw_lengths == trimmed_lengths
+      assert_equal raw_lengths, trimmed_lengths
     end
 
     test 'should accept attributes as array' do
@@ -608,8 +608,8 @@ text
       assert_css 'html:root > head > link[rel="stylesheet"][href="./asciidoctor.css"]', output, 0
       stylenode = xmlnodes_at_css 'html:root > head > style', output, 1
       styles = stylenode.content
-      assert !styles.nil?
-      assert !styles.strip.empty?
+      refute_nil styles
+      refute_empty styles.strip
     end
 
     test 'should link to default stylesheet by default even if linkcss is unset in document' do
@@ -644,8 +644,8 @@ text
       assert_css 'html:root > head > style', output, 1
       stylenode = xmlnodes_at_css 'html:root > head > style', output, 1
       styles = stylenode.content
-      assert !styles.nil?
-      assert !styles.strip.empty?
+      refute_nil styles
+      refute_empty styles.strip
     end
 
     test 'should not link to stylesheet if stylesheet is unset' do
@@ -692,8 +692,8 @@ text
           :attributes => {'stylesheet' => 'custom.css', 'stylesdir' => './stylesheets', 'linkcss!' => ''}
       stylenode = xmlnodes_at_css 'html:root > head > style', output, 1
       styles = stylenode.content
-      assert !styles.nil?
-      assert !styles.strip.empty?
+      refute_nil styles
+      refute_empty styles.strip
     end
 
     test 'should convert source file and write result to adjacent file by default' do
@@ -703,7 +703,7 @@ text
         Asciidoctor.convert_file sample_input_path
         assert File.exist?(sample_output_path)
         output = IO.read(sample_output_path)
-        assert !output.empty?
+        refute_empty output
         assert_xpath '/html', output, 1
         assert_xpath '/html/head', output, 1
         assert_xpath '/html/body', output, 1
@@ -721,7 +721,7 @@ text
         Asciidoctor.convert_file sample_input_path, :to_file => sample_output_path
         assert File.exist?(sample_output_path)
         output = IO.read(sample_output_path)
-        assert !output.empty?
+        refute_empty output
         assert_xpath '/html', output, 1
         assert_xpath '/html/head', output, 1
         assert_xpath '/html/body', output, 1
@@ -740,7 +740,7 @@ text
         Asciidoctor.convert_file sample_input_path, :to_file => 'result.html', :base_dir => fixture_dir
         assert File.exist?(sample_output_path)
         output = IO.read(sample_output_path)
-        assert !output.empty?
+        refute_empty output
         assert_xpath '/html', output, 1
         assert_xpath '/html/head', output, 1
         assert_xpath '/html/body', output, 1
@@ -865,7 +865,7 @@ text
       cases.each do |attr_val, markup|
         output = Asciidoctor.convert_file sample_input_path, :to_file => false,
             :header_footer => true, :safe => Asciidoctor::SafeMode::SERVER, :attributes => %(linkcss copycss! #{attr_val})
-        assert !output.empty?
+        refute_empty output
         assert_css 'script[src="modernizr.js"]', output, markup[:head_script]
         assert_css 'meta[http-equiv="imagetoolbar"]', output, markup[:meta]
         assert_css 'body > a#top', output, markup[:top_link]
@@ -877,7 +877,7 @@ text
       sample_input_path = fixture_path('basic.asciidoc')
       output = Asciidoctor.convert_file sample_input_path, :to_file => false,
           :header_footer => true, :safe => Asciidoctor::SafeMode::SERVER, :attributes => {'docinfo1' => '', 'nofooter' => ''}
-      assert !output.empty?
+      refute_empty output
       assert_css 'body > a#top', output, 1
     end
 
@@ -886,25 +886,25 @@ text
 
       output = Asciidoctor.convert_file sample_input_path, :to_file => false,
                                         :header_footer => true, :safe => Asciidoctor::SafeMode::SERVER, :attributes => {'docinfo' => '', 'docinfodir' => 'custom-docinfodir'}
-      assert !output.empty?
+      refute_empty output
       assert_css 'script[src="bootstrap.js"]', output, 1
       assert_css 'meta[name="robots"]', output, 0
 
       output = Asciidoctor.convert_file sample_input_path, :to_file => false,
                                         :header_footer => true, :safe => Asciidoctor::SafeMode::SERVER, :attributes => {'docinfo1' => '', 'docinfodir' => 'custom-docinfodir'}
-      assert !output.empty?
+      refute_empty output
       assert_css 'script[src="bootstrap.js"]', output, 0
       assert_css 'meta[name="robots"]', output, 1
 
       output = Asciidoctor.convert_file sample_input_path, :to_file => false,
                                         :header_footer => true, :safe => Asciidoctor::SafeMode::SERVER, :attributes => {'docinfo2' => '', 'docinfodir' => './custom-docinfodir'}
-      assert !output.empty?
+      refute_empty output
       assert_css 'script[src="bootstrap.js"]', output, 1
       assert_css 'meta[name="robots"]', output, 1
 
       output = Asciidoctor.convert_file sample_input_path, :to_file => false,
                                         :header_footer => true, :safe => Asciidoctor::SafeMode::SERVER, :attributes => {'docinfo2' => '', 'docinfodir' => 'custom-docinfodir/subfolder'}
-      assert !output.empty?
+      refute_empty output
       assert_css 'script[src="bootstrap.js"]', output, 0
       assert_css 'meta[name="robots"]', output, 0
     end
@@ -914,13 +914,13 @@ text
 
       output = Asciidoctor.convert_file sample_input_path, :to_file => false,
           :header_footer => true, :backend => 'docbook', :safe => Asciidoctor::SafeMode::SERVER, :attributes => {'docinfo' => ''}
-      assert !output.empty?
+      refute_empty output
       assert_css 'productname', output, 0
       assert_css 'copyright', output, 1
 
       output = Asciidoctor.convert_file sample_input_path, :to_file => false,
           :header_footer => true, :backend => 'docbook', :safe => Asciidoctor::SafeMode::SERVER, :attributes => {'docinfo1' => ''}
-      assert !output.empty?
+      refute_empty output
       assert_css 'productname', output, 1
       assert_xpath '//xmlns:productname[text()="Asciidoctor™"]', output, 1
       assert_css 'edition', output, 1
@@ -929,7 +929,7 @@ text
 
       output = Asciidoctor.convert_file sample_input_path, :to_file => false,
           :header_footer => true, :backend => 'docbook', :safe => Asciidoctor::SafeMode::SERVER, :attributes => {'docinfo2' => ''}
-      assert !output.empty?
+      refute_empty output
       assert_css 'productname', output, 1
       assert_xpath '//xmlns:productname[text()="Asciidoctor™"]', output, 1
       assert_css 'edition', output, 1
@@ -942,19 +942,19 @@ text
 
       output = Asciidoctor.convert_file sample_input_path, :to_file => false,
           :header_footer => true, :safe => Asciidoctor::SafeMode::SERVER, :attributes => {'docinfo' => ''}
-      assert !output.empty?
+      refute_empty output
       assert_css 'body script', output, 1
       assert_css 'a#top', output, 0
 
       output = Asciidoctor.convert_file sample_input_path, :to_file => false,
           :header_footer => true, :safe => Asciidoctor::SafeMode::SERVER, :attributes => {'docinfo1' => ''}
-      assert !output.empty?
+      refute_empty output
       assert_css 'body script', output, 0
       assert_css 'a#top', output, 1
 
       output = Asciidoctor.convert_file sample_input_path, :to_file => false,
           :header_footer => true, :safe => Asciidoctor::SafeMode::SERVER, :attributes => {'docinfo2' => ''}
-      assert !output.empty?
+      refute_empty output
       assert_css 'body script', output, 1
       assert_css 'a#top', output, 1
     end
@@ -964,20 +964,20 @@ text
 
       output = Asciidoctor.convert_file sample_input_path, :to_file => false,
           :header_footer => true, :backend => 'docbook', :safe => Asciidoctor::SafeMode::SERVER, :attributes => {'docinfo' => ''}
-      assert !output.empty?
+      refute_empty output
       assert_css 'article > revhistory', output, 1
       assert_xpath '/xmlns:article/xmlns:revhistory/xmlns:revision/xmlns:revnumber[text()="1.0"]', output, 1 # verifies substitutions are performed
       assert_css 'glossary#_glossary', output, 0
 
       output = Asciidoctor.convert_file sample_input_path, :to_file => false,
           :header_footer => true, :backend => 'docbook', :safe => Asciidoctor::SafeMode::SERVER, :attributes => {'docinfo1' => ''}
-      assert !output.empty?
+      refute_empty output
       assert_css 'article > revhistory', output, 0
       assert_css 'glossary#_glossary', output, 1
 
       output = Asciidoctor.convert_file sample_input_path, :to_file => false,
           :header_footer => true, :backend => 'docbook', :safe => Asciidoctor::SafeMode::SERVER, :attributes => {'docinfo2' => ''}
-      assert !output.empty?
+      refute_empty output
       assert_css 'article > revhistory', output, 1
       assert_xpath '/xmlns:article/xmlns:revhistory/xmlns:revision/xmlns:revnumber[text()="1.0"]', output, 1 # verifies substitutions are performed
       assert_css 'glossary#_glossary', output, 1
@@ -1000,7 +1000,7 @@ text
         end
         output = Asciidoctor.convert_file sample_input_path, :to_file => false,
             :header_footer => true, :backend => 'docbook', :safe => Asciidoctor::SafeMode::SERVER, :attributes => {'docinfo2' => ''}
-        assert !output.empty?
+        refute_empty output
         assert_css 'productname', output, 1
         assert_css 'edition', output, 1
         assert_xpath '//xmlns:edition[text()="1.0"]', output, 1 # verifies substitutions are performed
@@ -1019,13 +1019,13 @@ text
 
       output = Asciidoctor.convert_file sample_input_path, :to_file => false,
           :header_footer => true, :safe => Asciidoctor::SafeMode::SERVER
-      assert !output.empty?
+      refute_empty output
       assert_css 'script[src="modernizr.js"]', output, 0
       assert_css 'meta[http-equiv="imagetoolbar"]', output, 0
 
       output = Asciidoctor.convert_file sample_input_path, :to_file => false,
           :header_footer => true, :backend => 'docbook', :safe => Asciidoctor::SafeMode::SERVER
-      assert !output.empty?
+      refute_empty output
       assert_css 'productname', output, 0
       assert_css 'copyright', output, 0
     end
@@ -1035,13 +1035,13 @@ text
 
       output = Asciidoctor.convert_file sample_input_path, :to_file => false,
           :header_footer => true, :attributes => {'docinfo2' => ''}
-      assert !output.empty?
+      refute_empty output
       assert_css 'script[src="modernizr.js"]', output, 0
       assert_css 'meta[http-equiv="imagetoolbar"]', output, 0
 
       output = Asciidoctor.convert_file sample_input_path, :to_file => false,
           :header_footer => true, :backend => 'docbook', :attributes => {'docinfo2' => ''}
-      assert !output.empty?
+      refute_empty output
       assert_css 'productname', output, 0
       assert_css 'copyright', output, 0
     end
@@ -1056,7 +1056,7 @@ text
             :attributes => { 'docinfo' => '', 'bootstrap-version' => nil, 'linkcss' => '', 'attribute-missing' => 'drop-line' }
         [output, err.string]
       end
-      refute output.empty?
+      refute_empty output
       assert_css 'script', output, 0
       assert_xpath %(//meta[@name="copyright"][@content="(C) OpenDevise"]), output, 1
       assert_includes warnings, 'dropping line containing reference to missing attribute'
@@ -1069,7 +1069,7 @@ text
           :header_footer => true,
           :safe => :server,
           :attributes => { 'docinfo' => '', 'docinfosubs' => 'attributes,replacements', 'linkcss' => '' }
-      refute output.empty?
+      refute_empty output
       assert_css 'script[src="bootstrap.3.2.0.min.js"]', output, 1
       assert_xpath %(//meta[@name="copyright"][@content="#{decode_char 169} OpenDevise"]), output, 1
     end
@@ -1093,9 +1093,9 @@ text
       assert_equal 'html', doc.attributes['basebackend']
       assert doc.attributes.has_key? 'basebackend-html'
       converter = doc.converter
-      assert converter.is_a? Asciidoctor::Converter::Html5Converter
+      assert_kind_of Asciidoctor::Converter::Html5Converter, converter
       BUILT_IN_ELEMENTS.each do |element|
-        assert converter.respond_to? element
+        assert_respond_to converter, element
       end
     end
 
@@ -1107,9 +1107,9 @@ text
       assert_equal 'docbook', doc.attributes['basebackend']
       assert doc.attributes.has_key? 'basebackend-docbook'
       converter = doc.converter
-      assert converter.is_a? Asciidoctor::Converter::DocBook45Converter
+      assert_kind_of Asciidoctor::Converter::DocBook45Converter, converter
       BUILT_IN_ELEMENTS.each do |element|
-        assert converter.respond_to? element
+        assert_respond_to converter, element
       end
     end
 
@@ -1121,9 +1121,9 @@ text
       assert_equal 'docbook', doc.attributes['basebackend']
       assert doc.attributes.has_key? 'basebackend-docbook'
       converter = doc.converter
-      assert converter.is_a? Asciidoctor::Converter::DocBook5Converter
+      assert_kind_of Asciidoctor::Converter::DocBook5Converter, converter
       BUILT_IN_ELEMENTS.each do |element|
-        assert converter.respond_to? element
+        assert_respond_to converter, element
       end
     end
 
@@ -1146,7 +1146,7 @@ text
       doc = document_from_string('Snorf')
       assert_nil doc.doctitle
       assert_nil doc.name
-      assert !doc.has_header?
+      refute doc.has_header?
       assert_nil doc.header
     end
 
@@ -1395,17 +1395,17 @@ content
 
     test 'should not choke on empty source' do
       doc = Asciidoctor::Document.new ''
-      assert doc.blocks.empty?
+      assert_empty doc.blocks
       assert_nil doc.doctitle
-      assert !doc.has_header?
+      refute doc.has_header?
       assert_nil doc.header
     end
 
     test 'should not choke on nil source' do
       doc = Asciidoctor::Document.new nil
-      assert doc.blocks.empty?
+      assert_empty doc.blocks
       assert_nil doc.doctitle
-      assert !doc.has_header?
+      refute doc.has_header?
       assert_nil doc.header
     end
 
@@ -1627,7 +1627,7 @@ content
 
     test 'with header footer' do
       doc = document_from_string "= Title\n\nparagraph"
-      assert !doc.attr?('embedded')
+      refute doc.attr?('embedded')
       result = doc.render
       assert_xpath '/html', result, 1
       assert_xpath '//*[@id="header"]', result, 1
@@ -2344,7 +2344,7 @@ asciidoctor - converts AsciiDoc source files to HTML, DocBook and other formats
       naughty_path = "#{disk_root}etc/passwd"
       doc = empty_document
       secure_path = doc.normalize_asset_path(naughty_path)
-      assert naughty_path != secure_path
+      refute_equal naughty_path, secure_path
       assert_match(/^#{doc.base_dir}/, secure_path)
     end
 
@@ -2352,7 +2352,7 @@ asciidoctor - converts AsciiDoc source files to HTML, DocBook and other formats
       naughty_path = 'safe/ok/../../../../../etc/passwd'
       doc = empty_document
       secure_path = redirect_streams { doc.normalize_asset_path(naughty_path) }
-      assert naughty_path != secure_path
+      refute_equal naughty_path, secure_path
       assert_match(/^#{doc.base_dir}/, secure_path)
     end
 

--- a/test/extensions_test.rb
+++ b/test/extensions_test.rb
@@ -476,7 +476,7 @@ context 'Extensions' do
       registry = Asciidoctor::Extensions::Registry.new
       registry.block SampleBlock, :sample
       registry.activate Asciidoctor::Document.new
-      assert !(registry.registered_for_block? :sample, :sidebar)
+      refute registry.registered_for_block? :sample, :sidebar
     end
 
     test 'should instantiate block macro processor' do
@@ -1173,7 +1173,7 @@ sample content
                                           :header_footer => true,
                                           :safe => Asciidoctor::SafeMode::SERVER,
                                           :attributes => {'docinfo' => ''}
-        assert !output.empty?
+        refute_empty output
         assert_css 'script[src="modernizr.js"]', output, 1
         assert_css 'meta[name="robots"]', output, 1
         assert_css 'meta[http-equiv="imagetoolbar"]', output, 0

--- a/test/invoker_test.rb
+++ b/test/invoker_test.rb
@@ -14,9 +14,9 @@ context 'Invoker' do
       invoker = invoke_cli %w(-o -)
       output = out.string
     end
-    assert !invoker.nil?
+    refute_nil invoker
     doc = invoker.document
-    assert !doc.nil?
+    refute_nil doc
     assert_equal 'Document Title', doc.doctitle
     assert_equal 'Doc Writer', doc.attr('author')
     assert_equal 'html5', doc.attr('backend')
@@ -24,7 +24,7 @@ context 'Invoker' do
     assert_equal 'article', doc.attr('doctype')
     assert doc.blocks?
     assert_equal :preamble, doc.blocks.first.context
-    assert !output.empty?
+    refute_empty output
     assert_xpath '/html', output, 1
     assert_xpath '/html/head', output, 1
     assert_xpath '/html/body', output, 1
@@ -44,7 +44,7 @@ context 'Invoker' do
     assert doc.attr?('docyear')
     assert doc.attr?('doctime')
     assert doc.attr?('docdatetime')
-    assert invoker.read_output.empty?
+    assert_empty invoker.read_output
   end
 
   test 'should allow docdate and doctime to be overridden' do
@@ -60,16 +60,16 @@ context 'Invoker' do
   test 'should accept document from stdin and write to stdout' do
     invoker = invoke_cli_to_buffer(%w(-s), '-') { 'content' }
     doc = invoker.document
-    assert !doc.attr?('docname')
-    assert !doc.attr?('docfile')
+    refute doc.attr?('docname')
+    refute doc.attr?('docfile')
     assert_equal Dir.pwd, doc.attr('docdir')
     assert_equal doc.attr('docdate'), doc.attr('localdate')
     assert_equal doc.attr('docyear'), doc.attr('localyear')
     assert_equal doc.attr('doctime'), doc.attr('localtime')
     assert_equal doc.attr('docdatetime'), doc.attr('localdatetime')
-    assert !doc.attr?('outfile')
+    refute doc.attr?('outfile')
     output = invoker.read_output
-    assert !output.empty?
+    refute_empty output
     assert_xpath '/*[@class="paragraph"]/p[text()="content"]', output, 1
   end
 
@@ -90,8 +90,8 @@ context 'Invoker' do
     begin
       invoker = invoke_cli(%W(-s -o #{sample_outpath}), '-') { 'content' }
       doc = invoker.document
-      assert !doc.attr?('docname')
-      assert !doc.attr?('docfile')
+      refute doc.attr?('docname')
+      refute doc.attr?('docfile')
       assert_equal Dir.pwd, doc.attr('docdir')
       assert_equal doc.attr('docdate'), doc.attr('localdate')
       assert_equal doc.attr('docyear'), doc.attr('localyear')
@@ -210,7 +210,7 @@ context 'Invoker' do
       assert_equal sample_outpath, doc.attr('outfile')
       assert File.exist?(sample_outpath)
       output = IO.read(sample_outpath)
-      assert !output.empty?
+      refute_empty output
       assert_xpath '/html', output, 1
       assert_xpath '/html/head', output, 1
       assert_xpath '/html/body', output, 1
@@ -274,7 +274,7 @@ context 'Invoker' do
       invoker = invoke_cli %W(-o #{sample_outpath} -a linkcss -a copycss!)
       invoker.document
       assert File.exist?(sample_outpath)
-      assert !File.exist?(default_stylesheet)
+      refute File.exist?(default_stylesheet)
     ensure
       FileUtils.rm_f(sample_outpath)
       FileUtils.rm_f(default_stylesheet)
@@ -308,7 +308,7 @@ context 'Invoker' do
       invoker = invoke_cli %W(-o #{sample_outpath} -a linkcss -a stylesdir=./styles -a stylesheet=custom.css -a copycss!)
       invoker.document
       assert File.exist?(sample_outpath)
-      assert !File.exist?(custom_stylesheet)
+      refute File.exist?(custom_stylesheet)
     ensure
       FileUtils.rm_f(sample_outpath)
       FileUtils.rm_f(custom_stylesheet)
@@ -325,7 +325,7 @@ context 'Invoker' do
       invoker = invoke_cli %W(-o #{sample_outpath} -a linkcss -a stylesdir=http://example.org/styles -a stylesheet=custom.css)
       invoker.document
       assert File.exist?(sample_outpath)
-      assert !File.exist?(stylesdir)
+      refute File.exist?(stylesdir)
     ensure
       FileUtils.rm_f(sample_outpath)
       FileUtils.rmdir(stylesdir) if File.directory? stylesdir
@@ -401,8 +401,8 @@ context 'Invoker' do
       invoker = invoke_cli %w(-o -)
       output = out.string
     end
-    assert !invoker.nil?
-    assert !output.nil?
+    refute_nil invoker
+    refute_nil output
     assert output.end_with?("\n")
   end
 
@@ -529,7 +529,7 @@ context 'Invoker' do
   test 'should unset attribute ending in bang' do
     invoker = invoke_cli_to_buffer %w(-a sectids! -s -o -)
     doc = invoker.document
-    assert !doc.attr?('sectids')
+    refute doc.attr?('sectids')
     output = invoker.read_output
     # leave the count loose in case we add more sections
     assert_xpath '//h2[not(@id)]', output
@@ -581,9 +581,9 @@ context 'Invoker' do
       _, out, _ = Open3.popen3 cmd
       #stderr_lines = stderr.readlines
       # warnings may be issued, so don't assert on stderr
-      #assert stderr_lines.empty?, 'Command failed. Expected to receive a rendered document.'
+      #assert_empty stderr_lines, 'Command failed. Expected to receive a rendered document.'
       stdout_lines = out.readlines
-      assert !stdout_lines.empty?
+      refute_empty stdout_lines
       stdout_lines.each {|l| l.force_encoding Encoding::UTF_8 } if Asciidoctor::FORCE_ENCODING
       stdout_str = stdout_lines.join
       assert stdout_str.include?('Codierungen sind verrückt auf älteren Versionen von Ruby')
@@ -602,8 +602,8 @@ context 'Invoker' do
       invoker = invoke_cli(%w(-t -o /dev/null), '-') { input }
       error = err.string
     end
-    assert !invoker.nil?
-    assert !error.nil?
+    refute_nil invoker
+    refute_nil error
     assert_match(/Total time/, error)
   end
 

--- a/test/links_test.rb
+++ b/test/links_test.rb
@@ -575,7 +575,7 @@ See <<foobaz>>.
       old_verbose, $VERBOSE = $VERBOSE, true
       output, warnings = redirect_streams {|_, err| [(render_embedded_string input), err.string] }
       assert_xpath '//a[@href="#foobaz"][text() = "[foobaz]"]', output, 1
-      refute warnings.empty?
+      refute_empty warnings
       assert_includes warnings, 'asciidoctor: WARNING: invalid reference: foobaz'
     ensure
       $VERBOSE = old_verbose

--- a/test/lists_test.rb
+++ b/test/lists_test.rb
@@ -185,7 +185,7 @@ Bar
 
       output = render_embedded_string input
       assert_css 'ul ul', output, 1
-      assert !output.include?('* Foo')
+      refute output.include?('* Foo')
     end
 
     test 'a list item for a different list terminates non-indented paragraph for text of list item' do
@@ -205,9 +205,9 @@ term:: def
 
       output = render_embedded_string input
       assert_css 'ul ol', output, 1
-      assert !output.include?('* Foo')
+      refute output.include?('* Foo')
       assert_css 'ul dl', output, 1
-      assert !output.include?('term:: def')
+      refute output.include?('term:: def')
     end
 
     test 'an indented wrapped line is unindented and folded into text of list item' do
@@ -255,7 +255,7 @@ second wrapped line
 
       output = render_embedded_string input
       assert_css 'ul ul', output, 1
-      assert !output.include?('* Foo')
+      refute output.include?('* Foo')
     end
 
     test 'a list item that starts with a sequence of list markers characters should not match a nested list' do
@@ -287,9 +287,9 @@ term:: def
 
       output = render_embedded_string input
       assert_css 'ul ol', output, 1
-      assert !output.include?('* Foo')
+      refute output.include?('* Foo')
       assert_css 'ul dl', output, 1
-      assert !output.include?('term:: def')
+      refute output.include?('term:: def')
     end
 
     test "a literal paragraph offset by blank lines in list content is appended as a literal block" do
@@ -4471,7 +4471,7 @@ label:: desc
 
     doc = document_from_string input
     list = doc.blocks.first
-    assert !list.outline?
+    refute list.outline?
   end
 
   test 'simple? should return true for list item with no nested blocks' do
@@ -4484,7 +4484,7 @@ label:: desc
     doc = document_from_string input
     list = doc.blocks.first
     assert list.items.first.simple?
-    assert !list.items.first.compound?
+    refute list.items.first.compound?
   end
 
   test 'simple? should return true for list item with nested outline list' do
@@ -4499,7 +4499,7 @@ label:: desc
     doc = document_from_string input
     list = doc.blocks.first
     assert list.items.first.simple?
-    assert !list.items.first.compound?
+    refute list.items.first.compound?
   end
 
   test 'simple? should return false for list item with block content' do
@@ -4515,7 +4515,7 @@ listing block in list item 1
 
     doc = document_from_string input
     list = doc.blocks.first
-    assert !list.items.first.simple?
+    refute list.items.first.simple?
     assert list.items.first.compound?
   end
 

--- a/test/paragraphs_test.rb
+++ b/test/paragraphs_test.rb
@@ -541,7 +541,7 @@ Wise words from a wise person.
           output =  render_string input, :doctype => 'inline'
           err.string
         end
-        assert output.nil?
+        assert_nil output
         assert_includes warnings, 'no inline candidate'
       end
     end

--- a/test/parser_test.rb
+++ b/test/parser_test.rb
@@ -606,7 +606,7 @@ v8.6.8,
     metadata, _ = parse_header_metadata input
     assert_equal 7, metadata.size
     assert_equal '8.6.8', metadata['revnumber']
-    assert !metadata.has_key?('revdate')
+    refute metadata.has_key?('revdate')
   end
 
   # Asciidoctor recognizes a standalone revision without a trailing comma
@@ -618,7 +618,7 @@ v8.6.8
     metadata, _ = parse_header_metadata input
     assert_equal 7, metadata.size
     assert_equal '8.6.8', metadata['revnumber']
-    assert !metadata.has_key?('revdate')
+    refute metadata.has_key?('revdate')
   end
 
   # while compliant w/ AsciiDoc, this is just sloppy parsing
@@ -650,7 +650,7 @@ Joe Cool
     EOS
     metadata, _ = parse_header_metadata input
     refute_equal 'page-layout: post', metadata['revremark']
-    assert !metadata.has_key?('revdate')
+    refute metadata.has_key?('revdate')
   end
 
   test "parse rev remark only" do
@@ -660,7 +660,7 @@ Joe Cool
     EOS
     metadata, _ = parse_header_metadata input
     assert_equal 'Must start revremark-only line with space', metadata['revremark']
-    assert !metadata.has_key?('revdate')
+    refute metadata.has_key?('revdate')
   end
 
   test "skip line comments before author" do

--- a/test/reader_test.rb
+++ b/test/reader_test.rb
@@ -73,7 +73,7 @@ third line
 
     context 'With empty data' do
       test 'has_more_lines? should return false with empty data' do
-        assert !Asciidoctor::Reader.new.has_more_lines?
+        refute Asciidoctor::Reader.new.has_more_lines?
       end
 
       test 'empty? should return true with empty data' do
@@ -112,13 +112,13 @@ third line
 
       test 'empty? should return false if there are lines remaining' do
         reader = Asciidoctor::Reader.new SAMPLE_DATA
-        assert !reader.empty?
-        assert !reader.eof?
+        refute reader.empty?
+        refute reader.eof?
       end
 
       test 'next_line_empty? should return false if next line is not blank' do
         reader = Asciidoctor::Reader.new SAMPLE_DATA
-        assert !reader.next_line_empty?
+        refute reader.next_line_empty?
       end
 
       test 'next_line_empty? should return true if next line is blank' do
@@ -180,7 +180,7 @@ third line
         assert reader.advance
         assert reader.advance
         assert reader.advance
-        assert !reader.advance
+        refute reader.advance
       end
 
       test 'read_lines should return all lines' do
@@ -196,7 +196,7 @@ third line
       test 'has_more_lines? should return false after read_lines is invoked' do
         reader = Asciidoctor::Reader.new SAMPLE_DATA
         reader.read_lines
-        assert !reader.has_more_lines?
+        refute reader.has_more_lines?
       end
 
       test 'unshift puts line onto Reader as next line to read' do
@@ -273,7 +273,7 @@ This is another paragraph.
         result = reader.read_lines_until
         assert_equal 3, result.size
         assert_equal lines.map {|l| l.chomp }, result
-        assert !reader.has_more_lines?
+        refute reader.has_more_lines?
         assert reader.eof?
       end
 
@@ -411,9 +411,9 @@ endlines\r
           doc = Asciidoctor::Document.new lines
           reader = doc.reader
           reader.lines.each do |line|
-            assert !line.end_with?("\r"), "CRLF not properly cleaned for source lines: #{lines.inspect}"
-            assert !line.end_with?("\r\n"), "CRLF not properly cleaned for source lines: #{lines.inspect}"
-            assert !line.end_with?("\n"), "CRLF not properly cleaned for source lines: #{lines.inspect}"
+            refute line.end_with?("\r"), "CRLF not properly cleaned for source lines: #{lines.inspect}"
+            refute line.end_with?("\r\n"), "CRLF not properly cleaned for source lines: #{lines.inspect}"
+            refute line.end_with?("\n"), "CRLF not properly cleaned for source lines: #{lines.inspect}"
           end
         end
       end
@@ -434,7 +434,7 @@ preamble
 
         doc = Asciidoctor::Document.new input
         reader = doc.reader
-        assert !doc.attributes.key?('front-matter')
+        refute doc.attributes.key?('front-matter')
         assert_equal '---', reader.peek_line
     end
 

--- a/test/sections_test.rb
+++ b/test/sections_test.rb
@@ -68,7 +68,7 @@ context 'Sections' do
 
     test 'synthetic ids can be disabled' do
       sec = block_from_string(":sectids!:\n\n== Section One\n")
-      assert sec.id.nil?
+      assert_nil sec.id
     end
 
     test 'explicit id in anchor above section title overrides synthetic id' do
@@ -373,7 +373,7 @@ preamble
 content
       EOS
       doc = document_from_string input
-      assert doc.blocks[0].attributes.empty?
+      assert_empty doc.blocks[0].attributes
       output = doc.convert
       assert_css 'body#idname', output, 1
       assert_css '.rolename', output, 0
@@ -665,7 +665,6 @@ not in section
       doc = document_from_string input
       heading = doc.blocks.first
       assert heading.is_a?(Asciidoctor::Block)
-      assert heading.context != :section
       assert_equal :floating_title, heading.context
       assert_equal '_independent_heading', heading.id
       assert doc.catalog[:ids].has_key?('_independent_heading')
@@ -827,7 +826,7 @@ text in standalone
         warnings = err.string
       end
 
-      assert !warnings.empty?
+      refute_empty warnings
       assert_match(/only book doctypes can contain level 0 sections/, warnings)
     end
 
@@ -864,7 +863,7 @@ Master section text.
         warnings = err.string
       end
 
-      assert warnings.empty?
+      assert_empty warnings
       assert_match(/Master document written by Doc Writer/, output)
       assert_match(/Standalone document written by Junior Writer/, output)
       assert_xpath '//*[@class="sect1"]/h2[text() = "Standalone Document"]', output, 1
@@ -2769,7 +2768,7 @@ intro
       end
 
       refute_nil warnings
-      assert !warnings.empty?
+      refute_empty warnings
       assert_match(/ERROR:.*section/, warnings)
     end
 
@@ -2856,7 +2855,7 @@ Appendix subsection content
         output = render_string input, :backend => 'docbook'
         warnings = err.string
       end
-      assert warnings.empty?
+      assert_empty warnings
       assert_xpath '/book/preface', output, 1
       assert_xpath '/book/preface/section', output, 1
       assert_xpath '/book/part', output, 1

--- a/test/substitutions_test.rb
+++ b/test/substitutions_test.rb
@@ -796,7 +796,7 @@ context 'Substitutions' do
     test 'should not match an inline image macro if target contains an endline character' do
       para = block_from_string(%(Fear not. There are no image:big\ncats.png[] around here.))
       result = para.sub_macros(para.source)
-      assert !result.include?('<img ')
+      refute result.include?('<img ')
       assert_includes result, %(image:big\ncats.png[])
     end
 
@@ -804,7 +804,7 @@ context 'Substitutions' do
       ['image: big cats.png[]', 'image:big cats.png []'].each do |input|
         para = block_from_string %(Fear not. There are no #{input} around here.)
         result = para.sub_macros(para.source)
-        assert !result.include?('<img ')
+        refute result.include?('<img ')
         assert_includes result, input
       end
     end
@@ -812,7 +812,7 @@ context 'Substitutions' do
     test 'should not detect a block image macro found inline' do
       para = block_from_string(%(Not an inline image macro image::tiger.png[].))
       result = para.sub_macros(para.source)
-      assert !result.include?('<img ')
+      refute result.include?('<img ')
       assert result.include?('image::tiger.png[]')
     end
 
@@ -827,7 +827,7 @@ context 'Substitutions' do
       end
       assert sect.document.catalog[:images].include? 'fixtures/dot.gif'
       refute_nil warnings
-      assert warnings.empty?
+      assert_empty warnings
     end
 
     test 'an icon macro should be interpreted as an icon if icons are enabled' do
@@ -866,7 +866,7 @@ context 'Substitutions' do
       assert_equal 1, para.document.catalog[:footnotes].size
       footnote = para.document.catalog[:footnotes].first
       assert_equal 1, footnote.index
-      assert footnote.id.nil?
+      assert_nil footnote.id
       assert_equal 'An example footnote.', footnote.text
     end
 
@@ -876,7 +876,7 @@ context 'Substitutions' do
       assert_equal 1, para.document.catalog[:footnotes].size
       footnote = para.document.catalog[:footnotes].first
       assert_equal 1, footnote.index
-      assert footnote.id.nil?
+      assert_nil footnote.id
       assert_equal "An example footnote with wrapped text.", footnote.text
     end
 
@@ -966,11 +966,11 @@ foofootnote:[+http://example.com+]barfootnote:[+http://acme.com+]baz
       assert_equal 2, para.document.catalog[:footnotes].size
       footnote1 = para.document.catalog[:footnotes][0]
       assert_equal 1, footnote1.index
-      assert footnote1.id.nil?
+      assert_nil footnote1.id
       assert_equal "An example footnote.", footnote1.text
       footnote2 = para.document.catalog[:footnotes][1]
       assert_equal 2, footnote2.index
-      assert footnote2.id.nil?
+      assert_nil footnote2.id
       assert_equal "Another footnote.", footnote2.text
     end
 
@@ -1412,7 +1412,7 @@ EOS
       assert_equal Asciidoctor::Substitutors::PASS_START + '0' + Asciidoctor::Substitutors::PASS_END, result
       assert_equal 1, para.passthroughs.size
       assert_equal '<code>inline code</code>', para.passthroughs[0][:text]
-      assert para.passthroughs[0][:subs].empty?
+      assert_empty para.passthroughs[0][:subs]
     end
 
     test 'collect multi-line inline triple plus passthroughs' do
@@ -1421,7 +1421,7 @@ EOS
       assert_equal Asciidoctor::Substitutors::PASS_START + '0' + Asciidoctor::Substitutors::PASS_END, result
       assert_equal 1, para.passthroughs.size
       assert_equal "<code>inline\ncode</code>", para.passthroughs[0][:text]
-      assert para.passthroughs[0][:subs].empty?
+      assert_empty para.passthroughs[0][:subs]
     end
 
     test 'collect inline double dollar passthroughs' do
@@ -1843,17 +1843,17 @@ foo&#8201;&#8212;&#8201;'
     test 'should not use subs if subs option passed to block constructor is nil' do
       doc = empty_document
       block = Asciidoctor::Block.new doc, :paragraph, :source => '*bold* _italic_', :subs => nil, :attributes => {'subs' => 'quotes'}
-      assert block.subs.empty?
+      assert_empty block.subs
       block.lock_in_subs
-      assert block.subs.empty?
+      assert_empty block.subs
     end
 
     test 'should not use subs if subs option passed to block constructor is empty array' do
       doc = empty_document
       block = Asciidoctor::Block.new doc, :paragraph, :source => '*bold* _italic_', :subs => [], :attributes => {'subs' => 'quotes'}
-      assert block.subs.empty?
+      assert_empty block.subs
       block.lock_in_subs
-      assert block.subs.empty?
+      assert_empty block.subs
     end
 
     test 'should use subs from subs option passed to block constructor' do
@@ -1867,7 +1867,7 @@ foo&#8201;&#8212;&#8201;'
     test 'should use subs from subs attribute if subs option is not passed to block constructor' do
       doc = empty_document
       block = Asciidoctor::Block.new doc, :paragraph, :source => '*bold* _italic_', :attributes => {'subs' => 'quotes'}
-      assert block.subs.empty?
+      assert_empty block.subs
       # in this case, we have to call lock_in_subs to resolve the subs
       block.lock_in_subs
       assert_equal [:quotes], block.subs

--- a/test/tables_test.rb
+++ b/test/tables_test.rb
@@ -1052,11 +1052,11 @@ output file name is used.
       EOS
       doc = document_from_string input
       table = doc.blocks.first
-      assert !table.nil?
+      refute_nil table
       tbody = table.rows.body
       assert_equal 2, tbody.size
       body_cell_1_3 = tbody[0][2]
-      assert !body_cell_1_3.inner_document.nil?
+      refute_nil body_cell_1_3.inner_document
       assert body_cell_1_3.inner_document.nested?
       assert_equal doc, body_cell_1_3.inner_document.parent_document
       assert_equal doc.converter, body_cell_1_3.inner_document.converter


### PR DESCRIPTION
- replace assert ! with refute
- use assert_nil and refute_nil
- use assert_empty and refute_empty
- use assert_kind_of instead of direct is_a? call
- use assert_respond_to instead of direct respond_to? call