### PR TITLE
resolves #1365 allow table stripes to be configured using stripe option on table

### DIFF
--- a/data/stylesheets/asciidoctor-default.css
+++ b/data/stylesheets/asciidoctor-default.css
@@ -257,6 +257,8 @@ table.grid-all>tbody>tr:last-child>.tableblock,table.grid-all>thead:last-child>t
 table.frame-all{border-width:1px}
 table.frame-sides{border-width:0 1px}
 table.frame-topbot{border-width:1px 0}
+table.stripe-all tr,table.stripe-odd tr:nth-of-type(odd){background:#f8f8f7}
+table.stripe-none tr,table.stripe-odd tr:nth-of-type(even){background:none}
 th.halign-left,td.halign-left{text-align:left}
 th.halign-right,td.halign-right{text-align:right}
 th.halign-center,td.halign-center{text-align:center}

--- a/lib/asciidoctor/converter/html5.rb
+++ b/lib/asciidoctor/converter/html5.rb
@@ -778,6 +778,9 @@ Your browser does not support the audio tag.
       result = []
       id_attribute = node.id ? %( id="#{node.id}") : ''
       classes = ['tableblock', %(frame-#{node.attr 'frame', 'all'}), %(grid-#{node.attr 'grid', 'all'})]
+      if (stripe = node.attr 'stripe')
+        classes << %(stripe-#{stripe})
+      end
       styles = []
       unless (node.option? 'autowidth') && !(node.attr? 'width', nil, false)
         if node.attr? 'tablepcwidth', 100


### PR DESCRIPTION
- valid values are even, odd, all, and none
- not set by default; implies stripes on even rows
- requires support from stylesheet