### PR TITLE
Fixes #2430

### DIFF
--- a/lib/asciidoctor.rb
+++ b/lib/asciidoctor.rb
@@ -363,7 +363,7 @@ module Asciidoctor
   CIRCUMFIX_COMMENTS = {
     ['/*', '*/'] => ['.css'],
     ['(*', '*)'] => ['.ml', '.mli', '.nb'],
-    ['<!--', '-->'] => ['.html', '.xhtml', '.xml', '.xsl'],
+    ['<!--', '-->'] => ['.html', '.xhtml', '.xml', '.xsl', '.plist'],
     ['<%--', '--%>'] => ['.asp', '.jsp']
   }.inject({}) {|accum, (affixes, exts)|
     exts.each {|ext| accum[ext] = { :prefix => affixes[0], :suffix => affixes[-1] } }


### PR DESCRIPTION
This simply adds '.plist' as an extension that can contain XML-like comments (after all, Property Lists can be and usually are XML files.)