### PR TITLE
resolves #2599 and #2602 correctly resolve includes in browser environment

### DIFF
--- a/lib/asciidoctor/document.rb
+++ b/lib/asciidoctor/document.rb
@@ -387,11 +387,7 @@ class Document < AbstractBlock
     # paths. Otherwise, the base_dir is the directory of the source file (docdir), if set, otherwise
     # the current directory.
     if (base_dir_val = options[:base_dir])
-      if ::RUBY_ENGINE_OPAL && ::JAVASCRIPT_IO_MODULE == 'xmlhttprequest' && (Helpers.uriish? base_dir_val)
-        @base_dir = attr_overrides['docdir'] = base_dir_val
-      else
-        @base_dir = (attr_overrides['docdir'] = ::File.expand_path base_dir_val)
-      end
+      @base_dir = (attr_overrides['docdir'] = ::File.expand_path base_dir_val)
     elsif attr_overrides['docdir']
       @base_dir = attr_overrides['docdir']
     else

--- a/lib/asciidoctor/reader.rb
+++ b/lib/asciidoctor/reader.rb
@@ -836,10 +836,40 @@ class PreprocessorReader < Reader
         warn %(asciidoctor: ERROR: #{line_info}: maximum include depth of #{@maxdepth[:rel]} exceeded)
         return
       elsif ::RUBY_ENGINE_OPAL && ::JAVASCRIPT_IO_MODULE == 'xmlhttprequest'
-        # NOTE resolves uri relative to currently loaded document
-        # NOTE we defer checking if file exists and catch the 404 error if it does not
-        target_type = :file
-        inc_path = relpath = @include_stack.empty? && ::Dir.pwd == @document.base_dir ? target : %(#{@dir}/#{target})
+        # NOTE when the IO module is xmlhttprequest, the only way to check if the file exists is to catch a 404 response
+        p_target = (@path_resolver ||= PathResolver.new '\\').posixify target
+        target_type, base_dir = :file, @document.base_dir
+        if p_target.start_with? 'file://'
+          inc_path = relpath = p_target
+        elsif Helpers.uriish? p_target
+          unless (@path_resolver.descends_from? p_target, base_dir) || (@document.attributes.key? 'allow-uri-read')
+            return replace_next_line %(link:#{target}[])
+          end
+          inc_path = relpath = p_target
+        elsif @path_resolver.absolute_path? p_target
+          inc_path = relpath = %(file://#{(p_target.start_with? '/') ? '' : '/'}#{p_target})
+        elsif (ctx_dir = (top_level = @include_stack.empty?) ? base_dir : @dir) == '.'
+          # WARNING relative include won't work in the Firefox web extension (unless we use the second line)
+          inc_path = relpath = p_target
+          #inc_path = %(#{File.dirname `window.location.href`}/#{relpath = p_target})
+        elsif (ctx_dir.start_with? 'file://') || !(Helpers.uriish? ctx_dir)
+          # WARNING relative nested include won't work in the Firefox web extension if base_dir is '.'
+          inc_path = %(#{ctx_dir}/#{p_target})
+          if top_level
+            relpath = p_target
+          elsif base_dir == '.' || !(offset = @path_resolver.descends_from? inc_path, base_dir)
+            relpath = inc_path
+          else
+            relpath = inc_path.slice offset, inc_path.length
+          end
+        elsif top_level
+          inc_path = %(#{ctx_dir}/#{relpath = p_target})
+        elsif (offset = @path_resolver.descends_from? ctx_dir, base_dir) || (@document.attributes.key? 'allow-uri-read')
+          inc_path = %(#{ctx_dir}/#{p_target})
+          relpath = offset ? (inc_path.slice offset, inc_path.length) : p_target
+        else
+          return replace_next_line %(link:#{target}[])
+        end
       elsif (Helpers.uriish? target) || ((::URI === @dir) && (target = %(#{@dir}/#{target})))
         return replace_next_line %(link:#{target}[]) unless @document.attributes.key? 'allow-uri-read'
         if @document.attributes.key? 'cache-uri'


### PR DESCRIPTION
- add PathResolver#absolute_path? method
- isolate PathResolver#root? implementation for xmlhttprequest IO module
- add PathResolver#descends_from? helper
- initialize PathResolver to handle both both forward and backslashes in path
- always posixify target
- handle target with file:// prefix first
- don't modify target if it's a URL 
- enforce allow-uri-read restriction if target is a URL and doesn't descend from base_dir
- add file:// scheme to absolute path (xmlhttrequest IO module)
- resolve include path for top-level relative include
- resolve include path for nested relative include
- check allow-uri-read if nested include comes from a document w/ different origin as base_dir