### PR TITLE
resolves #2642 resolve parent references in start path when resolving system path

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -13,6 +13,22 @@ endif::[]
 This document provides a high-level view of the changes introduced in Asciidoctor by release.
 For a detailed view of what has changed, refer to the {uri-repo}/commits/master[commit history] on GitHub.
 
+== Unreleased
+
+Bug fixes::
+
+  * fix behavior of PathResolver#descends_from? when base path equals /
+  * automatically recover if start path passed to PathResolver#system_path is outside of jail path
+  * enforce that absolute start path passed to PathResolver#system_path is inside of jail path
+
+Improvements / Refactoring::
+
+  * resolve / expand parent references in start path passed to PathResolver#system_path (#2642)
+  * update PathResolver#expand_path to resolve parent references
+  * allow start path passed to PathResolver#system_path to be outside jail if target brings resolved path back inside jail
+  * don't run File.expand_path on Dir.pwd (assume Dir.pwd is absolute)
+  * posixify working_dir passed to PathResolver constructor if absolute
+
 // tag::compact[]
 == 1.5.6.2 (2018-03-20) - @mojavelinux
 

--- a/lib/asciidoctor.rb
+++ b/lib/asciidoctor.rb
@@ -1478,7 +1478,7 @@ module Asciidoctor
         raise ::IOError, %(input file and output file cannot be the same: #{outfile})
       end
     elsif write_to_target # write to explicit file or directory
-      working_dir = (options.key? :base_dir) ? (::File.expand_path options[:base_dir]) : (::File.expand_path ::Dir.pwd)
+      working_dir = (options.key? :base_dir) ? (::File.expand_path options[:base_dir]) : ::Dir.pwd
       # QUESTION should the jail be the working_dir or doc.base_dir???
       jail = doc.safe >= SafeMode::SAFE ? working_dir : nil
       if to_dir

--- a/lib/asciidoctor/path_resolver.rb
+++ b/lib/asciidoctor/path_resolver.rb
@@ -199,9 +199,9 @@ class PathResolver
     if base == path
       0
     elsif base == SLASH
-      (path.start_with? SLASH) ? 1 : false
+      (path.start_with? SLASH) && 1
     else
-      (path.start_with? base + SLASH) ? base.length + 1 : false
+      (path.start_with? base + SLASH) && (base.length + 1)
     end
   end
 
@@ -231,11 +231,7 @@ class PathResolver
     if path.include? DOT_DOT
       resolved_segments = []
       path_segments.each do |segment|
-        if segment == DOT_DOT
-          resolved_segments.pop
-        else
-          resolved_segments << segment
-        end
+        segment == DOT_DOT ? resolved_segments.pop : resolved_segments << segment
       end
       join_path resolved_segments, path_root
     else
@@ -421,7 +417,8 @@ class PathResolver
     end
 
     if recheck
-      if descends_from?((target_path = join_path resolved_segments, jail_root), jail)
+      target_path = join_path resolved_segments, jail_root
+      if descends_from? target_path, jail
         target_path
       elsif opts.fetch :recover, true
         warn %(asciidoctor: WARNING: #{opts[:target_name] || 'path'} is outside of jail, auto-recovering)

--- a/lib/asciidoctor/path_resolver.rb
+++ b/lib/asciidoctor/path_resolver.rb
@@ -196,7 +196,7 @@ class PathResolver
   #
   # returns If path descends from base, return the offset, otherwise false.
   def descends_from? path, base
-    base == path ? 0 : ((path.start_with? base + '/') ? base.length + 1 : false)
+    base == path ? 0 : ((path.start_with? base + SLASH) ? base.length + 1 : false)
   end
 
   # Public: Normalize path by converting any backslashes to forward slashes

--- a/lib/asciidoctor/path_resolver.rb
+++ b/lib/asciidoctor/path_resolver.rb
@@ -196,7 +196,13 @@ class PathResolver
   #
   # returns If path descends from base, return the offset, otherwise false.
   def descends_from? path, base
-    base == path ? 0 : ((path.start_with? base + SLASH) ? base.length + 1 : false)
+    if base == path
+      0
+    elsif base == SLASH
+      (path.start_with? SLASH) ? 1 : false
+    else
+      (path.start_with? base + SLASH) ? base.length + 1 : false
+    end
   end
 
   # Public: Normalize path by converting any backslashes to forward slashes
@@ -369,7 +375,7 @@ class PathResolver
       start = posixify start if jail
     else
       #start = system_path start, jail, jail, opts
-      start = %(#{jail || @working_dir}/#{start})
+      start = %(#{(jail || @working_dir).chomp '/'}/#{start})
     end
 
     # both jail and start have been posixified at this point if jail is set

--- a/lib/asciidoctor/path_resolver.rb
+++ b/lib/asciidoctor/path_resolver.rb
@@ -126,7 +126,7 @@ class PathResolver
     if working_dir
       @working_dir = (root? working_dir) ? (posixify working_dir) : (::File.expand_path working_dir)
     else
-      @working_dir = ::File.expand_path ::Dir.pwd
+      @working_dir = ::Dir.pwd
     end
     @_partition_path_sys, @_partition_path_web = {}, {}
   end

--- a/lib/asciidoctor/path_resolver.rb
+++ b/lib/asciidoctor/path_resolver.rb
@@ -213,19 +213,28 @@ class PathResolver
   end
   alias posixfy posixify
 
-  # Public: Expand the path by resolving any parent references (..)
-  # and cleaning self references (.).
-  #
-  # The result will be relative if the path is relative and
-  # absolute if the path is absolute. The file separator used
-  # in the expanded path is the one specified when the class
-  # was constructed.
+  # Public: Expand the specified path by converting the path to a posix path, resolving parent
+  # references (..), and removing self references (.).
   #
   # path - the String path to expand
   #
-  # returns a String path with any parent or self references resolved.
+  # returns a String path as a posix path with parent references resolved and self references removed.
+  # The result will be relative if the path is relative and absolute if the path is absolute.
   def expand_path path
-    join_path *partition_path(path)
+    path_segments, path_root = partition_path path
+    if path_segments.include? DOT_DOT
+      resolved_segments = []
+      path_segments.each do |segment|
+        if segment == DOT_DOT
+          resolved_segments.pop
+        else
+          resolved_segments << segment
+        end
+      end
+      join_path resolved_segments, path_root
+    else
+      join_path path_segments, path_root
+    end
   end
 
   # Public: Partition the path into path segments and remove any empty segments

--- a/test/document_test.rb
+++ b/test/document_test.rb
@@ -1739,9 +1739,12 @@ asciidoctor - converts AsciiDoc source files to HTML, DocBook and other formats
     test 'keeps naughty absolute paths from getting outside' do
       naughty_path = "#{disk_root}etc/passwd"
       doc = empty_document
-      secure_path = doc.normalize_asset_path(naughty_path)
+      secure_path, warnings = redirect_streams do |_, err|
+        [(doc.normalize_asset_path naughty_path), err.string]
+      end
       refute_equal naughty_path, secure_path
-      assert_match(/^#{doc.base_dir}/, secure_path)
+      assert_equal (::File.join doc.base_dir, 'etc/passwd'), secure_path
+      assert_includes warnings, 'path is outside of jail'
     end
 
     test 'keeps naughty relative paths from getting outside' do

--- a/test/paths_test.rb
+++ b/test/paths_test.rb
@@ -204,6 +204,9 @@ context 'Path Resolver' do
       assert_equal "#{JAIL}/my/path", @resolver.system_path('', "#{JAIL}/my/path", JAIL)
       assert_equal "#{JAIL}/my/path", @resolver.system_path(nil, "#{JAIL}/my/path", JAIL)
       assert_equal "#{JAIL}/my/path", @resolver.system_path('path', "#{JAIL}/my", JAIL)
+      assert_equal '/foo/bar/baz.adoc', @resolver.system_path('/foo/bar/baz.adoc', nil, '/')
+      assert_equal '/foo/bar/baz.adoc', @resolver.system_path('baz.adoc', '/foo/bar', '/')
+      assert_equal '/foo/bar/baz.adoc', @resolver.system_path('baz.adoc', 'foo/bar', '/')
     end
 
     test 'uses jail path if start path is empty' do
@@ -300,7 +303,7 @@ context 'Path Resolver' do
       assert_equal "#{pwd}/.images/tiger.png", @resolver.system_path('.images/tiger.png', nil)
     end
 
-    test 'resolves and normalizes start with target is empty' do
+    test 'resolves and normalizes start when target is empty' do
       pwd = File.expand_path Dir.pwd
       assert_equal '/home/doctor/docs', (@resolver.system_path '', '/home/doctor/docs')
       assert_equal '/home/doctor/docs', (@resolver.system_path '', '/home/doctor/./docs')

--- a/test/paths_test.rb
+++ b/test/paths_test.rb
@@ -142,6 +142,10 @@ context 'Path Resolver' do
       assert_equal "#{JAIL}/assets/stylesheets", @resolver.system_path(nil, "#{JAIL}/assets/stylesheets", JAIL)
     end
 
+    test 'expands parent references in start path if target is empty' do
+      assert_equal "#{JAIL}/stylesheets", @resolver.system_path('', "#{JAIL}/assets/../stylesheets", JAIL)
+    end
+
     test 'resolves start path if target is dot' do
       assert_equal "#{JAIL}/assets/stylesheets", @resolver.system_path('.', "#{JAIL}/assets/stylesheets", JAIL)
       assert_equal "#{JAIL}/assets/stylesheets", @resolver.system_path('./', "#{JAIL}/assets/stylesheets", JAIL)


### PR DESCRIPTION
- resolve parent references in start path when resolving system path
- change PathResolver#expand_path to resolve parent references
- fix case where string literal is used instead of SLASH constant in PathResolver
- change partition_path to return two elements instead of three
- consolidate path split in partition_path
- enforce that start is inside of jail when absolute
- automatically recover if start is outside of jail by default
- allow target to bring resolved path back into jail even when start is outside
- fix descends_from? when base is /
- don't run File.expand_path on Dir.pwd
- allow target to bring resolved path under jail when start is outside jail