### PR TITLE
resolves #2568 collapse bottom margin of last block in AsciiDoc table cell

### DIFF
--- a/data/stylesheets/asciidoctor-default.css
+++ b/data/stylesheets/asciidoctor-default.css
@@ -245,7 +245,8 @@ table.pyhltable .linenodiv{background:none!important;padding-right:0!important}
 .quoteblock.abstract blockquote,.quoteblock.abstract blockquote p{text-align:left;word-spacing:0}
 .quoteblock.abstract blockquote::before,.quoteblock.abstract blockquote p:first-of-type::before{display:none}
 table.tableblock{max-width:100%;border-collapse:separate}
-table.tableblock td>.paragraph:last-child p>p:last-child,table.tableblock th>p:last-child,table.tableblock td>p:last-child{margin-bottom:0}
+p.tableblock:last-child{margin-bottom:0}
+td.tableblock>.content{margin-bottom:-1.25em}
 table.tableblock,th.tableblock,td.tableblock{border:0 solid #dedede}
 table.grid-all>thead>tr>.tableblock,table.grid-all>tbody>tr>.tableblock{border-width:0 1px 1px 0}
 table.grid-all>tfoot>tr>.tableblock{border-width:1px 1px 0 0}

--- a/features/xref.feature
+++ b/features/xref.feature
@@ -583,7 +583,7 @@ Feature: Cross References
       tbody
         tr
           td.tableblock.halign-left.valign-top
-            div
+            div.content
               .paragraph: p
                 |See
                 a< href='#_install' Install

--- a/lib/asciidoctor/converter/html5.rb
+++ b/lib/asciidoctor/converter/html5.rb
@@ -830,7 +830,7 @@ Your browser does not support the audio tag.
               else
                 case cell.style
                 when :asciidoc
-                  cell_content = %(<div>#{cell.content}</div>)
+                  cell_content = %(<div class="content">#{cell.content}</div>)
                 when :verse
                   cell_content = %(<div class="verse">#{cell.text}</div>)
                 when :literal

--- a/test/tables_test.rb
+++ b/test/tables_test.rb
@@ -947,7 +947,7 @@ third paragraph
       assert_xpath %((//p[@class="tableblock"])[3][text()="third paragraph"]), result, 1
     end
 
-    test 'basic asciidoc cell' do
+    test 'basic AsciiDoc cell' do
       input = <<-EOS
 |===
 a|--
@@ -966,7 +966,19 @@ content
       assert_css 'table.tableblock td.tableblock .openblock .paragraph', result, 1
     end
 
-    test 'doctype can be set in asciidoc table cell' do
+    test 'AsciiDoc table cell should be wrapped in div with class "content"' do
+      input = <<-EOS
+|===
+a|AsciiDoc table cell
+|===
+      EOS
+
+      result = render_embedded_string input
+      assert_css 'table.tableblock td.tableblock > div.content', result, 1
+      assert_css 'table.tableblock td.tableblock > div.content > div.paragraph', result, 1
+    end
+
+    test 'doctype can be set in AsciiDoc table cell' do
       input = <<-EOS
 |===
 a|
@@ -1028,7 +1040,7 @@ doctype={doctype}
       assert_includes result, '{backend-html5-doctype-article}'
     end
 
-    test 'asciidoc content' do
+    test 'AsciiDoc content' do
       input = <<-EOS
 [cols="1e,1,5a",frame="topbot",options="header"]
 |===


### PR DESCRIPTION

- add content class to div surrounding AsciiDoc cell content
- collapse bottom margin of last block in AsciiDoc table cell
- simplify margin collapsing on last paragraph in normal cell
- remove unused styles
- update tests