### PR TITLE
Allow the tests to run when asciimath is not installed

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -116,6 +116,7 @@ Improvements / Refactoring::
   * only warn if thread_safe gem is missing when using built-in template cache
   * rename enumerate_section to assign_numeral; update API docs
   * drop deprecated compact option from CLI; remove from manpage
+  * use more robust mechanism for lazy loading the asciimath gem
   * purge render method from test suite (except to verify alias)
 
 Documentation::

--- a/test/blocks_test.rb
+++ b/test/blocks_test.rb
@@ -1525,7 +1525,8 @@ sqrt(3x-1)+(1+x)^2 < y
       assert_equal '\$sqrt(3x-1)+(1+x)^2 &lt; y\$', nodes.first.to_s.strip
     end
 
-    test 'should render asciimath block in textobject of equation in DocBook backend' do
+    test 'should convert contents of asciimath block to MathML in DocBook output if asciimath gem is available' do
+      asciimath_available = !(Asciidoctor::Helpers.require_library 'asciimath', true, :ignore).nil?
       input = <<-'EOS'
 [asciimath]
 ++++
@@ -1537,9 +1538,17 @@ x+b/(2a)<+-sqrt((b^2)/(4a^2)-c/a)
 <mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML"><mml:mi>x</mml:mi><mml:mo>+</mml:mo><mml:mfrac><mml:mi>b</mml:mi><mml:mrow><mml:mn>2</mml:mn><mml:mi>a</mml:mi></mml:mrow></mml:mfrac><mml:mo>&#x003C;</mml:mo><mml:mo>&#x00B1;</mml:mo><mml:msqrt><mml:mrow><mml:mfrac><mml:msup><mml:mi>b</mml:mi><mml:mn>2</mml:mn></mml:msup><mml:mrow><mml:mn>4</mml:mn><mml:msup><mml:mi>a</mml:mi><mml:mn>2</mml:mn></mml:msup></mml:mrow></mml:mfrac><mml:mo>&#x2212;</mml:mo><mml:mfrac><mml:mi>c</mml:mi><mml:mi>a</mml:mi></mml:mfrac></mml:mrow></mml:msqrt></mml:math>
 </informalequation>)
 
-      doc = document_from_string input, :backend => :docbook, :header_footer => false
-      assert_equal expect.strip, doc.convert.strip
-      assert_equal :loaded, doc.converter.instance_variable_get(:@asciimath)
+      using_memory_logger do |logger|
+        doc = document_from_string input, :backend => :docbook, :header_footer => false
+        actual = doc.convert
+        if asciimath_available
+          assert_equal expect.strip, actual.strip
+          assert_equal :loaded, doc.converter.instance_variable_get(:@asciimath)
+        else
+          assert_message logger, :WARN, 'optional gem \'asciimath\' is not installed. Functionality disabled.'
+          assert_equal :unavailable, doc.converter.instance_variable_get(:@asciimath)
+        end
+      end
     end
 
     test 'should output title for latexmath block if defined' do

--- a/test/substitutions_test.rb
+++ b/test/substitutions_test.rb
@@ -1649,19 +1649,34 @@ EOS
         assert_equal '\$a &lt; b\$', para.content
       end
 
-      # NOTE this test doesn't work once AsciiMath has been loaded
-      #test 'should not perform specialcharacters subs on asciimath macro content in docbook backend by default' do
-      #  input = 'asciimath:[a < b]'
-      #  para = block_from_string input, :backend => :docbook
-      #  para.document.converter.instance_variable_set :@asciimath_available, false
-      #  assert_equal '<inlineequation><mathphrase><![CDATA[a < b]]></mathphrase></inlineequation>', para.content
-      #end
+      test 'should convert contents of asciimath macro to MathML in DocBook output if asciimath gem is available' do
+        asciimath_available = !(Asciidoctor::Helpers.require_library 'asciimath', true, :ignore).nil?
+        input = 'asciimath:[a < b]'
+        expected = '<inlineequation><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML"><mml:mi>a</mml:mi><mml:mo>&#x003C;</mml:mo><mml:mi>b</mml:mi></mml:math></inlineequation>'
+        using_memory_logger do |logger|
+          para = block_from_string input, :backend => :docbook
+          actual = para.content
+          if asciimath_available
+            assert_equal expected, actual
+            assert_equal :loaded, para.document.converter.instance_variable_get(:@asciimath)
+          else
+            assert_message logger, :WARN, 'optional gem \'asciimath\' is not installed. Functionality disabled.'
+            assert_equal :unavailable, para.document.converter.instance_variable_get(:@asciimath)
+          end
+        end
+      end
 
-      test 'should convert asciimath macro content to MathML when asciimath gem is available' do
+      test 'should not perform specialcharacters subs on asciimath macro content in Docbook output if asciimath gem not available' do
+        asciimath_available = !(Asciidoctor::Helpers.require_library 'asciimath', true, :ignore).nil?
         input = 'asciimath:[a < b]'
         para = block_from_string input, :backend => :docbook
-        assert_equal '<inlineequation><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML"><mml:mi>a</mml:mi><mml:mo>&#x003C;</mml:mo><mml:mi>b</mml:mi></mml:math></inlineequation>', para.content
-        assert_equal :loaded, para.document.converter.instance_variable_get(:@asciimath)
+        para.document.converter.instance_variable_set :@asciimath, :unavailable
+        if asciimath_available
+          old_asciimath = ::AsciiMath
+          Object.send :remove_const, 'AsciiMath'
+        end
+        assert_equal '<inlineequation><mathphrase><![CDATA[a < b]]></mathphrase></inlineequation>', para.content
+        ::AsciiMath = old_asciimath if asciimath_available
       end
 
       test 'should honor explicit subslist on asciimath macro' do


### PR DESCRIPTION
Hi,

As asciimath is an optional gem (and not packaged in Debian yet), we maintain a patch that skips the tests that fail when asciimath is not installed: https://salsa.debian.org/ruby-team/asciidoctor/blob/master/debian/patches/skip-asciimath-test.patch
But if you only do the assert when the warning message about the gem is not present we would be able to avoid this.
Does that seem reasonable?

Thanks
Joseph