### PR TITLE
resolves #2369 add XML circumfix comments to .js and .ts files

### DIFF
--- a/lib/asciidoctor.rb
+++ b/lib/asciidoctor.rb
@@ -363,7 +363,7 @@ module Asciidoctor
   CIRCUMFIX_COMMENTS = {
     ['/*', '*/'] => ['.css'],
     ['(*', '*)'] => ['.ml', '.mli', '.nb'],
-    ['<!--', '-->'] => ['.html', '.xhtml', '.xml', '.xsl'],
+    ['<!--', '-->'] => ['.html', '.xhtml', '.xml', '.xsl', '.js', '.ts'],
     ['<%--', '--%>'] => ['.asp', '.jsp']
   }.inject({}) {|accum, (affixes, exts)|
     exts.each {|ext| accum[ext] = { :prefix => affixes[0], :suffix => affixes[-1] } }


### PR DESCRIPTION
- JavaScript / TypeScript often have embedded HTML, so treat as XML files