### PR TITLE
resolves #2654 don't output e-mail address twice in manpage output

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -47,6 +47,7 @@ Bug fixes::
   * fix typo in gemspec that removed README and CONTRIBUTING files from the generated gem (PR #2650) (*@aerostitch*)
   * don't turn bare URI scheme (no host) into a link (#2609, PR #2611)
   * fix em dash replacement in manpage converter (#2604, PR #2607)
+  * don't output e-mail address twice when replacing bare e-mail address in manpage output (#2654, PR #2665)
   * enforce that absolute start path passed to PathResolver#system_path is inside of jail path (#2642, PR #2644)
   * fix behavior of PathResolver#descends_from? when base path equals / (#2642, PR #2644)
   * automatically recover if start path passed to PathResolver#system_path is outside of jail path (#2642, PR #2644)

--- a/lib/asciidoctor/converter/manpage.rb
+++ b/lib/asciidoctor/converter/manpage.rb
@@ -597,17 +597,18 @@ allbox tab(:);'
       target = node.target
       case node.type
       when :link
+        if target.start_with? 'mailto:'
+          macro = 'MTO'
+          target = target.slice 7, target.length
+        else
+          macro = 'URL'
+        end
         if (text = node.text) == target
           text = ''
         else
           text = text.gsub '"', %[#{ESC_BS}(dq]
         end
-        if target.start_with? 'mailto:'
-          macro = 'MTO'
-          target = target[7..-1].sub '@', %[#{ESC_BS}(at]
-        else
-          macro = 'URL'
-        end
+        target = target.sub '@', %[#{ESC_BS}(at] if macro == 'MTO'
         %(#{ESC_BS}c#{LF}#{ESC_FS}#{macro} "#{target}" "#{text}" )
       when :xref
         refid = (node.attr 'refid') || target

--- a/test/manpage_test.rb
+++ b/test/manpage_test.rb
@@ -282,6 +282,14 @@ First paragraph.
 .sp
 .MTO "doc\\(atexample.org" "Contact the doc" ""', output.lines.entries[-4..-1].join
     end
+
+    test 'should set text of MTO macro to blank for implicit email' do
+      input = %(#{SAMPLE_MANPAGE_HEADER}
+Bugs fixed daily by doc@example.org.)
+      output = Asciidoctor.convert input, :backend => :manpage
+      assert output.end_with? 'Bugs fixed daily by \\c
+.MTO "doc\\(atexample.org" "" "."'
+    end
   end
 
   context 'Table' do


### PR DESCRIPTION
- set text of MTO macro to blank if text matches e-mail address
- primarily used for implicit e-mail link
- previous check was failing due to mailto: prefix in value
- add test