### PR TITLE
Pass env var BUILD_REASON=UPDATE_UPSTREAM to downstream builds

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -154,7 +154,18 @@ desc 'Trigger builds for all dependent projects on Travis CI'
       if (commit_hash = ENV['TRAVIS_COMMIT'])
         commit_memo = %( (#{commit_hash.slice 0, 8})\\n\\nhttps://github.com/#{ENV['TRAVIS_REPO_SLUG'] || 'asciidoctor/asciidoctor'}/commit/#{commit_hash})
       end
-      payload = %({ "request": { "branch": "#{branch}", "message": "Build triggered by Asciidoctor#{commit_memo}" } })
+      payload = %({ 
+                    "request": { 
+                      "branch": "#{branch}", 
+                      "message": "Build triggered by Asciidoctor#{commit_memo}", 
+                      "config": {
+                        "merge_mode": "deep_merge",
+                        "env": {
+                          "BUILD_REASON": "UPDATE_UPSTREAM"
+                        }
+                      }
+                    } 
+                  })
       (http = Net::HTTP.new 'api.travis-ci.org', 443).use_ssl = true
       request = Net::HTTP::Post.new %(/repo/#{org}%2F#{name}/requests), header
       request.body = payload


### PR DESCRIPTION
If I understood correctly we are still looking for a way to let downstream builds only run against the latest upstream version when Asciidoctor is built. (https://github.com/asciidoctor/asciidoctor.js/issues/363)

Therefore this PR adds an env variable to the downstream builds `BUILD_REASON=UPDATE_UPSTREAM` that would allow the downstream builds to detect that only a build against the current upstream is necessary.

I think in AsciidoctorJ it should be easily possible to skip the "normal" build when this var is set.
I didn't find how the upstream build is done in Asciidoctor.js, but I guess it should be possible there as well to consider this.

I could not test this, therefore I hope that it works and that I didn't add any error.