### PR TITLE
Add source and manual attrs for manpage

### DIFF
--- a/lib/asciidoctor/converter/docbook5.rb
+++ b/lib/asciidoctor/converter/docbook5.rb
@@ -730,6 +730,12 @@ module Asciidoctor
         result << '<refmeta>'
         result << %(<refentrytitle>#{doc.attr 'mantitle'}</refentrytitle>) if doc.attr? 'mantitle'
         result << %(<manvolnum>#{doc.attr 'manvolnum'}</manvolnum>) if doc.attr? 'manvolnum'
+        if doc.attr? 'mansource'
+          result << %(<refmiscinfo class="source">#{doc.attr 'mansource'}</refmiscinfo>)
+        else
+          result << '<refmiscinfo class="source">&#160;</refmiscinfo>'
+        end
+        result << %(<refmiscinfo class="manual">#{doc.attr 'manmanual'}</refmiscinfo>) if doc.attr? 'manmanual'
         result << '</refmeta>'
         result << '<refnamediv>'
         result += (doc.attr 'mannames').map {|n| %(<refname>#{n}</refname>) } if doc.attr? 'mannames'


### PR DESCRIPTION
Define source and manual refmiscinfo entries if the corresponding
attributes are defined.  For source, we need to define a dumb one
always; otherwise xmlto puts ugly "FIXME".