### PR TITLE
resolves #2567 duplicate header attributes when restoring

### DIFF
--- a/lib/asciidoctor/document.rb
+++ b/lib/asciidoctor/document.rb
@@ -869,8 +869,7 @@ class Document < AbstractBlock
   # Internal: Restore the attributes to the previously saved state (attributes in header)
   def restore_attributes
     @catalog[:callouts].rewind unless @parent_document
-    # QUESTION shouldn't this be a dup in case we convert again?
-    @attributes = @header_attributes
+    @attributes.replace @header_attributes
   end
 
   # Internal: Delete any attributes stored for playback

--- a/test/api_test.rb
+++ b/test/api_test.rb
@@ -212,6 +212,25 @@ idseparator=-')
       end
     end
 
+    test 'should be able to restore header attributes after call to convert' do
+      input = <<-EOS
+= Document Title
+:foo: bar
+
+content
+
+:foo: baz
+
+content
+      EOS
+      doc = Asciidoctor.load input
+      assert_equal 'bar', (doc.attr 'foo')
+      doc.convert
+      assert_equal 'baz', (doc.attr 'foo')
+      doc.restore_attributes
+      assert_equal 'bar', (doc.attr 'foo')
+    end
+
     test 'should track file and line information with blocks if sourcemap option is set' do
       doc = Asciidoctor.load_file fixture_path('sample.asciidoc'), :sourcemap => true
 


### PR DESCRIPTION
- when restoring attributes, duplicate header attributes
- allow header attributes to be restored an arbitrary number of times