### PR TITLE
resolves #2405 add compliance setting to disable natural cross references

### DIFF
--- a/features/xref.feature
+++ b/features/xref.feature
@@ -593,7 +593,7 @@ Feature: Cross References
         .paragraph: p Instructions go here.
     """
 
-    Scenario: Create a cross reference using the target section title
+    Scenario: Create a cross reference using the title of the target section
     Given the AsciiDoc source
       """
       == Section One
@@ -617,7 +617,7 @@ Feature: Cross References
           a< href='#_section_one' Section One
       """
 
-    Scenario: Create a natural cross reference using the reftext of the target section
+    Scenario: Create a cross reference using the reftext of the target section
     Given the AsciiDoc source
       """
       [reftext="the first section"]
@@ -654,7 +654,7 @@ Feature: Cross References
           xref< linkend='_section_one'/
       """
 
-    Scenario: Create a cross reference using the formatted target title
+    Scenario: Create a cross reference using the formatted title of the target section
     Given the AsciiDoc source
       """
       == Section *One*
@@ -677,4 +677,31 @@ Feature: Cross References
         .sectionbody: .paragraph: p
           |refer to
           a< href='#_section_strong_one_strong' Section <strong>One</strong>
+      """
+
+    Scenario: Does not process a natural cross reference in compat mode
+    Given the AsciiDoc source
+      """
+      :compat-mode:
+
+      == Section One
+
+      content
+
+      == Section Two
+
+      refer to <<Section One>>
+      """
+    When it is converted to html
+    Then the result should match the HTML structure
+      """
+      .sect1
+        h2#_section_one
+          |Section One
+        .sectionbody: .paragraph: p content
+      .sect1
+        h2#_section_two Section Two
+        .sectionbody: .paragraph: p
+          |refer to
+          a< href='#Section One' [Section One]
       """

--- a/lib/asciidoctor.rb
+++ b/lib/asciidoctor.rb
@@ -170,6 +170,11 @@ module Asciidoctor
     # Compliance value: false
     define :shorthand_property_syntax, true
 
+    # Asciidoctor will attempt to resolve the target of a cross reference by
+    # matching its reference text (reftext or title) (e.g., <<Section Title>>)
+    # Compliance value: false
+    define :natural_xrefs, true
+
     # Asciidoctor will start counting at the following number
     # when creating a unique id when there is a conflict
     # Compliance value: 2

--- a/lib/asciidoctor/substitutors.rb
+++ b/lib/asciidoctor/substitutors.rb
@@ -1068,7 +1068,8 @@ module Substitutors
         else
           # resolve fragment as reftext if it's not a known ID and resembles reftext (includes space or has uppercase char)
           unless @document.catalog[:ids].key? fragment
-            if ((fragment.include? ' ') || fragment.downcase != fragment) &&
+            if Compliance.natural_xrefs && !@document.compat_mode &&
+                ((fragment.include? ' ') || fragment.downcase != fragment) &&
                 (resolved_id = @document.catalog[:ids].key fragment)
               fragment = resolved_id
             elsif $VERBOSE


### PR DESCRIPTION

- add Compliance.natural_xrefs
- don't resolve xref by reference text if compat-mode is on
- don't resolve xref by reference text if compliance setting is disabled
- add test scenario
- rename scenarios related to natural xrefs