### PR TITLE
update nokogiri to 1.8.0 for ruby >= 2.1

### DIFF
--- a/asciidoctor.gemspec
+++ b/asciidoctor.gemspec
@@ -34,7 +34,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'erubis', '~> 2.7.0'
   # haml is needed for testing custom templates
   s.add_development_dependency 'haml', '~> 5.0.0'
-  s.add_development_dependency 'nokogiri', '~> 1.7.0'
+  s.add_development_dependency 'nokogiri', '~> 1.8.0'
   s.add_development_dependency 'rake', '~> 10.0.0'
   s.add_development_dependency 'rspec-expectations', '~> 2.14.0'
   # slim is needed for testing custom templates


### PR DESCRIPTION
This fixes dependencies installation on Windows with ruby >= 2.4.