### PR TITLE
resolves #2398 automatically assign parent reference when adding node to parent

### DIFF
--- a/lib/asciidoctor/abstract_block.rb
+++ b/lib/asciidoctor/abstract_block.rb
@@ -239,8 +239,7 @@ class AbstractBlock < AbstractNode
   #
   # Returns The parent Block
   def << block
-    # parent assignment pending refactor
-    #block.parent = self
+    block.parent = self unless block.parent == self
     @blocks << block
     self
   end

--- a/lib/asciidoctor/abstract_node.rb
+++ b/lib/asciidoctor/abstract_node.rb
@@ -47,7 +47,7 @@ class AbstractNode
   # parent - The Block to set as the parent of this Block
   #
   # Returns nothing
-  def parent=(parent)
+  def parent= parent
     @parent, @document = parent, parent.document
     nil
   end


### PR DESCRIPTION
- automatically assign parent node in << method on block
- only use << method internally when functionality is needed