### PR TITLE
Fix travis error (ruby-2.5.0, failed to uninstall bundler)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,14 +21,6 @@ env:
   global:
   # use system libraries to speed up installation of nokogiri
   - NOKOGIRI_USE_SYSTEM_LIBRARIES=true
-before_install:
-- >-
-  if [ "`rvm current`" == "ruby-2.5.0" ]; then
-  rvm use @global &&
-  gem uninstall -x --silent bundler &&
-  rvm use @ &&
-  gem install --silent bundler;
-  fi
 script: bundle exec rake coverage test:all
 after_success: bundle exec rake build:dependents
 #notifications:


### PR DESCRIPTION
`gem uninstall -x --silent bundler` causes erros ..., so I removed the `before_install:` (but, I don't know why this settings was necessary ..., the original PR is https://github.com/asciidoctor/asciidoctor/pull/2528 ).

----

https://travis-ci.org/asciidoctor/asciidoctor/jobs/334344979

```
...
$ ruby --version
ruby 2.5.0p0 (2017-12-25 revision 61468) [x86_64-linux]
$ rvm --version
rvm 1.29.3 (latest) by Michal Papis, Piotr Kuczynski, Wayne E. Seguin [https://rvm.io]
$ bundle --version
Bundler version 1.16.0
$ gem --version
2.7.4
1.25s$ if [ "`rvm current`" == "ruby-2.5.0" ]; then rvm use @global && gem uninstall -x --silent bundler && rvm use @ && gem install --silent bundler; fi
Using /home/travis/.rvm/gems/ruby-2.5.0 with gemset global
ERROR:  While executing gem ... (Gem::InstallError)
        gem "bundler" cannot be uninstalled because it is a default gem

The command "if [ "`rvm current`" == "ruby-2.5.0" ]; then rvm use @global && gem uninstall -x --silent bundler && rvm use @ && gem install --silent bundler; fi" failed and exited with 1 during .

Your build has been stopped.
```