### PR TITLE
fix French translation of Appendix

### DIFF
--- a/data/locale/attributes-fr.adoc
+++ b/data/locale/attributes-fr.adoc
@@ -1,5 +1,5 @@
 // French translation, courtesy of Nicolas Comet <nicolas.comet@gmail.com>
-:appendix-caption: Appendice
+:appendix-caption: Annexe
 :appendix-refsig: {appendix-caption}
 :caution-caption: Avertissement
 //:chapter-label: ???


### PR DESCRIPTION
Appendix must translate to Annexe, not Appendice. Appendice exists but has other meanings.