### PR TITLE
resolves #794 drop XML tags, character refs, and non-word chars when generating ID for section

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -17,6 +17,7 @@ For a detailed view of what has changed, refer to the {uri-repo}/commits/master[
 
 Enhancements::
 
+  * BREAKING: drop XML tags, character refs, and non-word characters (except hyphen and space) when generating ID for section (#794)
   * route messages through a logger instead of using Kernel#warn (#44, PR #2660)
   * add MemoryLogger for capturing messages sent to logger into memory (#44, PR #2660)
   * add NullLogger to prevent messages from being logged (#44, PR #2660)

--- a/features/xref.feature
+++ b/features/xref.feature
@@ -669,14 +669,14 @@ Feature: Cross References
     Then the result should match the HTML structure
       """
       .sect1
-        h2#_section_strong_one_strong
+        h2#_section_one
           |Section <strong>One</strong>
         .sectionbody: .paragraph: p content
       .sect1
         h2#_section_two Section Two
         .sectionbody: .paragraph: p
           |refer to
-          a< href='#_section_strong_one_strong' Section <strong>One</strong>
+          a< href='#_section_one' Section <strong>One</strong>
       """
 
     Scenario: Does not process a natural cross reference in compat mode

--- a/lib/asciidoctor.rb
+++ b/lib/asciidoctor.rb
@@ -661,10 +661,10 @@ module Asciidoctor
     #
     InlineSectionAnchorRx = / (\\)?\[\[([#{CC_ALPHA}_:][#{CC_WORD}:.-]*)(?:, *(.+))?\]\]$/
 
-    # Matches invalid characters in a section id.
+    # Matches invalid ID characters in a section title.
     #
-    # NOTE uppercase chars are not included since the expression is used on a lowercased string
-    InvalidSectionIdCharsRx = /&(?:[a-z][a-z]+\d{0,2}|#\d\d\d{0,4}|#x[\da-f][\da-f][\da-f]{0,3});|[^#{CC_WORD}]+?/
+    # NOTE uppercase chars not included since expression is only run on a lowercase string
+    InvalidSectionIdCharsRx = /<[^>]+>|&(?:[a-z][a-z]+\d{0,2}|#\d\d\d{0,4}|#x[\da-f][\da-f][\da-f]{0,3});|[^ #{CC_WORD}\-]+?/
 
     # Matches the block style used to designate a discrete (aka free-floating) heading.
     #

--- a/lib/asciidoctor.rb
+++ b/lib/asciidoctor.rb
@@ -529,7 +529,7 @@ module Asciidoctor
     AttributeEntryRx = /^:(!?#{CG_WORD}[^:]*):(?:[ \t]+(.*))?$/
 
     # Matches invalid characters in an attribute name.
-    InvalidAttributeNameCharsRx = /[^#{CC_WORD}\-]/
+    InvalidAttributeNameCharsRx = /[^#{CC_WORD}-]/
 
     # Matches a pass inline macro that surrounds the value of an attribute
     # entry once it has been parsed.
@@ -664,7 +664,7 @@ module Asciidoctor
     # Matches invalid ID characters in a section title.
     #
     # NOTE uppercase chars not included since expression is only run on a lowercase string
-    InvalidSectionIdCharsRx = /<[^>]+>|&(?:[a-z][a-z]+\d{0,2}|#\d\d\d{0,4}|#x[\da-f][\da-f][\da-f]{0,3});|[^ #{CC_WORD}\-]+?/
+    InvalidSectionIdCharsRx = /<[^>]+>|&(?:[a-z][a-z]+\d{0,2}|#\d\d\d{0,4}|#x[\da-f][\da-f][\da-f]{0,3});|[^ #{CC_WORD}-]+?/
 
     # Matches the block style used to designate a discrete (aka free-floating) heading.
     #
@@ -879,7 +879,7 @@ module Asciidoctor
     #   footnoteref:[id,text] (legacy)
     #   footnoteref:[id] (legacy)
     #
-    InlineFootnoteMacroRx = /\\?footnote(?:(ref):|:([\w\-]+)?)\[(?:|(#{CC_ALL}*?[^\\]))\]/m
+    InlineFootnoteMacroRx = /\\?footnote(?:(ref):|:([\w-]+)?)\[(?:|(#{CC_ALL}*?[^\\]))\]/m
 
     # Matches an image or icon inline macro.
     #

--- a/test/sections_test.rb
+++ b/test/sections_test.rb
@@ -11,12 +11,12 @@ context 'Sections' do
       assert_equal '_section_one', sec.id
     end
 
-    test 'synthetic id replaces non-word characters with underscores' do
+    test 'synthetic id removes non-word characters' do
       sec = block_from_string("== We're back!")
-      assert_equal '_we_re_back', sec.id
+      assert_equal '_were_back', sec.id
     end
 
-    test 'synthetic id removes repeating underscores' do
+    test 'synthetic id removes repeating separators' do
       sec = block_from_string('== Section $ One')
       assert_equal '_section_one', sec.id
     end
@@ -29,6 +29,21 @@ context 'Sections' do
     test 'synthetic id removes adjacent entities with mixed case' do
       sec = block_from_string('== a &#xae;&AMP;&#xA9; b')
       assert_equal '_a_b', sec.id
+    end
+
+    test 'synthetic id removes XML tags' do
+      sec = block_from_string('== Use the `run` command to make it icon:gear[]')
+      assert_equal '_use_the_run_command_to_make_it_gear', sec.id
+    end
+
+    test 'synthetic id collapses repeating spaces' do
+      sec = block_from_string('== Go    Far')
+      assert_equal '_go_far', sec.id
+    end
+
+    test 'synthetic id replaces hyphens with separator' do
+      sec = block_from_string('== State-of-the-art design')
+      assert_equal '_state_of_the_art_design', sec.id
     end
 
     test 'synthetic id prefix can be customized' do
@@ -49,6 +64,11 @@ context 'Sections' do
     test 'synthetic id separator can be customized' do
       sec = block_from_string(":idseparator: -\n\n== Section One")
       assert_equal '_section-one', sec.id
+    end
+
+    test 'synthetic id separator can be hyphen and hyphens are preserved' do
+      sec = block_from_string(":idseparator: -\n\n== State-of-the-art design")
+      assert_equal '_state-of-the-art-design', sec.id
     end
 
     test 'synthetic id separator can only be one character' do
@@ -481,11 +501,11 @@ endif::[]
     end
 
     test "with XML entity" do
-      assert_xpath "//h2[@id='_where_s_the_love'][text() = \"Where#{decode_char 8217}s the love?\"]", render_string("== Where's the love?")
+      assert_xpath "//h2[@id='_whats_new'][text() = \"What#{decode_char 8217}s new?\"]", render_string("== What's new?")
     end
 
     test "with non-word character" do
-      assert_xpath "//h2[@id='_where_s_the_love'][text() = \"Where’s the love?\"]", render_string("== Where’s the love?")
+      assert_xpath "//h2[@id='_whats_new'][text() = \"What’s new?\"]", render_string("== What’s new?")
     end
 
     test "with sequential non-word characters" do
@@ -2773,9 +2793,9 @@ content
       assert_xpath '/*[@id="toc"]', output, 1
       toc_links = xmlnodes_at_xpath '/*[@id="toc"]//li', output
       assert_equal 3, toc_links.size
-      toc_links.each do |toc_link|
-        assert_equal 1, toc_link.inner_html.scan('<a').size
-      end
+      assert_equal '<a href="#_section_one">Section One</a>', toc_links[0].inner_html
+      assert_equal '<a href="#_section_two">Section Two</a>', toc_links[1].inner_html
+      assert_equal '<a href="#_plant_trees_by_searching">Plant Trees by Searching</a>', toc_links[2].inner_html
     end
 
     test 'should not remove non-anchor tags from contents of entries in table of contents' do
@@ -2801,9 +2821,9 @@ content
       assert_xpath '/*[@id="toc"]', output, 1
       toc_links = xmlnodes_at_xpath '/*[@id="toc"]//li', output
       assert_equal 3, toc_links.size
-      assert_match(/^<a[^>]+><code>run<\/code> command<\/a>$/, toc_links[0].inner_html)
-      assert_match(/^<a[^>]+><span class="icon"><i class="fa fa-bug"><\/i><\/span> Issues<\/a>$/, toc_links[1].inner_html)
-      assert_match(/^<a[^>]+><em>Sustainable<\/em> Searches<\/a>/, toc_links[2].inner_html)
+      assert_equal '<a href="#_run_command"><code>run</code> command</a>', toc_links[0].inner_html
+      assert_equal '<a href="#_issues"><span class="icon"><i class="fa fa-bug"></i></span> Issues</a>', toc_links[1].inner_html
+      assert_equal '<a href="#_sustainable_searches"><em>Sustainable</em> Searches</a>', toc_links[2].inner_html
     end
   end
 


### PR DESCRIPTION
- drop character refs and non-word chars (except for hyphen and space) instead of replacing with ID separator
- drop XML tags (but not the contents of the tag)
- replace spaces and hyphens with ID separator
- optimize logic in Section.generate_id method