### PR TITLE
Fix wrong `Asciidoctor::AbstractBlock#lineno` of nested lists and tables

### DIFF
--- a/lib/asciidoctor/parser.rb
+++ b/lib/asciidoctor/parser.rb
@@ -853,7 +853,8 @@ class Parser
         block = build_block(block_context, :compound, terminator, parent, reader, attributes)
 
       when :table
-        block_reader = Reader.new reader.read_lines_until(:terminator => terminator, :skip_line_comments => true), reader.cursor
+        cursor = reader.cursor
+        block_reader = Reader.new reader.read_lines_until(:terminator => terminator, :skip_line_comments => true), cursor
         # NOTE it's very rare that format is set when using a format hint char, so short-circuit
         unless terminator.start_with? '|', '!'
           # NOTE infer dsv once all other format hint chars are ruled out
@@ -1031,7 +1032,8 @@ class Parser
       block_reader = reader
     else
       lines = nil
-      block_reader = Reader.new reader.read_lines_until(:terminator => terminator, :skip_processing => skip_processing), reader.cursor
+      cursor = reader.cursor
+      block_reader = Reader.new reader.clone.read_lines_until(:terminator => terminator, :skip_processing => skip_processing), cursor
     end
 
     if content_model == :verbatim
@@ -1293,7 +1295,8 @@ class Parser
 
     # first skip the line with the marker / term
     reader.shift
-    list_item_reader = Reader.new read_lines_for_list_item(reader, list_type, sibling_trait, has_text), reader.cursor
+    cursor = reader.cursor
+    list_item_reader = Reader.new read_lines_for_list_item(reader, list_type, sibling_trait, has_text), cursor
     if list_item_reader.has_more_lines?
       # NOTE peek on the other side of any comment lines
       comment_lines = list_item_reader.skip_line_comments

--- a/test/lists_test.rb
+++ b/test/lists_test.rb
@@ -4588,4 +4588,20 @@ listing block in list item 1
     assert_equal '`three`', list.items[2].text
     assert_equal '<mark>four</mark>', list.items[3].text
   end
+
+  test 'lineno should return source line number where the list started' do
+    input = <<-EOS
+* bullet 1
+** bullet 1.1
+*** bullet 1.1.1
+* bullet 2
+    EOS
+    doc = document_from_string input, { :sourcemap => true }
+    list1 = (doc.find_by :context => :ulist).first
+    list2 = list1.items[0].blocks[0]
+    list3 = list2.items[0].blocks[0]
+    assert_equal 1, list1.lineno
+    assert_equal 2, list2.lineno
+    assert_equal 3, list3.lineno
+  end
 end

--- a/test/tables_test.rb
+++ b/test/tables_test.rb
@@ -1054,7 +1054,7 @@ DocBook outputs. If the input file is the standard input then the
 output file name is used.
 |===
       EOS
-      doc = document_from_string input
+      doc = document_from_string input, { :sourcemap => true }
       table = doc.blocks.first
       refute_nil table
       tbody = table.rows.body
@@ -1064,6 +1064,7 @@ output file name is used.
       assert body_cell_1_3.inner_document.nested?
       assert_equal doc, body_cell_1_3.inner_document.parent_document
       assert_equal doc.converter, body_cell_1_3.inner_document.converter
+      assert_equal 6, body_cell_1_3.inner_document.lineno
       output = doc.render
 
       assert_css 'table > tbody > tr', output, 2


### PR DESCRIPTION
`Asciidoctor::AbstractBlock#lineno` returns wrong line number for nested lists
and nested tables. This commit fixes the problem  (save `reader.cursor` as a
local variable before doing lookahead).

Example:

```ruby
require 'asciidoctor'
doc = Asciidoctor.load(<<EOF, sourcemap: true)
* foo
** bar
EOF
nested_list = doc.find_by(context: :ulist).last
puts nested_list.lineno # => 3 (expect 2)
```