### PR TITLE
base_dir can be a uri

### DIFF
--- a/lib/asciidoctor/document.rb
+++ b/lib/asciidoctor/document.rb
@@ -383,8 +383,12 @@ class Document < AbstractBlock
     # If the base_dir option is specified, it overrides docdir and used as the root for relative
     # paths. Otherwise, the base_dir is the directory of the source file (docdir), if set, or else
     # the current directory.
-    if options[:base_dir]
-      @base_dir = attr_overrides['docdir'] = ::File.expand_path(options[:base_dir])
+    if (base_dir_val = options[:base_dir])
+      @base_dir = attr_overrides['docdir'] = if Helpers.uriish? base_dir_val
+        ::URI.parse(base_dir_val)
+      else
+        ::File.expand_path(base_dir_val)
+      end
     elsif attr_overrides['docdir']
       @base_dir = attr_overrides['docdir']
     else

--- a/lib/asciidoctor/reader.rb
+++ b/lib/asciidoctor/reader.rb
@@ -836,11 +836,6 @@ class PreprocessorReader < Reader
       if @include_stack.size >= abs_maxdepth
         warn %(asciidoctor: ERROR: #{line_info}: maximum include depth of #{@maxdepth[:rel]} exceeded)
         return
-      elsif ::RUBY_ENGINE_OPAL && ::JAVASCRIPT_IO_MODULE == 'xmlhttprequest'
-        # NOTE resolves uri relative to currently loaded document
-        # NOTE we defer checking if file exists and catch the 404 error if it does not
-        target_type = :file
-        inc_path = relpath = @include_stack.empty? && ::Dir.pwd == @document.base_dir ? target : %(#{@dir}/#{target})
       elsif (Helpers.uriish? target) || ((::URI === @dir) && (target = %(#{@dir}/#{target})))
         unless @document.attributes.key? 'allow-uri-read'
           replace_next_line %(link:#{target}[])

--- a/test/reader_test.rb
+++ b/test/reader_test.rb
@@ -826,6 +826,31 @@ include::#{url}[]
         end
       end
 
+      test 'relative uri should be resolved using the base_dir' do
+        input = <<-EOS
+....
+include::asciidoctor[]
+....
+        EOS
+
+        begin
+          output = warnings = nil
+          redirect_streams do |_, err|
+            output = using_test_webserver do
+              render_embedded_string input,
+                                     :safe => :safe,
+                                     :base_dir => "http://#{resolve_localhost}:9876/name",
+                                     :attributes => {'allow-uri-read' => ''}
+            end
+            warnings = err.string
+          end
+          refute_nil output
+          assert_match(/\{"name": "asciidoctor"\}/, output)
+        rescue
+          flunk 'include directive should not raise exception on relative uri'
+        end
+      end
+
       test 'include directive supports line selection' do
         input = <<-EOS
 include::fixtures/include-file.asciidoc[lines=1;3..4;6..-1]


### PR DESCRIPTION
If `base_dir` is an URI, use `URI.parse` instead of `::File.expand_path`. Otherwise the current working directory will be prepended to the URI (thus making the `base_dir` invalid and unusable).

Also remove the special condition for Opal and `xmlhttprequest ` since it's not required anymore.

Ref: 
- https://github.com/asciidoctor/asciidoctor-browser-extension/issues/210
- https://github.com/asciidoctor/asciidoctor.js/pull/384
- https://github.com/asciidoctor/asciidoctor.js/issues/382