### PR TITLE
Have parse_section_title turn off Markdown compliance on seeing = header

### DIFF
--- a/lib/asciidoctor/parser.rb
+++ b/lib/asciidoctor/parser.rb
@@ -1706,6 +1706,9 @@ class Parser
 
     if Compliance.markdown_syntax ? ((line1.start_with? '=', '#') && ExtAtxSectionTitleRx =~ line1) :
         ((line1.start_with? '=') && AtxSectionTitleRx =~ line1)
+      if (line1.start_with? '=')
+          Compliance.markdown_syntax = false
+      end
       # NOTE level is 1 less than number of line markers
       sect_level, sect_title, atx = $1.length - 1, $2, true
       if sect_title.end_with?(']]') && InlineSectionAnchorRx =~ sect_title && !$1 # escaped

--- a/test/blocks_test.rb
+++ b/test/blocks_test.rb
@@ -357,12 +357,14 @@ A famous quote.
 > A famous quote.
 > Some more inspiring words.
       EOS
+      Asciidoctor::Compliance.markdown_syntax = true
       output = render_string input
       assert_css '.quoteblock', output, 1
       assert_css '.quoteblock > blockquote', output, 1
       assert_css '.quoteblock > blockquote > .paragraph > p', output, 1
       assert_css '.quoteblock > .attribution', output, 0
       assert_xpath %(//*[@class = "quoteblock"]//p[text() = "A famous quote.\nSome more inspiring words."]), output, 1
+      Asciidoctor::Compliance.markdown_syntax = false
     end
 
     test 'lazy markdown-style quote block with single paragraph and no attribution' do
@@ -370,12 +372,14 @@ A famous quote.
 > A famous quote.
 Some more inspiring words.
       EOS
+      Asciidoctor::Compliance.markdown_syntax = true
       output = render_string input
       assert_css '.quoteblock', output, 1
       assert_css '.quoteblock > blockquote', output, 1
       assert_css '.quoteblock > blockquote > .paragraph > p', output, 1
       assert_css '.quoteblock > .attribution', output, 0
       assert_xpath %(//*[@class = "quoteblock"]//p[text() = "A famous quote.\nSome more inspiring words."]), output, 1
+      Asciidoctor::Compliance.markdown_syntax = false
     end
 
     test 'markdown-style quote block with multiple paragraphs and no attribution' do
@@ -384,6 +388,7 @@ Some more inspiring words.
 >
 > Some more inspiring words.
       EOS
+      Asciidoctor::Compliance.markdown_syntax = true
       output = render_string input
       assert_css '.quoteblock', output, 1
       assert_css '.quoteblock > blockquote', output, 1
@@ -391,6 +396,7 @@ Some more inspiring words.
       assert_css '.quoteblock > .attribution', output, 0
       assert_xpath %((//*[@class = "quoteblock"]//p)[1][text() = "A famous quote."]), output, 1
       assert_xpath %((//*[@class = "quoteblock"]//p)[2][text() = "Some more inspiring words."]), output, 1
+      Asciidoctor::Compliance.markdown_syntax = false
     end
 
     test 'markdown-style quote block with multiple blocks and no attribution' do
@@ -399,6 +405,7 @@ Some more inspiring words.
 >
 > NOTE: Some more inspiring words.
       EOS
+      Asciidoctor::Compliance.markdown_syntax = true
       output = render_string input
       assert_css '.quoteblock', output, 1
       assert_css '.quoteblock > blockquote', output, 1
@@ -407,6 +414,7 @@ Some more inspiring words.
       assert_css '.quoteblock > .attribution', output, 0
       assert_xpath %((//*[@class = "quoteblock"]//p)[1][text() = "A famous quote."]), output, 1
       assert_xpath %((//*[@class = "quoteblock"]//*[@class = "admonitionblock note"]//*[@class="content"])[1][normalize-space(text()) = "Some more inspiring words."]), output, 1
+      Asciidoctor::Compliance.markdown_syntax = false
     end
 
     test 'markdown-style quote block with single paragraph and attribution' do
@@ -415,6 +423,7 @@ Some more inspiring words.
 > Some more inspiring words.
 > -- Famous Person, Famous Source, Volume 1 (1999)
       EOS
+      Asciidoctor::Compliance.markdown_syntax = true
       output = render_string input
       assert_css '.quoteblock', output, 1
       assert_css '.quoteblock > blockquote', output, 1
@@ -427,6 +436,7 @@ Some more inspiring words.
       attribution = xmlnodes_at_xpath '//*[@class = "quoteblock"]/*[@class = "attribution"]', output, 1
       author = attribution.children.first
       assert_equal "#{decode_char 8212} Famous Person", author.text.strip
+      Asciidoctor::Compliance.markdown_syntax = false
     end
 
     test 'should parse credit line in markdown-style quote block like positional block attributes' do
@@ -436,9 +446,11 @@ Some more inspiring words.
 -- Thomas Jefferson, https://jeffersonpapers.princeton.edu/selected-documents/james-madison-1[The Papers of Thomas Jefferson, Volume 11]
       EOS
 
+      Asciidoctor::Compliance.markdown_syntax = true
       output = render_embedded_string input
       assert_css '.quoteblock', output, 1
       assert_css '.quoteblock cite a[href="https://jeffersonpapers.princeton.edu/selected-documents/james-madison-1"]', output, 1
+      Asciidoctor::Compliance.markdown_syntax = false
     end
 
     test 'quoted paragraph-style quote block with attribution' do
@@ -2486,10 +2498,12 @@ puts "Hello, World!"
 ```
       EOS
 
+      Asciidoctor::Compliance.markdown_syntax = true
       output = render_embedded_string input
       assert_css '.listingblock', output, 1
       assert_css '.listingblock pre code', output, 1
       assert_css '.listingblock pre code:not([class])', output, 1
+      Asciidoctor::Compliance.markdown_syntax = false
     end
 
     test 'should not recognize fenced code blocks with more than three delimiters' do
@@ -2518,10 +2532,12 @@ alert("Hello, World!")
 ```
       EOS
 
+      Asciidoctor::Compliance.markdown_syntax = true
       output = render_embedded_string input
       assert_css '.listingblock', output, 2
       assert_css '.listingblock pre code.language-ruby[data-lang=ruby]', output, 1
       assert_css '.listingblock pre code.language-javascript[data-lang=javascript]', output, 1
+      Asciidoctor::Compliance.markdown_syntax = false
     end
 
     test 'should support fenced code blocks with languages and numbering' do
@@ -2535,10 +2551,12 @@ alert("Hello, World!")
 ```
       EOS
 
+      Asciidoctor::Compliance.markdown_syntax = true
       output = render_embedded_string input
       assert_css '.listingblock', output, 2
       assert_css '.listingblock pre code.language-ruby[data-lang=ruby]', output, 1
       assert_css '.listingblock pre code.language-javascript[data-lang=javascript]', output, 1
+      Asciidoctor::Compliance.markdown_syntax = false
     end
 
     test 'should highlight source if source-highlighter attribute is coderay' do

--- a/test/document_test.rb
+++ b/test/document_test.rb
@@ -1141,11 +1141,13 @@ content
       input = <<-EOS
 ---
       EOS
+      Asciidoctor::Compliance.markdown_syntax = true
       doc = document_from_string input, :safe => :safe, :attributes => { 'htmlsyntax' => 'xml' }
       assert_equal 'html5', doc.backend
       assert_equal 'xml', (doc.attr 'htmlsyntax')
       result = doc.convert :header_footer => false
       assert_equal '<hr/>', result
+      Asciidoctor::Compliance.markdown_syntax = false
     end
 
     test 'honor htmlsyntax attribute in document header if followed by backend attribute' do
@@ -1155,11 +1157,13 @@ content
 
 ---
       EOS
+      Asciidoctor::Compliance.markdown_syntax = true
       doc = document_from_string input, :safe => :safe
       assert_equal 'html5', doc.backend
       assert_equal 'xml', (doc.attr 'htmlsyntax')
       result = doc.convert :header_footer => false
       assert_equal '<hr/>', result
+      Asciidoctor::Compliance.markdown_syntax = false
     end
 
     test 'does not honor htmlsyntax attribute in document header if not followed by backend attribute' do
@@ -1169,8 +1173,10 @@ content
 
 ---
       EOS
+      Asciidoctor::Compliance.markdown_syntax = true
       result = render_embedded_string input, :safe => :safe
       assert_equal '<hr>', result
+      Asciidoctor::Compliance.markdown_syntax = false
     end
 
     test 'should close all short tags when htmlsyntax is xml' do

--- a/test/sections_test.rb
+++ b/test/sections_test.rb
@@ -557,16 +557,20 @@ content
       input = <<-EOS
 # Document Title
       EOS
+      Asciidoctor::Compliance.markdown_syntax = true
       output = render_string input
       assert_xpath "//h1[not(@id)][text() = 'Document Title']", output, 1
+      Asciidoctor::Compliance.markdown_syntax = false
     end
 
     test 'atx document title with symmetric markers' do
       input = <<-EOS
 # Document Title #
       EOS
+      Asciidoctor::Compliance.markdown_syntax = true
       output = render_string input
       assert_xpath "//h1[not(@id)][text() = 'Document Title']", output, 1
+      Asciidoctor::Compliance.markdown_syntax = false
     end
 
     test 'atx section title with leading marker' do
@@ -575,8 +579,10 @@ content
 
 blah blah
       EOS
+      Asciidoctor::Compliance.markdown_syntax = true
       output = render_string input
       assert_xpath "//h2[@id='_section_one'][text() = 'Section One']", output, 1
+      Asciidoctor::Compliance.markdown_syntax = false
     end
 
     test 'atx section title with symmetric markers' do
@@ -585,17 +591,21 @@ blah blah
 
 blah blah
       EOS
+      Asciidoctor::Compliance.markdown_syntax = true
       output = render_string input
       assert_xpath "//h2[@id='_section_one'][text() = 'Section One']", output, 1
+      Asciidoctor::Compliance.markdown_syntax = false
     end
 
     test 'should not match atx syntax with mixed markers' do
       input = <<-EOS
 =#= My Title
       EOS
+      Asciidoctor::Compliance.markdown_syntax = true
       output = render_embedded_string input
       assert_xpath "//h3[@id='_my_title'][text() = 'My Title']", output, 0
       assert_includes output, '<p>=#= My Title</p>'
+      Asciidoctor::Compliance.markdown_syntax = false
     end
   end
 

--- a/test/text_test.rb
+++ b/test/text_test.rb
@@ -118,11 +118,13 @@ This line is separated by a horizontal rule...
 
 ...from this line.
         EOS
+        Asciidoctor::Compliance.markdown_syntax = true
         output = render_embedded_string input
         assert_xpath "//hr", output, 1
         assert_xpath "/*[@class='paragraph']", output, 2
         assert_xpath "(/*[@class='paragraph'])[1]/following-sibling::hr", output, 1
         assert_xpath "/hr/following-sibling::*[@class='paragraph']", output, 1
+        Asciidoctor::Compliance.markdown_syntax = false
       end
     end
   end
@@ -151,8 +153,10 @@ This line is separated by something that is not a horizontal rule...
 
 ...from this line.
         EOS
+        Asciidoctor::Compliance.markdown_syntax = true
         output = render_embedded_string input
         assert_xpath '//hr', output, 0
+        Asciidoctor::Compliance.markdown_syntax = false
       end
     end
 


### PR DESCRIPTION
This addresses #2471.  Tests updated.