### PR TITLE
Allow the DATA_PATH variable to be picked from an environment variable

### DIFF
--- a/lib/asciidoctor.rb
+++ b/lib/asciidoctor.rb
@@ -196,7 +196,7 @@ module Asciidoctor
   #LIB_PATH = ::File.join ROOT_PATH, 'lib'
 
   # The absolute data path of the Asciidoctor RubyGem
-  DATA_PATH = ::File.join ROOT_PATH, 'data'
+  DATA_PATH = ::ENV['ASCIIDOCTOR_DATA_PATH'] || (::File.join ROOT_PATH, 'data')
 
   # The user's home directory, as best we can determine it
   # NOTE not using infix rescue for performance reasons, see: https://github.com/jruby/jruby/issues/1816


### PR DESCRIPTION
Hi guys,

In the Debian packaging process we maintain a patch to allow the DATA_PATH variable to be set from another location as the location we have during the debian package build process (and in the final installation) are different from an usual gem context.

The current patch in Debian is: https://salsa.debian.org/ruby-team/asciidoctor/blob/master/debian/patches/data_path.patch

I'd like to avoid patching from within the package so I thought it could be more flexible to allow a variable (named here `ASCIIDOCTOR_DATA_PATH`) to be set to define the path where the `data` folder is located.

Would that be an acceptable solution?

Thanks for your help,
Joseph