### PR TITLE
Allow tests to run outside of the gem context with the manpage help topic

### DIFF
--- a/test/options_test.rb
+++ b/test/options_test.rb
@@ -23,12 +23,22 @@ context 'Options' do
   end
 
   test 'should dump man page and return error code 0 when help topic is manpage' do
+    skip 'this test should run only in a gem install context' if ENV['ASCIIDOCTOR_MANPAGE_ABSENT_FROM_TEST']
     exitval, output = redirect_streams do |out, _|
       [Asciidoctor::Cli::Options.parse!(%w(-h manpage)), out.string]
     end
     assert_equal 0, exitval
     assert_includes output, 'Manual: Asciidoctor Manual'
     assert_includes output, '.TH "ASCIIDOCTOR"'
+  end
+
+  test 'should print a message and return error code 1 when help topic is manpage' do
+    skip 'this test should run outside of the gem context' unless ENV['ASCIIDOCTOR_MANPAGE_ABSENT_FROM_TEST']
+    redirect_streams do |out, stderr|
+      exitval = Asciidoctor::Cli::Options.parse!(%w(-h manpage))
+      assert_equal 1, exitval
+      assert_equal 'asciidoctor: FAILED: man page not found; try `man asciidoctor`', stderr.string.chomp
+    end
   end
 
   test 'should return error code 1 when invalid option present' do


### PR DESCRIPTION
I'm packaging the latest asciidoctor version for Debian and right now it fails because of the test reading the man page form a non-standard location (which fails without trying the standard location).
This PR would check in the standard man page location (so it would not fail once the package is installed via distribution package installation).

The 1st case is when the installation has been done in a non-gzip way (can happen when you are building the package) and the other one is once you've installed the package.