### PR TITLE
resolves #44 add logging infrastructure and route messages to logger

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -17,6 +17,11 @@ For a detailed view of what has changed, refer to the {uri-repo}/commits/master[
 
 Enhancements::
 
+  * route messages through a logger instead of using Kernel#warn (#44, PR #2660)
+  * add MemoryLogger for capturing messages sent to logger into memory (#44, PR #2660)
+  * add NullLogger to prevent messages from being logged (#44, PR #2660)
+  * log message containing source location / cursor as an object; provides more context (#44, PR #2660)
+  * add :logger option to API to set logger instance (#44, PR #2660)
   * resolve nested includes in remote documents relative to URI (#2506, PR #2511)
   * support name!@, !name@, name!=@, and !name=@ syntax to soft unset attribute from API or CLI (#642, PR #2649)
   * allow modifier to be placed at end of name to soft set an attribute (e.g., icons@=font) (#642, PR #2649)
@@ -84,6 +89,7 @@ Improvements / Refactoring::
   * don't run File.expand_path on Dir.pwd (assume Dir.pwd is absolute) (#2642, PR #2644)
   * posixify working_dir passed to PathResolver constructor if absolute (#2642, PR #2644)
   * optimize detection for footnote* and indexterm* macros (#2347, PR #2362)
+  * set logger to DEBUG when verbose is enabled; check logger.debug? instead of $VERBOSE
   * coerce value of template_dirs option to an Array (PR #2621)
   * allow paragraph to masquerade as open block (PR #2412)
   * move callouts into document catalog (PR #2394)

--- a/lib/asciidoctor.rb
+++ b/lib/asciidoctor.rb
@@ -22,6 +22,8 @@ end
 # ideally we should use require_relative instead of modifying the LOAD_PATH
 $:.unshift File.dirname __FILE__
 
+require 'asciidoctor/logging'
+
 # Public: Methods for parsing AsciiDoc input files and converting documents
 # using eRuby templates.
 #

--- a/lib/asciidoctor.rb
+++ b/lib/asciidoctor.rb
@@ -1296,6 +1296,10 @@ module Asciidoctor
       timings.start :read
     end
 
+    if (logger = options[:logger]) && logger != LoggerManager.logger
+      LoggerManager.logger = logger
+    end
+
     if !(attrs = options[:attributes])
       attrs = {}
     elsif ::Hash === attrs || (::RUBY_ENGINE_JRUBY && ::Java::JavaUtil::Map === attrs)

--- a/lib/asciidoctor/abstract_node.rb
+++ b/lib/asciidoctor/abstract_node.rb
@@ -4,7 +4,7 @@ module Asciidoctor
 # node of AsciiDoc content. The state and methods on this class are comment to
 # all content segments in an AsciiDoc document.
 class AbstractNode
-
+  include Logging
   include Substitutors
 
   # Public: Get the Hash of attributes for this node
@@ -369,7 +369,7 @@ class AbstractNode
       # NOTE base64 is autoloaded by reference to ::Base64
       %(data:#{mimetype};base64,#{::Base64.encode64(::IO.binread image_path).delete LF})
     else
-      warn %(asciidoctor: WARNING: image to embed not found or not readable: #{image_path})
+      logger.warn %(image to embed not found or not readable: #{image_path})
       %(data:#{mimetype};base64,)
       # uncomment to return 1 pixel white dot instead
       #'data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw=='
@@ -407,7 +407,7 @@ class AbstractNode
       # NOTE base64 is autoloaded by reference to ::Base64
       %(data:#{mimetype};base64,#{::Base64.encode64(bindata).delete LF})
     rescue
-      warn %(asciidoctor: WARNING: could not retrieve image data from URI: #{image_uri})
+      logger.warn %(could not retrieve image data from URI: #{image_uri})
       image_uri
       # uncomment to return empty data (however, mimetype needs to be resolved)
       #%(data:#{mimetype}:base64,)
@@ -506,7 +506,7 @@ class AbstractNode
         ::IO.read path
       end
     elsif opts[:warn_on_failure]
-      warn %(asciidoctor: WARNING: #{(attr 'docfile') || '<stdin>'}: #{opts[:label] || 'file'} does not exist or cannot be read: #{path})
+      logger.warn %(#{(attr 'docfile') || '<stdin>'}: #{opts[:label] || 'file'} does not exist or cannot be read: #{path})
       nil
     end
   end
@@ -538,11 +538,11 @@ class AbstractNode
           data = (Helpers.normalize_lines_from_string data) * LF if opts[:normalize]
           return data
         rescue
-          warn %(asciidoctor: WARNING: could not retrieve contents of #{opts[:label] || 'asset'} at URI: #{target}) if opts.fetch :warn_on_failure, true
+          logger.warn %(could not retrieve contents of #{opts[:label] || 'asset'} at URI: #{target}) if opts.fetch :warn_on_failure, true
           return
         end
       else
-        warn %(asciidoctor: WARNING: cannot retrieve contents of #{opts[:label] || 'asset'} at URI: #{target} (allow-uri-read attribute not enabled)) if opts.fetch :warn_on_failure, true
+        logger.warn %(cannot retrieve contents of #{opts[:label] || 'asset'} at URI: #{target} (allow-uri-read attribute not enabled)) if opts.fetch :warn_on_failure, true
         return
       end
     else

--- a/lib/asciidoctor/block.rb
+++ b/lib/asciidoctor/block.rb
@@ -124,7 +124,7 @@ class Block < AbstractBlock
         result * LF
       end
     else
-      warn %(Unknown content model '#{@content_model}' for block: #{to_s}) unless @content_model == :empty
+      logger.warn %(Unknown content model '#{@content_model}' for block: #{to_s}) unless @content_model == :empty
       nil
     end
   end

--- a/lib/asciidoctor/cli/invoker.rb
+++ b/lib/asciidoctor/cli/invoker.rb
@@ -66,10 +66,12 @@ module Asciidoctor
             case val
             when 0
               $VERBOSE = nil
+              LoggerManager.logger = Logger::NullLogger.new
             when 1
               $VERBOSE = false
             when 2
               $VERBOSE = true
+              #LoggerManager.logger.level = ::Logger::Severity::DEBUG
             end
           else
             opts[key] = val unless val.nil?

--- a/lib/asciidoctor/cli/invoker.rb
+++ b/lib/asciidoctor/cli/invoker.rb
@@ -30,10 +30,10 @@ module Asciidoctor
       end
 
       def invoke!
-        old_verbose = -1
         return unless @options
 
         old_verbose = $VERBOSE
+        old_logger = old_logger_level = nil
         opts = {}
         infiles = []
         outfile = nil
@@ -66,12 +66,14 @@ module Asciidoctor
             case val
             when 0
               $VERBOSE = nil
+              old_logger = LoggerManager.logger
               LoggerManager.logger = Logger::NullLogger.new
             when 1
               $VERBOSE = false
             when 2
               $VERBOSE = true
-              #LoggerManager.logger.level = ::Logger::Severity::DEBUG
+              old_logger_level = LoggerManager.logger.level
+              LoggerManager.logger.level = ::Logger::Severity::DEBUG
             end
           else
             opts[key] = val unless val.nil?
@@ -149,7 +151,12 @@ module Asciidoctor
         end
         nil
       ensure
-        $VERBOSE = old_verbose unless old_verbose == -1
+        $VERBOSE = old_verbose
+        if old_logger
+          LoggerManager.logger = old_logger
+        elsif old_logger_level
+          LoggerManager.logger.level = old_logger_level
+        end
       end
 
       def document

--- a/lib/asciidoctor/cli/invoker.rb
+++ b/lib/asciidoctor/cli/invoker.rb
@@ -67,7 +67,7 @@ module Asciidoctor
             when 0
               $VERBOSE = nil
               old_logger = LoggerManager.logger
-              LoggerManager.logger = Logger::NullLogger.new
+              LoggerManager.logger = NullLogger.new
             when 1
               $VERBOSE = false
             when 2

--- a/lib/asciidoctor/converter/base.rb
+++ b/lib/asciidoctor/converter/base.rb
@@ -9,11 +9,15 @@ module Asciidoctor
   # Concrete subclasses must implement the {#convert} method and, optionally,
   # the {#convert_with_options} method.
   class Converter::Base
+    include Logging
     include Converter
   end
 
   # An abstract base class for built-in {Converter} classes.
+  # Does not inherit from Converter.
   class Converter::BuiltIn
+    include Logging
+
     def initialize backend, opts = {}
     end
 

--- a/lib/asciidoctor/converter/docbook5.rb
+++ b/lib/asciidoctor/converter/docbook5.rb
@@ -305,7 +305,7 @@ module Asciidoctor
       case node.style
       when 'abstract'
         if node.parent == node.document && node.document.doctype == 'book'
-          warn 'asciidoctor: WARNING: abstract block cannot be used in a document without a title when doctype is book. Excluding block content.'
+          logger.warn 'abstract block cannot be used in a document without a title when doctype is book. Excluding block content.'
           ''
         else
           %(<abstract>
@@ -314,7 +314,7 @@ module Asciidoctor
         end
       when 'partintro'
         unless node.level == 0 && node.parent.context == :section && node.document.doctype == 'book'
-          warn 'asciidoctor: ERROR: partintro block can only be used when doctype is book and must be a child of a book part. Excluding block content.'
+          logger.error 'partintro block can only be used when doctype is book and must be a child of a book part. Excluding block content.'
           ''
         else
           %(<partintro#{common_attributes node.id, node.role, node.reftext}>
@@ -429,7 +429,7 @@ module Asciidoctor
       result << '</tgroup>'
       result << %(</#{tag_name}>)
 
-      warn 'asciidoctor: WARNING: tables must have at least one body row' unless has_body
+      logger.warn 'tables must have at least one body row' unless has_body
       result * LF
     end
 
@@ -493,7 +493,7 @@ module Asciidoctor
         # NOTE technically node.text should be node.reftext, but subs have already been applied to text
         %(<anchor#{common_attributes node.id, nil, (text = node.text)}/>#{text})
       else
-        warn %(asciidoctor: WARNING: unknown anchor type: #{node.type.inspect})
+        logger.warn %(unknown anchor type: #{node.type.inspect})
         nil
       end
     end

--- a/lib/asciidoctor/converter/factory.rb
+++ b/lib/asciidoctor/converter/factory.rb
@@ -50,7 +50,8 @@ module Asciidoctor
             require 'thread_safe'.to_s unless defined? ::ThreadSafe
             new ::ThreadSafe::Cache.new
           rescue ::LoadError
-            warn 'asciidoctor: WARNING: gem \'thread_safe\' is not installed. This gem is recommended when registering custom converters.'
+            include Logging unless include? Logging
+            logger.warn 'gem \'thread_safe\' is not installed. This gem is recommended when registering custom converters.'
             new
           end
         end

--- a/lib/asciidoctor/converter/html5.rb
+++ b/lib/asciidoctor/converter/html5.rb
@@ -682,7 +682,7 @@ Your browser does not support the audio tag.
     def open node
       if (style = node.style) == 'abstract'
         if node.parent == node.document && node.document.doctype == 'book'
-          warn 'asciidoctor: WARNING: abstract block cannot be used in a document without a title when doctype is book. Excluding block content.'
+          logger.warn 'abstract block cannot be used in a document without a title when doctype is book. Excluding block content.'
           ''
         else
           id_attr = node.id ? %( id="#{node.id}") : ''
@@ -694,7 +694,7 @@ Your browser does not support the audio tag.
 </div>)
         end
       elsif style == 'partintro' && (node.level > 0 || node.parent.context != :section || node.document.doctype != 'book')
-        warn 'asciidoctor: ERROR: partintro block can only be used when doctype is book and must be a child of a book part. Excluding block content.'
+        logger.error 'partintro block can only be used when doctype is book and must be a child of a book part. Excluding block content.'
         ''
       else
           id_attr = node.id ? %( id="#{node.id}") : ''
@@ -1059,7 +1059,7 @@ Your browser does not support the video tag.
         # NOTE technically node.text should be node.reftext, but subs have already been applied to text
         %(<a id="#{node.id}"></a>#{node.text})
       else
-        warn %(asciidoctor: WARNING: unknown anchor type: #{node.type.inspect})
+        logger.warn %(unknown anchor type: #{node.type.inspect})
         nil
       end
     end

--- a/lib/asciidoctor/converter/manpage.rb
+++ b/lib/asciidoctor/converter/manpage.rb
@@ -67,7 +67,7 @@ module Asciidoctor
     end
 
     def skip_with_warning node, name = nil
-      warn %(asciidoctor: WARNING: converter missing for #{name || node.node_name} node in manpage backend)
+      logger.warn %(converter missing for #{name || node.node_name} node in manpage backend)
       nil
     end
 
@@ -617,7 +617,7 @@ allbox tab(:);'
         # These are anchor points, which shouldn't be visible
         ''
       else
-        warn %(asciidoctor: WARNING: unknown anchor type: #{node.type.inspect})
+        logger.warn %(unknown anchor type: #{node.type.inspect})
         nil
       end
     end

--- a/lib/asciidoctor/converter/template.rb
+++ b/lib/asciidoctor/converter/template.rb
@@ -75,7 +75,7 @@ module Asciidoctor
       end
       case opts[:template_cache]
       when true
-        warn 'asciidoctor: WARNING: gem \'thread_safe\' is not installed. This gem is recommended when using the built-in template cache.' unless defined? ::ThreadSafe
+        logger.warn 'gem \'thread_safe\' is not installed. This gem is recommended when using the built-in template cache.' unless defined? ::ThreadSafe
         @caches = self.class.caches
       when ::Hash
         @caches = opts[:template_cache]

--- a/lib/asciidoctor/document.rb
+++ b/lib/asciidoctor/document.rb
@@ -396,7 +396,7 @@ class Document < AbstractBlock
     elsif attr_overrides['docdir']
       @base_dir = attr_overrides['docdir']
     else
-      #warn 'asciidoctor: WARNING: setting base_dir is recommended when working with string documents' unless nested?
+      #logger.warn 'setting base_dir is recommended when working with string documents' unless nested?
       @base_dir = attr_overrides['docdir'] = ::Dir.pwd
     end
 
@@ -511,7 +511,7 @@ class Document < AbstractBlock
 
       if initialize_extensions
         if (ext_registry = options[:extension_registry])
-          # QUESTION should we warn the value type of the option is not a registry
+          # QUESTION should we warn if the value type of this option is not a registry
           if Extensions::Registry === ext_registry || (::RUBY_ENGINE_JRUBY &&
               ::AsciidoctorJ::Extensions::ExtensionRegistry === ext_registry)
             @extensions = ext_registry.activate self
@@ -1126,7 +1126,7 @@ class Document < AbstractBlock
     if doctype == 'inline'
       if (block = @blocks[0] || @header)
         if block.content_model == :compound || block.content_model == :empty
-          warn 'asciidoctor: WARNING: no inline candidate; use the inline doctype to convert a single paragragh, verbatim, or raw block'
+          logger.warn 'no inline candidate; use the inline doctype to convert a single paragragh, verbatim, or raw block'
         else
           output = block.content
         end

--- a/lib/asciidoctor/helpers.rb
+++ b/lib/asciidoctor/helpers.rb
@@ -23,20 +23,23 @@ module Helpers
   def self.require_library name, gem_name = true, on_failure = :abort
     require name
   rescue ::LoadError => e
+    include Logging unless include? Logging
     if gem_name
       gem_name = name if gem_name == true
       case on_failure
       when :abort
         raise ::LoadError, %(asciidoctor: FAILED: required gem '#{gem_name}' is not installed. Processing aborted.)
       when :warn
-        warn %(asciidoctor: WARNING: optional gem '#{gem_name}' is not installed. Functionality disabled.)
+        logger.warn %(optional gem '#{gem_name}' is not installed. Functionality disabled.)
+        return
       end
     else
       case on_failure
       when :abort
         raise ::LoadError, %(asciidoctor: FAILED: #{e.message.chomp '.'}. Processing aborted.)
       when :warn
-        warn %(asciidoctor: WARNING: #{e.message.chomp '.'}. Functionality disabled.)
+        logger.warn %(#{e.message.chomp '.'}. Functionality disabled.)
+        return
       end
     end
     nil

--- a/lib/asciidoctor/logging.rb
+++ b/lib/asciidoctor/logging.rb
@@ -17,6 +17,12 @@ class Logger < ::Logger
     end
   end
 
+  module AutoFormattingMessage
+    def inspect
+      (sloc = self[:source_location]) ? %(#{sloc}: #{self[:text]}) : self[:text]
+    end
+  end
+
   class NullLogger < ::Logger
     def initialize; end
 
@@ -63,6 +69,10 @@ module Logging
   private
   def logger
     LoggerManager.logger
+  end
+
+  def enrich_message text, context = {}
+    ({ :text => text }.merge context).extend Logger::AutoFormattingMessage
   end
 end
 end

--- a/lib/asciidoctor/logging.rb
+++ b/lib/asciidoctor/logging.rb
@@ -97,7 +97,7 @@ module Logging
     LoggerManager.logger
   end
 
-  def enrich_message text, context = {}
+  def message_with_context text, context = {}
     ({ :text => text }.merge context).extend Logger::AutoFormattingMessage
   end
 end

--- a/lib/asciidoctor/logging.rb
+++ b/lib/asciidoctor/logging.rb
@@ -22,30 +22,31 @@ class Logger < ::Logger
       (sloc = self[:source_location]) ? %(#{sloc}: #{self[:text]}) : self[:text]
     end
   end
+end
 
-  class MemoryLogger < ::Logger
-    SEVERITY_LABELS = ::Hash[Severity.constants.map {|c| [(Severity.const_get c), c.to_sym] }]
+class MemoryLogger < ::Logger
+  # NOTE Ruby 1.8.7 returns constants as strings instead of symbols
+  SEVERITY_LABELS = ::Hash[Severity.constants.map {|c| [(Severity.const_get c), c.to_sym] }]
 
-    attr_reader :messages
+  attr_reader :messages
 
-    def initialize
-      self.level = WARN
-      @messages = []
-    end
-
-    def add severity, message = nil, progname = nil
-      message = block_given? ? yield : progname unless message
-      @messages << { :severity => SEVERITY_LABELS[severity], :message => message }
-      true
-    end
+  def initialize
+    self.level = WARN
+    @messages = []
   end
 
-  class NullLogger < ::Logger
-    def initialize; end
+  def add severity, message = nil, progname = nil
+    message = block_given? ? yield : progname unless message
+    @messages << { :severity => SEVERITY_LABELS[severity], :message => message }
+    true
+  end
+end
 
-    def add *args
-      true
-    end
+class NullLogger < ::Logger
+  def initialize; end
+
+  def add *args
+    true
   end
 end
 

--- a/lib/asciidoctor/logging.rb
+++ b/lib/asciidoctor/logging.rb
@@ -23,6 +23,23 @@ class Logger < ::Logger
     end
   end
 
+  class MemoryLogger < ::Logger
+    SEVERITY_LABELS = ::Hash[Severity.constants.map {|c| [(Severity.const_get c), c.to_sym] }]
+
+    attr_reader :messages
+
+    def initialize
+      self.level = WARN
+      @messages = []
+    end
+
+    def add severity, message = nil, progname = nil
+      message = block_given? ? yield : progname unless message
+      @messages << { :severity => SEVERITY_LABELS[severity], :message => message }
+      true
+    end
+  end
+
   class NullLogger < ::Logger
     def initialize; end
 

--- a/lib/asciidoctor/logging.rb
+++ b/lib/asciidoctor/logging.rb
@@ -1,0 +1,68 @@
+require 'logger'
+
+module Asciidoctor
+class Logger < ::Logger
+  def initialize *args
+    super
+    self.progname = 'asciidoctor'
+    self.formatter = BasicFormatter.new
+    self.level = WARN
+  end
+
+  class BasicFormatter < Formatter
+    SEVERITY_LABELS = { 'WARN' => 'WARNING', 'FATAL' => 'FAILED' }
+
+    def call severity, _, progname, msg
+      %(#{progname}: #{SEVERITY_LABELS[severity] || severity}: #{::String === msg ? msg : msg.inspect}\n)
+    end
+  end
+
+  class NullLogger < ::Logger
+    def initialize; end
+
+    def add *args
+      true
+    end
+  end
+end
+
+module LoggerManager
+  @logger_class = Logger
+  class << self
+    attr_accessor :logger_class
+
+    # NOTE subsequent calls to logger access the logger via the logger property directly
+    def logger pipe = $stderr
+      memoize_logger
+      @logger ||= (@logger_class.new pipe)
+    end
+
+    def logger= logger
+      @logger = logger || (@logger_class.new $stderr)
+    end
+
+    private
+    def memoize_logger
+      class << self
+        alias_method :logger, :logger
+        if RUBY_ENGINE == 'opal'
+          define_method :logger do @logger end
+        else
+          attr_reader :logger
+        end
+      end
+    end
+  end
+end
+
+module Logging
+  def self.included into
+    into.extend Logging
+  end
+
+  private
+  def logger
+    LoggerManager.logger
+  end
+end
+end

--- a/lib/asciidoctor/logging.rb
+++ b/lib/asciidoctor/logging.rb
@@ -40,6 +40,14 @@ class MemoryLogger < ::Logger
     @messages << { :severity => SEVERITY_LABELS[severity], :message => message }
     true
   end
+
+  def empty?
+    @messages.empty?
+  end
+
+  def clear
+    @messages.clear
+  end
 end
 
 class NullLogger < ::Logger

--- a/lib/asciidoctor/parser.rb
+++ b/lib/asciidoctor/parser.rb
@@ -885,7 +885,7 @@ class Parser
           end
         else
           # this should only happen if there's a misconfiguration
-          raise %(Unsupported block type #{block_context} at #{reader.line_info})
+          raise %(Unsupported block type #{block_context} at #{reader.cursor})
         end
       end
     end
@@ -1728,7 +1728,7 @@ class Parser
       end unless sect_id
       reader.shift
     else
-      raise %(Unrecognized section at #{reader.prev_line_info})
+      raise %(Unrecognized section at #{reader.prev_line_cursor})
     end
     sect_level += document.attr('leveloffset').to_i if document.attr?('leveloffset')
     [sect_id, sect_reftext, sect_title, sect_level, atx]

--- a/lib/asciidoctor/parser.rb
+++ b/lib/asciidoctor/parser.rb
@@ -194,7 +194,7 @@ class Parser
       document.attributes['mantitle'] = document.sub_attributes $1.downcase
       document.attributes['manvolnum'] = $2
     else
-      logger.error %(#{reader.prev_line_info}: malformed manpage title)
+      logger.error enrich_message 'malformed manpage title', :source_location => reader.prev_line_cursor
       # provide sensible fallbacks
       document.attributes['mantitle'] = document.attributes['doctitle']
       document.attributes['manvolnum'] = '1'
@@ -223,13 +223,13 @@ class Parser
             document.attributes['outfilesuffix'] = %(.#{document.attributes['manvolnum']})
           end
         else
-          logger.error %(#{reader.prev_line_info}: malformed name section body)
+          logger.error enrich_message 'malformed name section body', :source_location => reader.prev_line_cursor
         end
       else
-        logger.error %(#{reader.prev_line_info}: name section title must be at level 1)
+        logger.error enrich_message 'name section title must be at level 1', :source_location => reader.prev_line_cursor
       end
     else
-      logger.error %(#{reader.prev_line_info}: name section expected)
+      logger.error enrich_message 'name section expected', :source_location => reader.prev_line_cursor
     end
     nil
   end
@@ -325,9 +325,9 @@ class Parser
         next_level += document.attr('leveloffset').to_i if document.attr?('leveloffset')
         if next_level > current_level || (next_level == 0 && section.context == :document)
           if next_level == 0 && doctype != 'book'
-            logger.error %(#{reader.line_info}: only book doctypes can contain level 0 sections)
+            logger.error enrich_message 'only book doctypes can contain level 0 sections', :source_location => reader.cursor
           elsif expected_next_levels && !expected_next_levels.include?(next_level)
-            logger.warn %(#{reader.line_info}: section title out of sequence: expected #{expected_next_levels.size > 1 ? 'levels' : 'level'} #{expected_next_levels * ' or '}, got level #{next_level})
+            logger.warn enrich_message %(section title out of sequence: expected #{expected_next_levels.size > 1 ? 'levels' : 'level'} #{expected_next_levels * ' or '}, got level #{next_level}), :source_location => reader.cursor
           end
           # the attributes returned are those that are orphaned
           new_section, attributes = next_section reader, section, attributes
@@ -335,14 +335,14 @@ class Parser
           section.blocks << new_section
         else
           if next_level == 0 && doctype != 'book'
-            logger.error %(#{reader.line_info}: only book doctypes can contain level 0 sections)
+            logger.error enrich_message 'only book doctypes can contain level 0 sections', :source_location => reader.cursor
           end
           # close this section (and break out of the nesting) to begin a new one
           break
         end
       else
         # just take one block or else we run the risk of overrunning section boundaries
-        block_line_info = reader.line_info
+        block_cursor = reader.cursor
         if (new_block = next_block reader, intro || section, attributes, :parse_metadata => false)
           # REVIEW this may be doing too much
           if part
@@ -364,7 +364,7 @@ class Parser
               first_block = section.blocks[0]
               # open the [partintro] open block for appending
               if !intro && first_block.content_model == :compound
-                logger.error %(#{block_line_info}: illegal block content outside of partintro block)
+                logger.error enrich_message 'illegal block content outside of partintro block', :source_location => block_cursor
               # rebuild [partintro] paragraph as an open block
               elsif first_block.content_model != :compound
                 new_block.parent = (intro = Block.new section, :open, :content_model => :compound)
@@ -393,7 +393,7 @@ class Parser
 
     if part
       unless section.blocks? && section.blocks[-1].context == :section
-        logger.error %(#{reader.line_info}: invalid part, must have at least one section (e.g., chapter, appendix, etc.))
+        logger.error enrich_message 'invalid part, must have at least one section (e.g., chapter, appendix, etc.)', :source_location => reader.cursor
       end
     # NOTE we could try to avoid creating a preamble in the first place, though
     # that would require reworking assumptions in next_section since the preamble
@@ -469,8 +469,7 @@ class Parser
     end
 
     # QUESTION should we introduce a parsing context object?
-    source_location = reader.cursor if document.sourcemap
-    this_path, this_lineno, this_line, doc_attrs = reader.path, reader.lineno, reader.read_line, document.attributes
+    this_file, this_dir, this_path, this_lineno, this_line, doc_attrs = reader.file, reader.dir, reader.path, reader.lineno, reader.read_line, document.attributes
     block = block_context = cloaked_context = terminator = nil
     style = attributes[1] ? (parse_style_attribute attributes, reader) : nil
 
@@ -487,7 +486,7 @@ class Parser
         elsif block_extensions && extensions.registered_for_block?(style, block_context)
           block_context = style.to_sym
         else
-          logger.warn %(#{this_path}: line #{this_lineno}: invalid style for #{block_context} block: #{style})
+          logger.warn enrich_message %(invalid style for #{block_context} block: #{style}), :source_location => (Reader::Cursor.new this_file, this_dir, this_path, this_lineno)
           style = block_context.to_s
         end
       end
@@ -616,12 +615,12 @@ class Parser
           list_item_lineno = reader.lineno
           # might want to move this check to a validate method
           unless match[1] == expected_index.to_s
-            logger.warn %(#{reader.path}: line #{list_item_lineno}: callout list item index: expected #{expected_index} got #{match[1]})
+            logger.warn enrich_message %(callout list item index: expected #{expected_index} got #{match[1]}), :source_location => (reader.cursor list_item_lineno)
           end
           if (list_item = next_list_item reader, block, match)
             block.items << list_item
             if (coids = document.callouts.callout_ids block.items.size).empty?
-              logger.warn %(#{reader.path}: line #{list_item_lineno}: no callouts refer to list item #{block.items.size})
+              logger.warn enrich_message %(no callouts refer to list item #{block.items.size}), :source_location => (reader.cursor list_item_lineno)
             else
               list_item.attributes['coids'] = coids
             end
@@ -698,7 +697,7 @@ class Parser
           # advance to block parsing =>
           break
         else
-          logger.warn %(#{this_path}: line #{this_lineno}: invalid style for paragraph: #{style})
+          logger.warn enrich_message %(invalid style for paragraph: #{style}), :source_location => (Reader::Cursor.new this_file, this_dir, this_path, this_lineno)
           style = nil
           # continue to process paragraph
         end
@@ -892,7 +891,7 @@ class Parser
     end
 
     # FIXME we've got to clean this up, it's horrible!
-    block.source_location = source_location if source_location
+    block.source_location = Reader::Cursor.new this_file, this_dir, this_path, this_lineno if document.sourcemap
     # FIXME title should be assigned when block is constructed
     block.title = attributes.delete 'title' if attributes.key? 'title'
     # TODO eventually remove the style attribute from the attributes hash
@@ -900,7 +899,7 @@ class Parser
     block.style = attributes['style']
     if (block_id = (block.id ||= attributes['id']))
       unless document.register :refs, [block_id, block, attributes['reftext'] || (block.title? ? block.title : nil)]
-        logger.warn %(#{this_path}: line #{this_lineno}: id assigned to block already in use: #{block_id})
+        logger.warn enrich_message %(id assigned to block already in use: #{block_id}), :source_location => (Reader::Cursor.new this_file, this_dir, this_path, this_lineno)
       end
     end
     # FIXME remove the need for this update!
@@ -1190,7 +1189,7 @@ class Parser
         end
       end
       unless document.register :refs, [id, (Inline.new block, :anchor, reftext, :type => :ref, :id => id), reftext]
-        logger.warn %(#{document.reader.path}: id assigned to anchor already in use: #{id})
+        logger.warn enrich_message %(id assigned to anchor already in use: #{id}), :source_location => document.reader.prev_line_cursor
       end
     end if (text.include? '[[') || (text.include? 'or:')
     nil
@@ -1207,7 +1206,7 @@ class Parser
     if InlineBiblioAnchorRx =~ text
       # QUESTION should we sub attributes in reftext (like with regular anchors)?
       unless document.register :refs, [(id = $1), (Inline.new block, :anchor, (reftext = %([#{$2 || id}])), :type => :bibref, :id => id), reftext]
-        logger.warn %(#{document.reader.path}: id assigned to bibliography anchor already in use: #{id})
+        logger.warn enrich_message %(id assigned to bibliography anchor already in use: #{id}), :source_location => document.reader.prev_line_cursor
       end
     end
     nil
@@ -1586,7 +1585,7 @@ class Parser
     # generate an ID if one was not embedded or specified as anchor above section title
     if (id = section.id ||= ((document.attributes.key? 'sectids') ? (Section.generate_id section.title, document) : nil))
       unless document.register :refs, [id, section, sect_reftext || section.title]
-        logger.warn %(#{reader.path}: line #{reader.lineno - (sect_atx ? 1 : 2)}: id assigned to section already in use: #{id})
+        logger.warn enrich_message %(id assigned to section already in use: #{id}), :source_location => (reader.cursor reader.lineno - (sect_atx ? 1 : 2))
       end
     end
 
@@ -2213,7 +2212,7 @@ class Parser
     end
 
     if validate && expected != actual
-      logger.warn %(#{reader.line_info}: list item index: expected #{expected}, got #{actual})
+      logger.warn enrich_message %(list item index: expected #{expected}, got #{actual}), :source_location => reader.cursor
     end
 
     marker
@@ -2537,7 +2536,11 @@ class Parser
       save_current = lambda {
         if collector.empty?
           unless type == :style
-            logger.warn %(#{reader ? " #{reader.prev_line_info}:" : ''} invalid empty #{type} detected in style attribute)
+            if reader
+              logger.warn enrich_message %(invalid empty #{type} detected in style attribute), :source_location => reader.prev_line_cursor
+            else
+              logger.warn %(invalid empty #{type} detected in style attribute)
+            end
           end
         else
           case type
@@ -2545,7 +2548,11 @@ class Parser
             (parsed[type] ||= []) << collector.join
           when :id
             if parsed.key? :id
-              logger.warn %(#{reader ? " #{reader.prev_line_info}:" : ''} multiple ids detected in style attribute)
+              if reader
+                logger.warn enrich_message 'multiple ids detected in style attribute', :source_location => reader.prev_line_cursor
+              else
+                logger.warn 'multiple ids detected in style attribute'
+              end
             end
             parsed[type] = collector.join
           else

--- a/lib/asciidoctor/reader.rb
+++ b/lib/asciidoctor/reader.rb
@@ -523,11 +523,6 @@ class Reader
   def line_info
     %(#{@path}: line #{@lineno})
   end
-  alias next_line_info line_info
-
-  def prev_line_info
-    %(#{@path}: line #{@lineno - 1})
-  end
 
   # Public: Get a copy of the remaining Array of String lines managed by this Reader
   #

--- a/lib/asciidoctor/reader.rb
+++ b/lib/asciidoctor/reader.rb
@@ -713,12 +713,12 @@ class PreprocessorReader < Reader
 
     if keyword == 'endif'
       if @conditional_stack.empty?
-        logger.error enrich_message %(unmatched macro: endif::#{target}[]), :source_location => cursor
+        logger.error message_with_context %(unmatched macro: endif::#{target}[]), :source_location => cursor
       elsif no_target || target == (pair = @conditional_stack[-1])[:target]
         @conditional_stack.pop
         @skipping = @conditional_stack.empty? ? false : @conditional_stack[-1][:skipping]
       else
-        logger.error enrich_message %(mismatched macro: endif::#{target}[], expected endif::#{pair[:target]}[]), :source_location => cursor
+        logger.error message_with_context %(mismatched macro: endif::#{target}[], expected endif::#{pair[:target]}[]), :source_location => cursor
       end
       return true
     end
@@ -834,7 +834,7 @@ class PreprocessorReader < Reader
       replace_next_line %(link:#{expanded_target}[])
     elsif (abs_maxdepth = @maxdepth[:abs]) > 0
       if @include_stack.size >= abs_maxdepth
-        logger.error enrich_message %(maximum include depth of #{@maxdepth[:rel]} exceeded), :source_location => cursor
+        logger.error message_with_context %(maximum include depth of #{@maxdepth[:rel]} exceeded), :source_location => cursor
         return
       end
 
@@ -900,7 +900,7 @@ class PreprocessorReader < Reader
             end
           end
         rescue
-          logger.error enrich_message %(include #{target_type} not readable: #{inc_path}), :source_location => cursor
+          logger.error message_with_context %(include #{target_type} not readable: #{inc_path}), :source_location => cursor
           return replace_next_line %(Unresolved directive in #{@path} - include::#{expanded_target}[#{attrlist}])
         end
         shift
@@ -939,9 +939,9 @@ class PreprocessorReader < Reader
                   elsif inc_tags.key? this_tag
                     if (idx = tag_stack.rindex {|key, _| key == this_tag })
                       idx == 0 ? tag_stack.shift : (tag_stack.delete_at idx)
-                      logger.warn enrich_message %(mismatched end tag in include: expected #{active_tag}, found #{this_tag}), :source_location => (Cursor.new inc_path, nil, expanded_target, inc_lineno)
+                      logger.warn message_with_context %(mismatched end tag in include: expected #{active_tag}, found #{this_tag}), :source_location => (Cursor.new inc_path, nil, expanded_target, inc_lineno)
                     else
-                      logger.warn enrich_message %(unexpected end tag in include: #{this_tag}), :source_location => (Cursor.new inc_path, nil, expanded_target, inc_lineno)
+                      logger.warn message_with_context %(unexpected end tag in include: #{this_tag}), :source_location => (Cursor.new inc_path, nil, expanded_target, inc_lineno)
                     end
                   end
                 elsif inc_tags.key?(this_tag = $2)
@@ -960,11 +960,11 @@ class PreprocessorReader < Reader
             end
           end
         rescue
-          logger.error enrich_message %(include #{target_type} not readable: #{inc_path}), :source_location => cursor
+          logger.error message_with_context %(include #{target_type} not readable: #{inc_path}), :source_location => cursor
           return replace_next_line %(Unresolved directive in #{@path} - include::#{expanded_target}[#{attrlist}])
         end
         unless (missing_tags = inc_tags.keys.to_a - tags_used.to_a).empty?
-          logger.warn enrich_message %(tag#{missing_tags.size > 1 ? 's' : ''} '#{missing_tags * ','}' not found in include #{target_type}: #{inc_path}), :source_location => cursor
+          logger.warn message_with_context %(tag#{missing_tags.size > 1 ? 's' : ''} '#{missing_tags * ','}' not found in include #{target_type}: #{inc_path}), :source_location => cursor
         end
         shift
         # FIXME not accounting for skipped lines in reader line numbering
@@ -976,7 +976,7 @@ class PreprocessorReader < Reader
           shift
           push_include inc_content, inc_path, relpath, 1, parsed_attributes
         rescue
-          logger.error enrich_message %(include #{target_type} not readable: #{inc_path}), :source_location => cursor
+          logger.error message_with_context %(include #{target_type} not readable: #{inc_path}), :source_location => cursor
           return replace_next_line %(Unresolved directive in #{@path} - include::#{expanded_target}[#{attrlist}])
         end
       end
@@ -1022,7 +1022,7 @@ class PreprocessorReader < Reader
           shift
           return true
         else
-          logger.error enrich_message %(include file not found: #{inc_path}), :source_location => cursor
+          logger.error message_with_context %(include file not found: #{inc_path}), :source_location => cursor
           return replace_next_line %(Unresolved directive in #{@path} - include::#{target}[#{attrlist}])
         end
       end

--- a/lib/asciidoctor/substitutors.rb
+++ b/lib/asciidoctor/substitutors.rb
@@ -1051,7 +1051,7 @@ module Substitutors
           if @document.attributes['docname'] == path || @document.catalog[:includes].include?(path)
             if fragment
               refid, path, target = fragment, nil, %(##{fragment})
-              if $VERBOSE
+              if logger.debug?
                 logger.warn %(invalid reference: #{fragment}) unless @document.catalog[:ids].key? fragment
               end
             else
@@ -1070,7 +1070,7 @@ module Substitutors
                 ((fragment.include? ' ') || fragment.downcase != fragment) &&
                 (resolved_id = @document.catalog[:ids].key fragment)
               fragment = resolved_id
-            elsif $VERBOSE
+            elsif logger.debug?
               logger.warn %(invalid reference: #{fragment})
             end
           end

--- a/lib/asciidoctor/substitutors.rb
+++ b/lib/asciidoctor/substitutors.rb
@@ -131,7 +131,7 @@ module Substitutors
       when :post_replacements
         text = sub_post_replacements text
       else
-        warn %(asciidoctor: WARNING: unknown substitution type #{type})
+        logger.warn %(unknown substitution type #{type})
       end
     end
     text = restore_passthroughs text if has_passthroughs
@@ -509,11 +509,11 @@ module Substitutors
             reject_if_empty = true
             ''
           when 'drop-line'
-            warn %(asciidoctor: WARNING: dropping line containing reference to missing attribute: #{key})
+            logger.warn %(dropping line containing reference to missing attribute: #{key})
             reject = true
             break ''
           when 'warn'
-            warn %(asciidoctor: WARNING: skipping reference to missing attribute: #{key})
+            logger.warn %(skipping reference to missing attribute: #{key})
             $&
           else # 'skip'
             $&
@@ -1052,7 +1052,7 @@ module Substitutors
             if fragment
               refid, path, target = fragment, nil, %(##{fragment})
               if $VERBOSE
-                warn %(asciidoctor: WARNING: invalid reference: #{fragment}) unless @document.catalog[:ids].key? fragment
+                logger.warn %(invalid reference: #{fragment}) unless @document.catalog[:ids].key? fragment
               end
             else
               refid, path, target = nil, nil, '#'
@@ -1071,7 +1071,7 @@ module Substitutors
                 (resolved_id = @document.catalog[:ids].key fragment)
               fragment = resolved_id
             elsif $VERBOSE
-              warn %(asciidoctor: WARNING: invalid reference: #{fragment})
+              logger.warn %(invalid reference: #{fragment})
             end
           end
           refid, target = fragment, %(##{fragment})
@@ -1339,7 +1339,7 @@ module Substitutors
     resolved = candidates & SUB_OPTIONS[type]
     unless (candidates - resolved).empty?
       invalid = candidates - resolved
-      warn %(asciidoctor: WARNING: invalid substitution type#{invalid.size > 1 ? 's' : ''}#{subject ? ' for ' : nil}#{subject}: #{invalid * ', '})
+      logger.warn %(invalid substitution type#{invalid.size > 1 ? 's' : ''}#{subject ? ' for ' : ''}#{subject}: #{invalid * ', '})
     end
     resolved
   end

--- a/lib/asciidoctor/table.rb
+++ b/lib/asciidoctor/table.rb
@@ -314,6 +314,8 @@ end
 # instantiated, the row is closed if the cell satisifies the column count and,
 # finally, a new buffer is allocated to track the next cell.
 class Table::ParserContext
+  include Logging
+
   # Public: An Array of String keys that represent the table formats in AsciiDoc
   #--
   # QUESTION should we recognize !sv as a valid format value?
@@ -365,7 +367,7 @@ class Table::ParserContext
           xsv = '!sv'
         end
       else
-        warn %(asciidoctor: ERROR: #{reader.prev_line_info}: illegal table format: #{xsv})
+        logger.error %(#{reader.prev_line_info}: illegal table format: #{xsv})
         @format, xsv = 'psv', (table.document.nested? ? '!sv' : 'psv')
       end
     else
@@ -519,7 +521,7 @@ class Table::ParserContext
       if (cellspec = take_cellspec)
         repeat = cellspec.delete('repeatcol') || 1
       else
-        warn %(asciidoctor: ERROR: #{@last_cursor.line_info}: table missing leading separator, recovering automatically)
+        logger.error %(#{@last_cursor.line_info}: table missing leading separator, recovering automatically)
         cellspec = {}
         repeat = 1
       end
@@ -556,7 +558,7 @@ class Table::ParserContext
       else
         # QUESTION is this right for cells that span columns?
         unless (column = @table.columns[@current_row.size])
-          warn %(asciidoctor: ERROR: #{@last_cursor.line_info}: dropping cell because it exceeds specified number of columns)
+          logger.error %(#{@last_cursor.line_info}: dropping cell because it exceeds specified number of columns)
           return
         end
       end

--- a/lib/asciidoctor/table.rb
+++ b/lib/asciidoctor/table.rb
@@ -367,7 +367,7 @@ class Table::ParserContext
           xsv = '!sv'
         end
       else
-        logger.error %(#{reader.prev_line_info}: illegal table format: #{xsv})
+        logger.error enrich_message %(illegal table format: #{xsv}), :source_location => reader.prev_line_cursor
         @format, xsv = 'psv', (table.document.nested? ? '!sv' : 'psv')
       end
     else
@@ -521,7 +521,7 @@ class Table::ParserContext
       if (cellspec = take_cellspec)
         repeat = cellspec.delete('repeatcol') || 1
       else
-        logger.error %(#{@last_cursor.line_info}: table missing leading separator, recovering automatically)
+        logger.error enrich_message 'table missing leading separator, recovering automatically', :source_location => @last_cursor
         cellspec = {}
         repeat = 1
       end
@@ -558,7 +558,7 @@ class Table::ParserContext
       else
         # QUESTION is this right for cells that span columns?
         unless (column = @table.columns[@current_row.size])
-          logger.error %(#{@last_cursor.line_info}: dropping cell because it exceeds specified number of columns)
+          logger.error enrich_message 'dropping cell because it exceeds specified number of columns', :source_location => @last_cursor
           return
         end
       end

--- a/lib/asciidoctor/table.rb
+++ b/lib/asciidoctor/table.rb
@@ -367,7 +367,7 @@ class Table::ParserContext
           xsv = '!sv'
         end
       else
-        logger.error enrich_message %(illegal table format: #{xsv}), :source_location => reader.prev_line_cursor
+        logger.error message_with_context %(illegal table format: #{xsv}), :source_location => reader.prev_line_cursor
         @format, xsv = 'psv', (table.document.nested? ? '!sv' : 'psv')
       end
     else
@@ -521,7 +521,7 @@ class Table::ParserContext
       if (cellspec = take_cellspec)
         repeat = cellspec.delete('repeatcol') || 1
       else
-        logger.error enrich_message 'table missing leading separator, recovering automatically', :source_location => @last_cursor
+        logger.error message_with_context 'table missing leading separator, recovering automatically', :source_location => @last_cursor
         cellspec = {}
         repeat = 1
       end
@@ -558,7 +558,7 @@ class Table::ParserContext
       else
         # QUESTION is this right for cells that span columns?
         unless (column = @table.columns[@current_row.size])
-          logger.error enrich_message 'dropping cell because it exceeds specified number of columns', :source_location => @last_cursor
+          logger.error message_with_context 'dropping cell because it exceeds specified number of columns', :source_location => @last_cursor
           return
         end
       end

--- a/test/attributes_test.rb
+++ b/test/attributes_test.rb
@@ -5,7 +5,7 @@ unless defined? ASCIIDOCTOR_PROJECT_DIR
 end
 
 context 'Attributes' do
-  logger = Asciidoctor::Logger::MemoryLogger.new
+  logger = Asciidoctor::MemoryLogger.new
   default_logger = Asciidoctor::LoggerManager.logger
 
   setup do

--- a/test/attributes_test.rb
+++ b/test/attributes_test.rb
@@ -5,12 +5,10 @@ unless defined? ASCIIDOCTOR_PROJECT_DIR
 end
 
 context 'Attributes' do
-  logger = Asciidoctor::MemoryLogger.new
   default_logger = Asciidoctor::LoggerManager.logger
 
   setup do
-    logger.messages.clear
-    Asciidoctor::LoggerManager.logger = logger
+    Asciidoctor::LoggerManager.logger = (@logger = Asciidoctor::MemoryLogger.new)
   end
 
   teardown do
@@ -147,11 +145,7 @@ linus.torvalds@example.com
     test 'assigns attribute to empty string if substitution fails to resolve attribute' do
       input = ':release: Asciidoctor {version}'
       document_from_string input, :attributes => { 'attribute-missing' => 'drop-line' }
-      assert_equal 1, logger.messages.size
-      message = logger.messages[0]
-      assert_equal :WARN, message[:severity]
-      assert_kind_of String, message[:message]
-      assert_equal 'dropping line containing reference to missing attribute: version', message[:message]
+      assert_message @logger, :WARN, 'dropping line containing reference to missing attribute: version'
     end
 
     test 'assigns multi-line attribute to empty string if substitution fails to resolve attribute' do
@@ -161,11 +155,7 @@ linus.torvalds@example.com
       EOS
       doc = document_from_string input, :attributes => { 'attribute-missing' => 'drop-line' }
       assert_equal '', doc.attributes['release']
-      assert_equal 1, logger.messages.size
-      message = logger.messages[0]
-      assert_equal :WARN, message[:severity]
-      assert_kind_of String, message[:message]
-      assert_equal 'dropping line containing reference to missing attribute: version', message[:message]
+      assert_message @logger, :WARN, 'dropping line containing reference to missing attribute: version'
     end
 
     test 'resolves attributes inside attribute value within header' do
@@ -621,11 +611,7 @@ all there is.
       output = render_embedded_string input
       para = xmlnodes_at_css 'p', output, 1
       refute_includes 'blah blah', para.content
-      assert_equal logger.messages.size, 1
-      message = logger.messages[0]
-      assert_equal :WARN, message[:severity]
-      assert_kind_of String, message[:message]
-      assert_equal 'dropping line containing reference to missing attribute: foobarbaz', message[:message]
+      assert_message @logger, :WARN, 'dropping line containing reference to missing attribute: foobarbaz'
     end
 
     test "attribute value gets interpretted when rendering" do
@@ -646,11 +632,7 @@ Line 2: Oh no, a {bogus-attribute}! This line should not appear in the output.
       output = render_embedded_string input
       assert_match(/Line 1/, output)
       refute_match(/Line 2/, output)
-      assert_equal logger.messages.size, 1
-      message = logger.messages[0]
-      assert_equal :WARN, message[:severity]
-      assert_kind_of String, message[:message]
-      assert_equal 'dropping line containing reference to missing attribute: bogus-attribute', message[:message]
+      assert_message @logger, :WARN, 'dropping line containing reference to missing attribute: bogus-attribute'
     end
 
     test 'should not drop line with reference to missing attribute by default' do

--- a/test/blocks_test.rb
+++ b/test/blocks_test.rb
@@ -5,7 +5,7 @@ unless defined? ASCIIDOCTOR_PROJECT_DIR
 end
 
 context 'Blocks' do
-  logger = Asciidoctor::Logger::MemoryLogger.new
+  logger = Asciidoctor::MemoryLogger.new
   default_logger = Asciidoctor::LoggerManager.logger
 
   setup do

--- a/test/document_test.rb
+++ b/test/document_test.rb
@@ -345,11 +345,7 @@ content
         refute_empty output
         assert_css 'script', output, 0
         assert_xpath %(//meta[@name="copyright"][@content="(C) OpenDevise"]), output, 1
-        assert_equal 1, logger.messages.size
-        message = logger.messages[0]
-        assert_equal :WARN, message[:severity]
-        assert_kind_of String, message[:message]
-        assert_includes message[:message], 'dropping line containing reference to missing attribute: bootstrap-version'
+        assert_message logger, :WARN, 'dropping line containing reference to missing attribute: bootstrap-version'
       end
     end
 

--- a/test/document_test.rb
+++ b/test/document_test.rb
@@ -336,18 +336,21 @@ content
 
     test 'should substitute attributes in docinfo files by default' do
       sample_input_path = fixture_path 'subs.adoc'
-      output, warnings = redirect_streams do |_, err|
+      using_memory_logger do |logger|
         output = Asciidoctor.convert_file sample_input_path,
             :to_file => false,
             :header_footer => true,
             :safe => :server,
             :attributes => { 'docinfo' => '', 'bootstrap-version' => nil, 'linkcss' => '', 'attribute-missing' => 'drop-line' }
-        [output, err.string]
+        refute_empty output
+        assert_css 'script', output, 0
+        assert_xpath %(//meta[@name="copyright"][@content="(C) OpenDevise"]), output, 1
+        assert_equal 1, logger.messages.size
+        message = logger.messages[0]
+        assert_equal :WARN, message[:severity]
+        assert_kind_of String, message[:message]
+        assert_includes message[:message], 'dropping line containing reference to missing attribute: bootstrap-version'
       end
-      refute_empty output
-      assert_css 'script', output, 0
-      assert_xpath %(//meta[@name="copyright"][@content="(C) OpenDevise"]), output, 1
-      assert_includes warnings, 'dropping line containing reference to missing attribute'
     end
 
     test 'should apply explicit substitutions to docinfo files' do
@@ -1749,10 +1752,12 @@ asciidoctor - converts AsciiDoc source files to HTML, DocBook and other formats
 
     test 'keeps naughty relative paths from getting outside' do
       naughty_path = 'safe/ok/../../../../../etc/passwd'
-      doc = empty_document
-      secure_path = redirect_streams { doc.normalize_asset_path(naughty_path) }
-      refute_equal naughty_path, secure_path
-      assert_match(/^#{doc.base_dir}/, secure_path)
+      using_memory_logger do
+        doc = empty_document
+        secure_path = doc.normalize_asset_path naughty_path
+        refute_equal naughty_path, secure_path
+        assert_match(/^#{doc.base_dir}/, secure_path)
+      end
     end
 
     test 'should raise an exception when a converter cannot be resolved before conversion' do

--- a/test/links_test.rb
+++ b/test/links_test.rb
@@ -462,11 +462,7 @@ anchor:foo[b[a\]r]text'
       doc.catalog[:includes] << 'tigers'
       output = doc.convert
       assert_xpath '//a[@href="#about"][text() = "About Tigers"]', output, 1
-      assert_equal 1, logger.messages.size
-      message = logger.messages[0]
-      assert_equal :WARN, message[:severity]
-      assert_kind_of String, message[:message]
-      assert_equal 'invalid reference: about', message[:message]
+      assert_message logger, :WARN, 'invalid reference: about'
     end
   end
 
@@ -476,11 +472,7 @@ anchor:foo[b[a\]r]text'
       doc.catalog[:includes] << 'part1/tigers'
       output = doc.convert
       assert_xpath '//a[@href="#about"][text() = "About Tigers"]', output, 1
-      assert_equal 1, logger.messages.size
-      message = logger.messages[0]
-      assert_equal :WARN, message[:severity]
-      assert_kind_of String, message[:message]
-      assert_equal 'invalid reference: about', message[:message]
+      assert_message logger, :WARN, 'invalid reference: about'
     end
   end
 
@@ -640,11 +632,7 @@ See <<foobaz>>.
     using_memory_logger true do |logger|
       output = render_embedded_string input
       assert_xpath '//a[@href="#foobaz"][text() = "[foobaz]"]', output, 1
-      assert_equal 1, logger.messages.size
-      message = logger.messages[0]
-      assert_equal :WARN, message[:severity]
-      assert_kind_of String, message[:message]
-      assert_equal 'invalid reference: foobaz', message[:message]
+      assert_message logger, :WARN, 'invalid reference: foobaz'
     end
   end
 
@@ -660,11 +648,7 @@ See <<test.adoc#foobaz>>.
     using_memory_logger true do |logger|
       output = render_embedded_string input, :attributes => { 'docname' => 'test' }
       assert_xpath '//a[@href="#foobaz"][text() = "[foobaz]"]', output, 1
-      assert_equal 1, logger.messages.size
-      message = logger.messages[0]
-      assert_equal :WARN, message[:severity]
-      assert_kind_of String, message[:message]
-      assert_equal 'invalid reference: foobaz', message[:message]
+      assert_message logger, :WARN, 'invalid reference: foobaz'
     end
   end
 

--- a/test/links_test.rb
+++ b/test/links_test.rb
@@ -457,26 +457,30 @@ anchor:foo[b[a\]r]text'
   end
 
   test 'xref using angled bracket syntax with path which has been included in this document' do
-    in_verbose_mode do
-      output, warnings = redirect_streams do |_, err|
-        doc = document_from_string '<<tigers#about,About Tigers>>', :header_footer => false
-        doc.catalog[:includes] << 'tigers'
-        [doc.convert, err.string]
-      end
+    using_memory_logger true do |logger|
+      doc = document_from_string '<<tigers#about,About Tigers>>', :header_footer => false
+      doc.catalog[:includes] << 'tigers'
+      output = doc.convert
       assert_xpath '//a[@href="#about"][text() = "About Tigers"]', output, 1
-      assert_includes warnings, 'invalid reference: about'
+      assert_equal 1, logger.messages.size
+      message = logger.messages[0]
+      assert_equal :WARN, message[:severity]
+      assert_kind_of String, message[:message]
+      assert_equal 'invalid reference: about', message[:message]
     end
   end
 
   test 'xref using angled bracket syntax with nested path which has been included in this document' do
-    in_verbose_mode do
-      output, warnings = redirect_streams do |_, err|
-        doc = document_from_string '<<part1/tigers#about,About Tigers>>', :header_footer => false
-        doc.catalog[:includes] << 'part1/tigers'
-        [doc.convert, err.string]
-      end
+    using_memory_logger true do |logger|
+      doc = document_from_string '<<part1/tigers#about,About Tigers>>', :header_footer => false
+      doc.catalog[:includes] << 'part1/tigers'
+      output = doc.convert
       assert_xpath '//a[@href="#about"][text() = "About Tigers"]', output, 1
-      assert_includes warnings, 'invalid reference: about'
+      assert_equal 1, logger.messages.size
+      message = logger.messages[0]
+      assert_equal :WARN, message[:severity]
+      assert_kind_of String, message[:message]
+      assert_equal 'invalid reference: about', message[:message]
     end
   end
 
@@ -633,11 +637,14 @@ see <<foo>>'
 
 See <<foobaz>>.
     EOS
-    in_verbose_mode do
-      output, warnings = redirect_streams {|_, err| [(render_embedded_string input), err.string] }
+    using_memory_logger true do |logger|
+      output = render_embedded_string input
       assert_xpath '//a[@href="#foobaz"][text() = "[foobaz]"]', output, 1
-      refute_empty warnings
-      assert_includes warnings, 'asciidoctor: WARNING: invalid reference: foobaz'
+      assert_equal 1, logger.messages.size
+      message = logger.messages[0]
+      assert_equal :WARN, message[:severity]
+      assert_kind_of String, message[:message]
+      assert_equal 'invalid reference: foobaz', message[:message]
     end
   end
 
@@ -650,11 +657,14 @@ See <<foobaz>>.
 
 See <<test.adoc#foobaz>>.
     EOS
-    in_verbose_mode do
-      output, warnings = redirect_streams {|_, err| [(render_embedded_string input, :attributes => { 'docname' => 'test' }), err.string] }
+    using_memory_logger true do |logger|
+      output = render_embedded_string input, :attributes => { 'docname' => 'test' }
       assert_xpath '//a[@href="#foobaz"][text() = "[foobaz]"]', output, 1
-      refute_empty warnings
-      assert_includes warnings, 'asciidoctor: WARNING: invalid reference: foobaz'
+      assert_equal 1, logger.messages.size
+      message = logger.messages[0]
+      assert_equal :WARN, message[:severity]
+      assert_kind_of String, message[:message]
+      assert_equal 'invalid reference: foobaz', message[:message]
     end
   end
 

--- a/test/lists_test.rb
+++ b/test/lists_test.rb
@@ -1773,12 +1773,7 @@ III) three
     using_memory_logger do |logger|
       output = render_embedded_string input
       assert_xpath '//ol/li', output, 2
-      assert_equal 1, logger.messages.size
-      message = logger.messages[0]
-      assert_equal :WARN, message[:severity]
-      refute_kind_of String, message[:message]
-      refute_nil message[:message][:source_location]
-      assert_equal '<stdin>: line 2: list item index: expected II, got III', message[:message].inspect
+      assert_message logger, :WARN, '<stdin>: line 2: list item index: expected II, got III', Hash
     end
   end
 
@@ -1790,12 +1785,7 @@ iii) three
     using_memory_logger do |logger|
       output = render_embedded_string input
       assert_xpath '//ol/li', output, 2
-      assert_equal 1, logger.messages.size
-      message = logger.messages[0]
-      assert_equal :WARN, message[:severity]
-      refute_kind_of String, message[:message]
-      refute_nil message[:message][:source_location]
-      assert_equal '<stdin>: line 2: list item index: expected ii, got iii', message[:message].inspect
+      assert_message logger, :WARN, '<stdin>: line 2: list item index: expected ii, got iii', Hash
     end
   end
 end
@@ -4246,12 +4236,7 @@ foo::
       assert_xpath '//dl//b', output, 0
       assert_xpath '//dl/dd/p[text()="bar <1>"]', output, 1
       assert_xpath '//ol/li/p[text()="Not pointing to a callout"]', output, 1
-      assert_equal 1, logger.messages.size
-      message = logger.messages[0]
-      assert_equal :WARN, message[:severity]
-      refute_kind_of String, message[:message]
-      refute_nil message[:message][:source_location]
-      assert_equal '<stdin>: line 4: no callouts refer to list item 1', message[:message].inspect
+      assert_message logger, :WARN, '<stdin>: line 4: no callouts refer to list item 1', Hash
     end
   end
 
@@ -4267,12 +4252,7 @@ foo::
       assert_xpath '//ul//b', output, 0
       assert_xpath %(//ul/li/p[text()="foo\nbar <1>"]), output, 1
       assert_xpath '//ol/li/p[text()="Not pointing to a callout"]', output, 1
-      assert_equal 1, logger.messages.size
-      message = logger.messages[0]
-      assert_equal :WARN, message[:severity]
-      refute_kind_of String, message[:message]
-      refute_nil message[:message][:source_location]
-      assert_equal '<stdin>: line 4: no callouts refer to list item 1', message[:message].inspect
+      assert_message logger, :WARN, '<stdin>: line 4: no callouts refer to list item 1', Hash
     end
   end
 
@@ -4290,17 +4270,10 @@ Beans are fun.
     using_memory_logger do |logger|
       output = render_embedded_string input
       assert_xpath '//ol/li', output, 2
-      assert_equal 2, logger.messages.size
-      message = logger.messages[0]
-      assert_equal :WARN, message[:severity]
-      refute_kind_of String, message[:message]
-      refute_nil message[:message][:source_location]
-      assert_equal '<stdin>: line 8: callout list item index: expected 2 got 3', message[:message].inspect
-      message = logger.messages[1]
-      assert_equal :WARN, message[:severity]
-      refute_kind_of String, message[:message]
-      refute_nil message[:message][:source_location]
-      assert_equal '<stdin>: line 8: no callouts refer to list item 2', message[:message].inspect
+      assert_messages logger, [
+        [:WARN, '<stdin>: line 8: callout list item index: expected 2 got 3', Hash],
+        [:WARN, '<stdin>: line 8: no callouts refer to list item 2', Hash]
+      ]
     end
   end
 

--- a/test/logger_test.rb
+++ b/test/logger_test.rb
@@ -5,6 +5,8 @@ unless defined? ASCIIDOCTOR_PROJECT_DIR
 end
 
 context 'Logger' do
+  MyLogger = Class.new Logger
+
   context 'LoggerManager' do
     test 'provides access to logger via static logger method' do
       logger = Asciidoctor::LoggerManager.logger
@@ -84,7 +86,7 @@ context 'Logger' do
   end
 
   context 'Logging' do
-    test 'including Logging gives instance methods on module access to logger via private logger method' do
+    test 'including Logging gives instance methods on module access to logging infrastructure' do
       module SampleModuleA
         include Asciidoctor::Logging
         def get_logger
@@ -99,7 +101,7 @@ context 'Logger' do
       assert SampleClassA.private_method_defined? :logger
     end
 
-    test 'including Logging gives static methods on module access to logger via logger method' do
+    test 'including Logging gives static methods on module access to logging infrastructure' do
       module SampleModuleB
         include Asciidoctor::Logging
         def self.get_logger
@@ -110,7 +112,7 @@ context 'Logger' do
       assert_same Asciidoctor::LoggerManager.logger, SampleModuleB.get_logger
     end
 
-    test 'including Logging gives instance methods on class access to logger via private logger method' do
+    test 'including Logging gives instance methods on class access to logging infrastructure' do
       class SampleClassC
         include Asciidoctor::Logging
         def get_logger
@@ -122,7 +124,7 @@ context 'Logger' do
       assert SampleClassC.private_method_defined? :logger
     end
 
-    test 'including Logging gives static methods on class access to logger via logger method' do
+    test 'including Logging gives static methods on class access to logging infrastructure' do
       class SampleClassD
         include Asciidoctor::Logging
         def self.get_logger
@@ -131,6 +133,21 @@ context 'Logger' do
       end
 
       assert_same Asciidoctor::LoggerManager.logger, SampleClassD.get_logger
+    end
+
+    test 'can enrich and auto-format message' do
+      class SampleClassE
+        include Asciidoctor::Logging
+        def create_message cursor
+          enrich_message 'Asciidoctor was here', :source_location => cursor
+        end
+      end
+
+      cursor = Asciidoctor::Reader::Cursor.new 'file.adoc', fixturedir, 'file.adoc', 5
+      message = SampleClassE.new.create_message cursor
+      assert_equal 'Asciidoctor was here', message[:text]
+      assert_same cursor, message[:source_location]
+      assert_equal 'file.adoc: line 5: Asciidoctor was here', message.inspect
     end
   end
 end

--- a/test/logger_test.rb
+++ b/test/logger_test.rb
@@ -15,9 +15,8 @@ context 'Logger' do
     end
 
     test 'allows logger instance to be changed' do
-      class MyLoggerA < Logger; end
       old_logger = Asciidoctor::LoggerManager.logger
-      new_logger = MyLoggerA.new $stdout
+      new_logger = MyLogger.new $stdout
       begin
         Asciidoctor::LoggerManager.logger = new_logger
         assert_same new_logger, Asciidoctor::LoggerManager.logger
@@ -27,10 +26,9 @@ context 'Logger' do
     end
 
     test 'setting logger instance to falsy value resets instance to default logger' do
-      class MyLoggerB < Logger; end
       old_logger = Asciidoctor::LoggerManager.logger
       begin
-        Asciidoctor::LoggerManager.logger = MyLoggerB.new $stdout
+        Asciidoctor::LoggerManager.logger = MyLogger.new $stdout
         Asciidoctor::LoggerManager.logger = nil
         refute_nil Asciidoctor::LoggerManager.logger
         assert_kind_of Logger, Asciidoctor::LoggerManager.logger
@@ -40,14 +38,13 @@ context 'Logger' do
     end
 
     test 'creates logger instance from static logger_class property' do
-      class MyLoggerC < Logger; end
       old_logger_class = Asciidoctor::LoggerManager.logger_class
       old_logger = Asciidoctor::LoggerManager.logger
       begin
-        Asciidoctor::LoggerManager.logger_class = MyLoggerC
+        Asciidoctor::LoggerManager.logger_class = MyLogger
         Asciidoctor::LoggerManager.logger = nil
         refute_nil Asciidoctor::LoggerManager.logger
-        assert_kind_of MyLoggerC, Asciidoctor::LoggerManager.logger
+        assert_kind_of MyLogger, Asciidoctor::LoggerManager.logger
       ensure
         Asciidoctor::LoggerManager.logger_class = old_logger_class
         Asciidoctor::LoggerManager.logger = old_logger
@@ -56,11 +53,11 @@ context 'Logger' do
   end
 
   context 'Logger' do
-    test 'configures default logger with progname equal to asciidoctor' do
+    test 'configures default logger with progname set to asciidoctor' do
       assert_equal 'asciidoctor', Asciidoctor::LoggerManager.logger.progname
     end
 
-    test 'configures default logger with level equal to WARN' do
+    test 'configures default logger with level set to WARN' do
       assert_equal Logger::Severity::WARN, Asciidoctor::LoggerManager.logger.level
     end
 
@@ -82,6 +79,52 @@ context 'Logger' do
       end
       assert_includes err_string, %(asciidoctor: WARNING: this is a call)
       assert_includes err_string, %(asciidoctor: FAILED: it cannot be done)
+    end
+  end
+
+  context ':logger API option' do
+    test 'should be able to set logger when invoking load API' do
+      old_logger = Asciidoctor::LoggerManager.logger
+      new_logger = MyLogger.new $stdout
+      begin
+        Asciidoctor.load 'contents', :logger => new_logger
+        assert_same new_logger, Asciidoctor::LoggerManager.logger
+      ensure
+        Asciidoctor::LoggerManager.logger = old_logger
+      end
+    end
+
+    test 'should be able to set logger when invoking load_file API' do
+      old_logger = Asciidoctor::LoggerManager.logger
+      new_logger = MyLogger.new $stdout
+      begin
+        Asciidoctor.load_file fixture_path('basic.asciidoc'), :logger => new_logger
+        assert_same new_logger, Asciidoctor::LoggerManager.logger
+      ensure
+        Asciidoctor::LoggerManager.logger = old_logger
+      end
+    end
+
+    test 'should be able to set logger when invoking convert API' do
+      old_logger = Asciidoctor::LoggerManager.logger
+      new_logger = MyLogger.new $stdout
+      begin
+        Asciidoctor.convert 'contents', :logger => new_logger
+        assert_same new_logger, Asciidoctor::LoggerManager.logger
+      ensure
+        Asciidoctor::LoggerManager.logger = old_logger
+      end
+    end
+
+    test 'should be able to set logger when invoking convert_file API' do
+      old_logger = Asciidoctor::LoggerManager.logger
+      new_logger = MyLogger.new $stdout
+      begin
+        Asciidoctor.convert_file fixture_path('basic.asciidoc'), :to_file => false, :logger => new_logger
+        assert_same new_logger, Asciidoctor::LoggerManager.logger
+      ensure
+        Asciidoctor::LoggerManager.logger = old_logger
+      end
     end
   end
 

--- a/test/logger_test.rb
+++ b/test/logger_test.rb
@@ -178,11 +178,11 @@ context 'Logger' do
       assert_same Asciidoctor::LoggerManager.logger, SampleClassD.get_logger
     end
 
-    test 'can enrich and auto-format message' do
+    test 'can create an auto-formatting message with context' do
       class SampleClassE
         include Asciidoctor::Logging
         def create_message cursor
-          enrich_message 'Asciidoctor was here', :source_location => cursor
+          message_with_context 'Asciidoctor was here', :source_location => cursor
         end
       end
 

--- a/test/logger_test.rb
+++ b/test/logger_test.rb
@@ -1,0 +1,136 @@
+# encoding: UTF-8
+unless defined? ASCIIDOCTOR_PROJECT_DIR
+  $: << File.dirname(__FILE__); $:.uniq!
+  require 'test_helper'
+end
+
+context 'Logger' do
+  context 'LoggerManager' do
+    test 'provides access to logger via static logger method' do
+      logger = Asciidoctor::LoggerManager.logger
+      refute_nil logger
+      assert_kind_of Logger, logger
+    end
+
+    test 'allows logger instance to be changed' do
+      class MyLoggerA < Logger; end
+      old_logger = Asciidoctor::LoggerManager.logger
+      new_logger = MyLoggerA.new $stdout
+      begin
+        Asciidoctor::LoggerManager.logger = new_logger
+        assert_same new_logger, Asciidoctor::LoggerManager.logger
+      ensure
+        Asciidoctor::LoggerManager.logger = old_logger
+      end
+    end
+
+    test 'setting logger instance to falsy value resets instance to default logger' do
+      class MyLoggerB < Logger; end
+      old_logger = Asciidoctor::LoggerManager.logger
+      begin
+        Asciidoctor::LoggerManager.logger = MyLoggerB.new $stdout
+        Asciidoctor::LoggerManager.logger = nil
+        refute_nil Asciidoctor::LoggerManager.logger
+        assert_kind_of Logger, Asciidoctor::LoggerManager.logger
+      ensure
+        Asciidoctor::LoggerManager.logger = old_logger
+      end
+    end
+
+    test 'creates logger instance from static logger_class property' do
+      class MyLoggerC < Logger; end
+      old_logger_class = Asciidoctor::LoggerManager.logger_class
+      old_logger = Asciidoctor::LoggerManager.logger
+      begin
+        Asciidoctor::LoggerManager.logger_class = MyLoggerC
+        Asciidoctor::LoggerManager.logger = nil
+        refute_nil Asciidoctor::LoggerManager.logger
+        assert_kind_of MyLoggerC, Asciidoctor::LoggerManager.logger
+      ensure
+        Asciidoctor::LoggerManager.logger_class = old_logger_class
+        Asciidoctor::LoggerManager.logger = old_logger
+      end
+    end
+  end
+
+  context 'Logger' do
+    test 'configures default logger with progname equal to asciidoctor' do
+      assert_equal 'asciidoctor', Asciidoctor::LoggerManager.logger.progname
+    end
+
+    test 'configures default logger with level equal to WARN' do
+      assert_equal Logger::Severity::WARN, Asciidoctor::LoggerManager.logger.level
+    end
+
+    test 'configures default logger to write messages to $stderr' do
+      out_string, err_string = redirect_streams do |out, err|
+        Asciidoctor::LoggerManager.logger.warn 'this is a call'
+        [out.string, err.string]
+      end
+      assert_empty out_string
+      refute_empty err_string
+      assert_includes err_string, 'this is a call'
+    end
+
+    test 'configures default logger to use a formatter that matches traditional format' do
+      err_string = redirect_streams do |_, err|
+        Asciidoctor::LoggerManager.logger.warn 'this is a call'
+        Asciidoctor::LoggerManager.logger.fatal 'it cannot be done'
+        err.string
+      end
+      assert_includes err_string, %(asciidoctor: WARNING: this is a call)
+      assert_includes err_string, %(asciidoctor: FAILED: it cannot be done)
+    end
+  end
+
+  context 'Logging' do
+    test 'including Logging gives instance methods on module access to logger via private logger method' do
+      module SampleModuleA
+        include Asciidoctor::Logging
+        def get_logger
+          logger
+        end
+      end
+
+      class SampleClassA
+        include SampleModuleA
+      end
+      assert_same Asciidoctor::LoggerManager.logger, SampleClassA.new.get_logger
+      assert SampleClassA.private_method_defined? :logger
+    end
+
+    test 'including Logging gives static methods on module access to logger via logger method' do
+      module SampleModuleB
+        include Asciidoctor::Logging
+        def self.get_logger
+          logger
+        end
+      end
+
+      assert_same Asciidoctor::LoggerManager.logger, SampleModuleB.get_logger
+    end
+
+    test 'including Logging gives instance methods on class access to logger via private logger method' do
+      class SampleClassC
+        include Asciidoctor::Logging
+        def get_logger
+          logger
+        end
+      end
+
+      assert_same Asciidoctor::LoggerManager.logger, SampleClassC.new.get_logger
+      assert SampleClassC.private_method_defined? :logger
+    end
+
+    test 'including Logging gives static methods on class access to logger via logger method' do
+      class SampleClassD
+        include Asciidoctor::Logging
+        def self.get_logger
+          logger
+        end
+      end
+
+      assert_same Asciidoctor::LoggerManager.logger, SampleClassD.get_logger
+    end
+  end
+end

--- a/test/logger_test.rb
+++ b/test/logger_test.rb
@@ -192,5 +192,20 @@ context 'Logger' do
       assert_same cursor, message[:source_location]
       assert_equal 'file.adoc: line 5: Asciidoctor was here', message.inspect
     end
+
+    test 'writes message prefixed with program name and source location to stderr' do
+      input = <<-EOS
+[#first]
+first paragraph
+
+[#first]
+another first paragraph
+      EOS
+      messages = redirect_streams do |_, err|
+        render_embedded_string input
+        err.string
+      end
+      assert_equal 'asciidoctor: WARNING: <stdin>: line 5: id assigned to block already in use: first', messages.chomp
+    end
   end
 end

--- a/test/paragraphs_test.rb
+++ b/test/paragraphs_test.rb
@@ -554,11 +554,7 @@ Wise words from a wise person.
         using_memory_logger do |logger|
           output =  render_string input, :doctype => 'inline'
           assert_nil output
-          assert_equal 1, logger.messages.size
-          message = logger.messages[0]
-          assert_equal :WARN, message[:severity]
-          assert_kind_of String, message[:message]
-          assert_includes message[:message], 'no inline candidate'
+          assert_message logger, :WARN, '~no inline candidate'
         end
       end
     end

--- a/test/paragraphs_test.rb
+++ b/test/paragraphs_test.rb
@@ -551,13 +551,15 @@ Wise words from a wise person.
 
       test 'should output nil and warn if first block is not a paragraph' do
         input = '* bullet'
-        output = nil
-        warnings = redirect_streams do |_, err|
+        using_memory_logger do |logger|
           output =  render_string input, :doctype => 'inline'
-          err.string
+          assert_nil output
+          assert_equal 1, logger.messages.size
+          message = logger.messages[0]
+          assert_equal :WARN, message[:severity]
+          assert_kind_of String, message[:message]
+          assert_includes message[:message], 'no inline candidate'
         end
-        assert_nil output
-        assert_includes warnings, 'no inline candidate'
       end
     end
   end

--- a/test/reader_test.rb
+++ b/test/reader_test.rb
@@ -257,13 +257,13 @@ third line
         reader = Asciidoctor::Reader.new SAMPLE_DATA, 'sample.adoc'
         reader.read_line
         assert_equal 'sample.adoc: line 2', reader.line_info
-        assert_equal 'sample.adoc: line 2', reader.next_line_info
+        assert_equal 'sample.adoc: line 2', reader.cursor.to_s
       end
 
-      test 'prev_line_info should return file name and line number of previous line read' do
+      test 'prev_line_cursor should return file name and line number of previous line read' do
         reader = Asciidoctor::Reader.new SAMPLE_DATA, 'sample.adoc'
         reader.read_line
-        assert_equal 'sample.adoc: line 1', reader.prev_line_info
+        assert_equal 'sample.adoc: line 1', reader.prev_line_cursor.to_s
       end
     end
 
@@ -601,7 +601,7 @@ include::fixtures/parent-include.adoc[]
 
         assert_equal 'first line of parent', reader.read_line
 
-        assert_equal 'fixtures/parent-include.adoc: line 1', reader.prev_line_info
+        assert_equal 'fixtures/parent-include.adoc: line 1', reader.prev_line_cursor.to_s
         assert_equal parent_include_docfile, reader.file
         assert_equal fixtures_dir, reader.dir
         assert_equal 'fixtures/parent-include.adoc', reader.path
@@ -610,7 +610,7 @@ include::fixtures/parent-include.adoc[]
 
         assert_equal 'first line of child', reader.read_line
 
-        assert_equal 'fixtures/child-include.adoc: line 1', reader.prev_line_info
+        assert_equal 'fixtures/child-include.adoc: line 1', reader.prev_line_cursor.to_s
         assert_equal child_include_docfile, reader.file
         assert_equal fixtures_dir, reader.dir
         assert_equal 'fixtures/child-include.adoc', reader.path
@@ -619,7 +619,7 @@ include::fixtures/parent-include.adoc[]
 
         assert_equal 'first line of grandchild', reader.read_line
 
-        assert_equal 'fixtures/grandchild-include.adoc: line 1', reader.prev_line_info
+        assert_equal 'fixtures/grandchild-include.adoc: line 1', reader.prev_line_cursor.to_s
         assert_equal grandchild_include_docfile, reader.file
         assert_equal fixtures_dir, reader.dir
         assert_equal 'fixtures/grandchild-include.adoc', reader.path
@@ -636,7 +636,7 @@ include::fixtures/parent-include.adoc[]
 
         assert_equal 'last line of parent', reader.read_line
 
-        assert_equal 'fixtures/parent-include.adoc: line 5', reader.prev_line_info
+        assert_equal 'fixtures/parent-include.adoc: line 5', reader.prev_line_cursor.to_s
         assert_equal parent_include_docfile, reader.file
         assert_equal fixtures_dir, reader.dir
         assert_equal 'fixtures/parent-include.adoc', reader.path

--- a/test/reader_test.rb
+++ b/test/reader_test.rb
@@ -650,12 +650,12 @@ trailing content
         EOS
 
         begin
-          doc, warnings = redirect_streams do |_, err|
-            [(document_from_string input, :safe => :safe, :base_dir => DIRNAME), err.string]
+          using_memory_logger do |logger|
+            doc = document_from_string input, :safe => :safe, :base_dir => DIRNAME
+            assert_equal 1, doc.blocks.size
+            assert_equal ['trailing content'], doc.blocks[0].lines
+            assert logger.empty?
           end
-          assert_equal 1, doc.blocks.size
-          assert_equal ['trailing content'], doc.blocks[0].lines
-          assert_equal 0, warnings.size
         rescue
           flunk 'include directive should not raise exception on missing file'
         end
@@ -669,13 +669,13 @@ trailing content
         EOS
 
         begin
-          doc, warnings = redirect_streams do |_, err|
-            [(document_from_string input, :safe => :safe, :base_dir => DIRNAME), err.string]
+          using_memory_logger do |logger|
+            doc = document_from_string input, :safe => :safe, :base_dir => DIRNAME
+            assert_equal 2, doc.blocks.size
+            assert_equal ['Unresolved directive in <stdin> - include::fixtures/no-such-file.adoc[]'], doc.blocks[0].lines
+            assert_equal ['trailing content'], doc.blocks[1].lines
+            assert_message logger, :ERROR, '~<stdin>: line 1: include file not found', Hash
           end
-          assert_equal 2, doc.blocks.size
-          assert_equal ['Unresolved directive in <stdin> - include::fixtures/no-such-file.adoc[]'], doc.blocks[0].lines
-          assert_equal ['trailing content'], doc.blocks[1].lines
-          assert_includes warnings, 'include file not found'
         rescue
           flunk 'include directive should not raise exception on missing file'
         end
@@ -691,13 +691,13 @@ trailing content
         EOS
 
         begin
-          doc, warnings = redirect_streams do |_, err|
-            [(document_from_string input, :safe => :safe, :base_dir => DIRNAME), err.string]
+          using_memory_logger do |logger|
+            doc = document_from_string input, :safe => :safe, :base_dir => DIRNAME
+            assert_equal 2, doc.blocks.size
+            assert_equal ['Unresolved directive in <stdin> - include::fixtures/chapter-a.adoc[]'], doc.blocks[0].lines
+            assert_equal ['trailing content'], doc.blocks[1].lines
+            assert_message logger, :ERROR, '~<stdin>: line 1: include file not readable', Hash
           end
-          assert_equal 2, doc.blocks.size
-          assert_equal ['Unresolved directive in <stdin> - include::fixtures/chapter-a.adoc[]'], doc.blocks[0].lines
-          assert_equal ['trailing content'], doc.blocks[1].lines
-          assert_includes warnings, 'include file not readable'
         rescue
           flunk 'include directive should not raise exception on missing file'
         ensure
@@ -790,15 +790,13 @@ include::#{include_url}[]
 ....
         EOS
         begin
-          output, warnings = redirect_streams do |_, err|
+          using_memory_logger do |logger|
             result = using_test_webserver do
               render_embedded_string input, :safe => :safe, :attributes => {'allow-uri-read' => ''}
             end
-            [result, err.string]
+            assert_includes result, %(Unresolved directive in #{include_url} - include::#{nested_include_url}[])
+            assert_message logger, :ERROR, %(#{include_url}: line 1: include uri not readable: http://#{resolve_localhost}:9876/fixtures/#{nested_include_url}), Hash
           end
-
-          assert_includes output, %(Unresolved directive in #{include_url} - include::#{nested_include_url}[])
-          assert_includes warnings, 'include uri not readable'
         rescue
           flunk 'include directive should not raise exception on missing file'
         end
@@ -831,16 +829,14 @@ include::#{url}[]
         EOS
 
         begin
-          output = warnings = nil
-          redirect_streams do |_, err|
+          using_memory_logger do |logger|
             output = using_test_webserver do
               render_embedded_string input, :safe => :safe, :attributes => {'allow-uri-read' => ''}
             end
-            warnings = err.string
+            refute_nil output
+            assert_match(/Unresolved directive/, output)
+            assert_message logger, :ERROR, %(<stdin>: line 2: include uri not readable: #{url}), Hash
           end
-          refute_nil output
-          assert_match(/Unresolved directive/, output)
-          assert_includes warnings, 'include uri not readable'
         rescue
           flunk 'include directive should not raise exception on inaccessible uri'
         end
@@ -1085,12 +1081,10 @@ end)
 include::fixtures/include-file.asciidoc[tag=snippetZ]
         EOS
 
-        warnings = redirect_streams do |_, err|
+        using_memory_logger do |logger|
           render_embedded_string input, :safe => :safe, :base_dir => DIRNAME
-          err.string
+          assert_message logger, :WARN, '~<stdin>: line 1: tag \'snippetZ\' not found in include file', Hash
         end
-        refute_nil warnings
-        assert_match(/WARNING.*snippetZ/, warnings)
       end
 
       test 'should warn if end tag in included file is mismatched' do
@@ -1100,12 +1094,11 @@ include::fixtures/mismatched-end-tag.adoc[tags=a;b]
 ++++
         EOS
 
-        result, warnings = redirect_streams do |out, err|
-          [(render_embedded_string input, :safe => :safe, :base_dir => DIRNAME), err.string]
+        using_memory_logger do |logger|
+          result = render_embedded_string input, :safe => :safe, :base_dir => DIRNAME
+          assert_equal %(a\nb), result
+          assert_message logger, :WARN, 'fixtures/mismatched-end-tag.adoc: line 5: mismatched end tag in include: expected b, found a', Hash
         end
-        assert_equal %(a\nb), result
-        refute_nil warnings
-        assert_match(/WARNING: .*end tag/, warnings)
       end
 
       test 'include directive ignores tags attribute when empty' do
@@ -1212,13 +1205,13 @@ include::{fixturesdir}/include-file.{ext}[]
 include::{foodir}/include-file.asciidoc[]
         EOS
 
-        line, warnings = redirect_streams do |_, err|
+        using_memory_logger do |logger|
           doc = empty_safe_document :base_dir => DIRNAME
           reader = Asciidoctor::PreprocessorReader.new doc, input, nil, :normalize => true
-          [reader.read_line, err.string]
+          line = reader.read_line
+          assert_equal 'Unresolved directive in <stdin> - include::{foodir}/include-file.asciidoc[]', line
+          assert_message logger, :WARN, 'dropping line containing reference to missing attribute: foodir'
         end
-        assert_equal 'Unresolved directive in <stdin> - include::{foodir}/include-file.asciidoc[]', line
-        assert_includes warnings, 'dropping line containing reference to missing attribute'
       end
 
       test 'line is dropped if target of include directive resolves to empty and attribute-missing attribute is not skip' do
@@ -1226,13 +1219,13 @@ include::{foodir}/include-file.asciidoc[]
 include::{foodir}/include-file.asciidoc[]
         EOS
 
-        line, warnings = redirect_streams do |_, err|
+        using_memory_logger do |logger|
           doc = empty_safe_document :base_dir => DIRNAME, :attributes => {'attribute-missing' => 'drop'}
           reader = Asciidoctor::PreprocessorReader.new doc, input, nil, :normalize => true
-          [reader.read_line, err.string]
+          line = reader.read_line
+          assert_nil line
+          assert_message logger, :WARN, 'dropping line containing reference to missing attribute: foodir'
         end
-        assert_nil line
-        assert_includes warnings, 'dropping line containing reference to missing attribute'
       end
 
       test 'line following dropped include is not dropped' do
@@ -1241,13 +1234,13 @@ include::{foodir}/include-file.asciidoc[]
 yo
         EOS
 
-        line, warnings = redirect_streams do |_, err|
+        using_memory_logger do |logger|
           doc = empty_safe_document :base_dir => DIRNAME, :attributes => {'attribute-missing' => 'drop'}
           reader = Asciidoctor::PreprocessorReader.new doc, input, nil, :normalize => true
-          [reader.read_line, err.string]
+          line = reader.read_line
+          assert_equal 'yo', line
+          assert_message logger, :WARN, 'dropping line containing reference to missing attribute: foodir'
         end
-        assert_equal 'yo', line
-        assert_includes warnings, 'dropping line containing reference to missing attribute'
       end
 
       test 'escaped include directive is left unprocessed' do
@@ -1301,14 +1294,14 @@ include::include-file.asciidoc[]
 include::fixtures/parent-include.adoc[depth=1]
         EOS
 
-        lines, warnings = redirect_streams do |_, err|
+        using_memory_logger do |logger|
           pseudo_docfile = File.join DIRNAME, 'include-master.adoc'
           doc = empty_safe_document :base_dir => DIRNAME
           reader = Asciidoctor::PreprocessorReader.new doc, input, Asciidoctor::Reader::Cursor.new(pseudo_docfile), :normalize => true
-          [reader.readlines, err.string]
+          lines = reader.readlines
+          assert_includes lines, 'include::child-include.adoc[]'
+          assert_message logger, :ERROR, 'fixtures/parent-include.adoc: line 3: maximum include depth of 1 exceeded', Hash
         end
-        assert_includes lines, 'include::child-include.adoc[]'
-        assert_match(/maximum include depth .* exceeded/, warnings)
       end
 
       test 'include directive should be disabled if max include depth set in nested context has been exceeded' do
@@ -1316,15 +1309,15 @@ include::fixtures/parent-include.adoc[depth=1]
 include::fixtures/parent-include-restricted.adoc[depth=3]
         EOS
 
-        lines, warnings = redirect_streams do |_, err|
+        using_memory_logger do |logger|
           pseudo_docfile = File.join DIRNAME, 'include-master.adoc'
           doc = empty_safe_document :base_dir => DIRNAME
           reader = Asciidoctor::PreprocessorReader.new doc, input, Asciidoctor::Reader::Cursor.new(pseudo_docfile), :normalize => true
-          [reader.readlines, err.string]
+          lines = reader.readlines
+          assert_includes lines, 'first line of child'
+          assert_includes lines, 'include::grandchild-include.adoc[]'
+          assert_message logger, :ERROR, 'fixtures/child-include.adoc: line 3: maximum include depth of 1 exceeded', Hash
         end
-        assert_includes lines, 'first line of child'
-        assert_includes lines, 'include::grandchild-include.adoc[]'
-        assert_match(/maximum include depth .* exceeded/, warnings)
       end
 
       test 'read_lines_until should not process lines if process option is false' do

--- a/test/sections_test.rb
+++ b/test/sections_test.rb
@@ -240,12 +240,7 @@ content
         reftext = doc.catalog[:ids]['install']
         refute_nil reftext
         assert_equal 'First Install', reftext
-        assert_equal 1, logger.messages.size
-        message = logger.messages[0]
-        assert_equal :WARN, message[:severity]
-        refute_kind_of String, message[:message]
-        refute_nil message[:message][:source_location]
-        assert_equal '<stdin>: line 7: id assigned to section already in use: install', message[:message].inspect
+        assert_message logger, :WARN, '<stdin>: line 7: id assigned to section already in use: install', Hash
       end
     end
 
@@ -265,12 +260,7 @@ content
         reftext = doc.catalog[:ids]['install']
         refute_nil reftext
         assert_equal 'First Install', reftext
-        assert_equal 1, logger.messages.size
-        message = logger.messages[0]
-        assert_equal :WARN, message[:severity]
-        refute_kind_of String, message[:message]
-        refute_nil message[:message][:source_location]
-        assert_equal '<stdin>: line 7: id assigned to block already in use: install', message[:message].inspect
+        assert_message logger, :WARN, '<stdin>: line 7: id assigned to block already in use: install', Hash
       end
     end
   end
@@ -878,12 +868,7 @@ text in standalone
 
       using_memory_logger do |logger|
         render_string input
-        assert_equal 1, logger.messages.size
-        message = logger.messages[0]
-        assert_equal :ERROR, message[:severity]
-        refute_kind_of String, message[:message]
-        refute_nil message[:message][:source_location]
-        assert_equal '<stdin>: line 7: only book doctypes can contain level 0 sections', message[:message].inspect
+        assert_message logger, :ERROR, '<stdin>: line 7: only book doctypes can contain level 0 sections', Hash
       end
     end
 
@@ -917,7 +902,7 @@ Master section text.
       output = nil
       using_memory_logger do |logger|
         output = render_string input
-        assert logger.messages.empty?
+        assert logger.empty?
       end
 
       assert_match(/Master document written by Doc Writer/, output)
@@ -2964,12 +2949,7 @@ intro
 
       using_memory_logger do |logger|
         document_from_string input
-        assert_equal 1, logger.messages.size
-        message = logger.messages[0]
-        assert_equal :ERROR, message[:severity]
-        refute_kind_of String, message[:message]
-        refute_nil message[:message][:source_location]
-        assert_equal '<stdin>: line 8: invalid part, must have at least one section (e.g., chapter, appendix, etc.)', message[:message].inspect
+        assert_message logger, :ERROR, '<stdin>: line 8: invalid part, must have at least one section (e.g., chapter, appendix, etc.)', Hash
       end
     end
 
@@ -3054,7 +3034,7 @@ Appendix subsection content
       output = nil
       using_memory_logger do |logger|
         output = render_string input, :backend => 'docbook'
-        assert logger.messages.empty?
+        assert logger.empty?
       end
       assert_xpath '/book/preface', output, 1
       assert_xpath '/book/preface/section', output, 1

--- a/test/substitutions_test.rb
+++ b/test/substitutions_test.rb
@@ -840,7 +840,7 @@ context 'Substitutions' do
       using_memory_logger do |logger|
         sect = block_from_string input, :attributes => { 'data-uri' => '', 'iconsdir' => 'fixtures', 'docdir' => testdir }, :safe => :server, :catalog_assets => true
         assert_includes sect.document.catalog[:images], 'fixtures/dot.gif'
-        assert logger.messages.empty?
+        assert logger.empty?
       end
     end
 

--- a/test/substitutions_test.rb
+++ b/test/substitutions_test.rb
@@ -837,12 +837,11 @@ context 'Substitutions' do
 == image:{iconsdir}/dot.gif[dot] Title
       EOS
 
-      sect, warnings = redirect_streams do |_, err|
-        [(block_from_string input, :attributes => { 'data-uri' => '', 'iconsdir' => 'fixtures', 'docdir' => testdir }, :safe => :server, :catalog_assets => true), err.string]
+      using_memory_logger do |logger|
+        sect = block_from_string input, :attributes => { 'data-uri' => '', 'iconsdir' => 'fixtures', 'docdir' => testdir }, :safe => :server, :catalog_assets => true
+        assert_includes sect.document.catalog[:images], 'fixtures/dot.gif'
+        assert logger.messages.empty?
       end
-      assert_includes sect.document.catalog[:images], 'fixtures/dot.gif'
-      refute_nil warnings
-      assert_empty warnings
     end
 
     test 'an icon macro should be interpreted as an icon if icons are enabled' do

--- a/test/tables_test.rb
+++ b/test/tables_test.rb
@@ -162,13 +162,8 @@ A | here| a | there
         assert_xpath '/table/tbody/tr/td[2]/p[text()="here"]', output, 1
         assert_xpath '/table/tbody/tr/td[3]/p[text()="a"]', output, 1
         assert_xpath '/table/tbody/tr/td[4]/p[text()="there"]', output, 1
-        assert_equal 1, logger.messages.size
-        message = logger.messages[0]
-        assert_equal :ERROR, message[:severity]
-        refute_equal String, message[:message]
-        refute_nil message[:message][:source_location]
         # FIXME line number is wrong
-        assert_includes message[:message].inspect, 'table missing leading separator'
+        assert_message logger, :ERROR, '~table missing leading separator', Hash
       end
     end
 
@@ -884,13 +879,8 @@ more C
         output = render_embedded_string input
         assert_css 'table', output, 1
         assert_css 'table *', output, 0
-        assert_equal 1, logger.messages.size
-        message = logger.messages[0]
-        assert_equal :ERROR, message[:severity]
-        refute_equal String, message[:message]
-        refute_nil message[:message][:source_location]
         # FIXME line number is wrong
-        assert_includes message[:message].inspect, 'exceeds specified number of columns'
+        assert_message logger, :ERROR, '~exceeds specified number of columns', Hash
       end
     end
 

--- a/test/tables_test.rb
+++ b/test/tables_test.rb
@@ -152,16 +152,24 @@ context 'Tables' do
 A | here| a | there
 |===
       EOS
-      output, warnings = redirect_streams {|_, err| [(render_embedded_string input), err.string] }
-      assert_css 'table', output, 1
-      assert_css 'table > colgroup > col', output, 4
-      assert_css 'table > tbody > tr', output, 1
-      assert_css 'table > tbody > tr > td', output, 4
-      assert_xpath '/table/tbody/tr/td[1]/p[text()="A"]', output, 1
-      assert_xpath '/table/tbody/tr/td[2]/p[text()="here"]', output, 1
-      assert_xpath '/table/tbody/tr/td[3]/p[text()="a"]', output, 1
-      assert_xpath '/table/tbody/tr/td[4]/p[text()="there"]', output, 1
-      assert_includes warnings, 'table missing leading separator'
+      using_memory_logger do |logger|
+        output = render_embedded_string input
+        assert_css 'table', output, 1
+        assert_css 'table > colgroup > col', output, 4
+        assert_css 'table > tbody > tr', output, 1
+        assert_css 'table > tbody > tr > td', output, 4
+        assert_xpath '/table/tbody/tr/td[1]/p[text()="A"]', output, 1
+        assert_xpath '/table/tbody/tr/td[2]/p[text()="here"]', output, 1
+        assert_xpath '/table/tbody/tr/td[3]/p[text()="a"]', output, 1
+        assert_xpath '/table/tbody/tr/td[4]/p[text()="there"]', output, 1
+        assert_equal 1, logger.messages.size
+        message = logger.messages[0]
+        assert_equal :ERROR, message[:severity]
+        refute_equal String, message[:message]
+        refute_nil message[:message][:source_location]
+        # FIXME line number is wrong
+        assert_includes message[:message].inspect, 'table missing leading separator'
+      end
     end
 
     test 'performs normal substitutions on cell content' do
@@ -872,10 +880,18 @@ a|C
 more C
 |===
       EOS
-      output, warnings = redirect_streams {|_, err| [(render_embedded_string input), err.string] }
-      assert_css 'table', output, 1
-      assert_css 'table *', output, 0
-      assert_includes warnings, 'exceeds specified number of columns'
+      using_memory_logger do |logger|
+        output = render_embedded_string input
+        assert_css 'table', output, 1
+        assert_css 'table *', output, 0
+        assert_equal 1, logger.messages.size
+        message = logger.messages[0]
+        assert_equal :ERROR, message[:severity]
+        refute_equal String, message[:message]
+        refute_nil message[:message][:source_location]
+        # FIXME line number is wrong
+        assert_includes message[:message].inspect, 'exceeds specified number of columns'
+      end
     end
 
     test 'paragraph, verse and literal content' do

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -135,6 +135,35 @@ class Minitest::Test
     end
   end
 
+  def assert_message logger, severity, expected_message, kind = String, idx = nil
+    unless idx
+      assert_equal 1, logger.messages.size
+      idx = 0
+    end
+    message = logger.messages[idx]
+    assert_equal severity, message[:severity]
+    assert_kind_of kind, message[:message]
+    if kind == String
+      actual_message = message[:message]
+    else
+      refute_nil message[:message][:source_location]
+      actual_message = message[:message].inspect
+    end
+    if expected_message.start_with? '~'
+      assert_includes actual_message, expected_message[1..-1]
+    else
+      assert_equal expected_message, actual_message
+    end
+  end
+
+  def assert_messages logger, expected_messages
+    assert_equal expected_messages.size, logger.messages.size
+    expected_messages.each_with_index do |expected_message_details, idx|
+      severity, expected_message, kind = expected_message_details
+      assert_message logger, severity, expected_message, (kind || String), idx
+    end
+  end
+
   def xmldoc_from_string(content)
     if content.match(RE_XMLNS_ATTRIBUTE)
       Nokogiri::XML::Document.parse(content)

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -258,9 +258,14 @@ class Minitest::Test
   def redirect_streams
     old_stdout, $stdout = $stdout, (tmp_stdout = ::StringIO.new)
     old_stderr, $stderr = $stderr, (tmp_stderr = ::StringIO.new)
+    old_logger = Asciidoctor::LoggerManager.logger
+    old_logger_level = old_logger.level
+    new_logger = (Asciidoctor::LoggerManager.logger = Asciidoctor::Logger.new $stderr)
+    new_logger.level = old_logger_level
     yield tmp_stdout, tmp_stderr
   ensure
     $stdout, $stderr = old_stdout, old_stderr
+    Asciidoctor::LoggerManager.logger = old_logger
   end
 
   def resolve_localhost
@@ -271,9 +276,12 @@ class Minitest::Test
   def in_verbose_mode
     begin
       old_verbose, $VERBOSE = $VERBOSE, true
+      old_logger_level = Asciidoctor::LoggerManager.logger.level
+      Asciidoctor::LoggerManager.logger.level = Logger::Severity::DEBUG
       yield
     ensure
       $VERBOSE = old_verbose
+      Asciidoctor::LoggerManager.logger.level = old_logger_level
     end
   end
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -273,6 +273,18 @@ class Minitest::Test
         Socket.ip_address_list.find {|addr| addr.ipv4? }.ip_address
   end
 
+  def using_memory_logger debug = false
+    old_logger = Asciidoctor::LoggerManager.logger
+    memory_logger = Asciidoctor::Logger::MemoryLogger.new
+    memory_logger.level = Logger::Severity::DEBUG if debug
+    begin
+      Asciidoctor::LoggerManager.logger = memory_logger
+      yield memory_logger
+    ensure
+      Asciidoctor::LoggerManager.logger = old_logger
+    end
+  end
+
   def in_verbose_mode
     begin
       old_verbose, $VERBOSE = $VERBOSE, true

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -275,7 +275,7 @@ class Minitest::Test
 
   def using_memory_logger debug = false
     old_logger = Asciidoctor::LoggerManager.logger
-    memory_logger = Asciidoctor::Logger::MemoryLogger.new
+    memory_logger = Asciidoctor::MemoryLogger.new
     memory_logger.level = Logger::Severity::DEBUG if debug
     begin
       Asciidoctor::LoggerManager.logger = memory_logger


### PR DESCRIPTION
- add a logging infrastructure that can be imported into a class or module using `include Logging`
- add tests for logging infrastructure
- send messages (warnings and errors) to logger instead of the warn function (stderr)
- log message containing source location as an object (enrich message with source location and configure it to automatically format)
- provide a default logger Asciidoctor::Logger set to the severity level WARN
- assign a custom formatter to to the default logger that formats messages in the traditional way
- tune the log level based on the CLI flags (-v = DEBUG, -q = off)
- consult logger.debug? instead of $VERBOSE in the processor
- add :logger option to API methods
- associate logger with redirected stream in test suite
- update most tests to use memory logger instead of capturing stderr