### PR TITLE
resolves #2387 allow role to be set on document

### DIFF
--- a/lib/asciidoctor/converter/html5.rb
+++ b/lib/asciidoctor/converter/html5.rb
@@ -115,13 +115,14 @@ module Asciidoctor
       end
 
       result << '</head>'
-      body_attrs = []
-      body_attrs << %(id="#{node.id}") if node.id
+      body_attrs = node.id ? [%(id="#{node.id}")] : []
       if (sectioned = node.sections?) && (node.attr? 'toc-class') && (node.attr? 'toc') && (node.attr? 'toc-placement', 'auto')
-        body_attrs << %(class="#{node.doctype} #{node.attr 'toc-class'} toc-#{node.attr 'toc-position', 'header'}")
+        classes = [node.doctype, (node.attr 'toc-class'), %(toc-#{node.attr 'toc-position', 'header'})]
       else
-        body_attrs << %(class="#{node.doctype}")
+        classes = [node.doctype]
       end
+      classes << (node.attr 'docrole') if node.attr? 'docrole'
+      body_attrs << %(class="#{classes * ' '}")
       body_attrs << %(style="max-width: #{node.attr 'max-width'};") if node.attr? 'max-width'
       result << %(<body #{body_attrs * ' '}>)
 

--- a/lib/asciidoctor/parser.rb
+++ b/lib/asciidoctor/parser.rb
@@ -157,6 +157,9 @@ class Parser
       else
         doc_id = document.id
       end
+      if (doc_role = block_attributes['role'])
+        document.attributes['docrole'] = doc_role
+      end
       if (doc_reftext = block_attributes['reftext'])
         document.attributes['reftext'] = doc_reftext
       end

--- a/test/sections_test.rb
+++ b/test/sections_test.rb
@@ -466,8 +466,10 @@ content
       doc = document_from_string input
       assert_empty doc.blocks[0].attributes
       output = doc.convert
+      assert_css '#idname', output, 1
       assert_css 'body#idname', output, 1
-      assert_css '.rolename', output, 0
+      assert_css '.rolename', output, 1
+      assert_css 'body.rolename', output, 1
     end
   end
 


### PR DESCRIPTION
- allow role to be set on document using block attribute (shorthand or longhand)
- assign role to docrole attribute on document
- add role to CSS classes on body in HTML5 output
- prefer ID defined in block attributes on document over ID defined inline (to be consistent w/ sections)