### PR TITLE
Fix typo in gemspec that removed the README and CONTRIBUTING from the gem

### DIFF
--- a/asciidoctor.gemspec
+++ b/asciidoctor.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |s|
   rescue
     Dir['**/*']
   end
-  s.files = files.grep(/^(?:(?:data|lib|man)\/.+|Gemfile|Rakefile|LICENSE|(?:CHANGELOG|CONTRIBUTINGREADME(?:-\w+)?)\.adoc|#{s.name}\.gemspec)$/)
+  s.files = files.grep(/^(?:(?:data|lib|man)\/.+|Gemfile|Rakefile|LICENSE|(?:CHANGELOG|CONTRIBUTING|README(?:-\w+)?)\.adoc|#{s.name}\.gemspec)$/)
   s.executables = files.grep(/^bin\//).map {|f| File.basename f }
   s.require_paths = ['lib']
   s.test_files = files.grep(/^(?:(?:features|test)\/.+)$/)


### PR DESCRIPTION
There's been a typo introduced in https://github.com/aerostitch/asciidoctor/commit/28e795792b0f4f2b3e6a8822605686c28c3535dc that makes the README and CONTRIBUTING files to not be included in the generated gem.
This PR fixes that.