### PR TITLE
resolves #2619 allow custom converter to declare that it supports templates

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -27,6 +27,7 @@ Enhancements::
   * allow modifier to be placed at end of name to soft set an attribute (e.g., icons@=font) (#642, PR #2649)
   * interpret false attribute value defined using API as a soft unset (#642, PR #2649)
   * allow footnote macro to define or reference footnote reference (footnoteref macro now considered deprecated) (#2347, PR #2362)
+  * allow custom converter to be used with custom templates; converter must declare that it supports templates (#2619)
   * allow manpage path for manpage help topic to be specified using ASCIIDOCTOR_MANPAGE_PATH environment variable (PR #2653) (*@aerostitch*)
   * if manpage cannot be found in default path inside gem, use `man -w asciidoctor` to resolve installed path (PR #2653)
   * uncompress contents of manpage for manpage help topic if path ends with .gz (PR #2653) (*@aerostitch*)

--- a/lib/asciidoctor/converter.rb
+++ b/lib/asciidoctor/converter.rb
@@ -86,42 +86,42 @@ module Asciidoctor
           syntax = 'html'
         end
         {
-          'basebackend' => base,
-          'outfilesuffix' => ext,
-          'filetype' => type,
-          'htmlsyntax' => syntax
+          :basebackend => base,
+          :outfilesuffix => ext,
+          :filetype => type,
+          :htmlsyntax => syntax
         }
       end
 
       def filetype value = nil
         if value
-          backend_info['filetype'] = value
+          backend_info[:filetype] = value
         else
-          backend_info['filetype']
+          backend_info[:filetype]
         end
       end
 
       def basebackend value = nil
         if value
-          backend_info['basebackend'] = value
+          backend_info[:basebackend] = value
         else
-          backend_info['basebackend']
+          backend_info[:basebackend]
         end
       end
 
       def outfilesuffix value = nil
         if value
-          backend_info['outfilesuffix'] = value
+          backend_info[:outfilesuffix] = value
         else
-          backend_info['outfilesuffix']
+          backend_info[:outfilesuffix]
         end
       end
 
       def htmlsyntax value = nil
         if value
-          backend_info['htmlsyntax'] = value
+          backend_info[:htmlsyntax] = value
         else
-          backend_info['htmlsyntax']
+          backend_info[:htmlsyntax]
         end
       end
     end

--- a/lib/asciidoctor/converter.rb
+++ b/lib/asciidoctor/converter.rb
@@ -183,6 +183,8 @@ module Asciidoctor
       raise ::NotImplementedError
     end
 
+    alias handles? respond_to?
+
     # Alias for backward compatibility.
     alias convert_with_options convert
   end

--- a/lib/asciidoctor/converter.rb
+++ b/lib/asciidoctor/converter.rb
@@ -124,6 +124,14 @@ module Asciidoctor
           backend_info[:htmlsyntax]
         end
       end
+
+      def supports_templates
+        backend_info[:supports_templates] = true
+      end
+
+      def supports_templates?
+        backend_info[:supports_templates]
+      end
     end
 
     class << self

--- a/lib/asciidoctor/converter.rb
+++ b/lib/asciidoctor/converter.rb
@@ -20,7 +20,7 @@ module Asciidoctor
   #       super
   #       outfilesuffix '.txt'
   #     end
-  #     def convert node, transform = nil
+  #     def convert node, transform = nil, opts = {}
   #       case (transform ||= node.node_name)
   #       when 'document'
   #         node.content

--- a/lib/asciidoctor/converter/factory.rb
+++ b/lib/asciidoctor/converter/factory.rb
@@ -185,26 +185,27 @@ module Asciidoctor
       # Returns the [Converter] object
       def create backend, opts = {}
         if (converter = resolve backend)
-          return ::Class === converter ? (converter.new backend, opts) : converter
-        end
-
-        base_converter = case backend
-        when 'html5'
-          # NOTE .to_s hides require from Opal
-          require 'asciidoctor/converter/html5'.to_s unless defined? ::Asciidoctor::Converter::Html5Converter
-          Html5Converter.new backend, opts
-        when 'docbook5'
-          # NOTE .to_s hides require from Opal
-          require 'asciidoctor/converter/docbook5'.to_s unless defined? ::Asciidoctor::Converter::DocBook5Converter
-          DocBook5Converter.new backend, opts
-        when 'docbook45'
-          # NOTE .to_s hides require from Opal
-          require 'asciidoctor/converter/docbook45'.to_s unless defined? ::Asciidoctor::Converter::DocBook45Converter
-          DocBook45Converter.new backend, opts
-        when 'manpage'
-          # NOTE .to_s hides require from Opal
-          require 'asciidoctor/converter/manpage'.to_s unless defined? ::Asciidoctor::Converter::ManPageConverter
-          ManPageConverter.new backend, opts
+          base_converter = ::Class === converter ? (converter.new backend, opts) : converter
+          return base_converter unless Converter::BackendInfo === base_converter && base_converter.supports_templates?
+        else
+          case backend
+          when 'html5'
+            # NOTE .to_s hides require from Opal
+            require 'asciidoctor/converter/html5'.to_s unless defined? ::Asciidoctor::Converter::Html5Converter
+            base_converter = Html5Converter.new backend, opts
+          when 'docbook5'
+            # NOTE .to_s hides require from Opal
+            require 'asciidoctor/converter/docbook5'.to_s unless defined? ::Asciidoctor::Converter::DocBook5Converter
+            base_converter = DocBook5Converter.new backend, opts
+          when 'docbook45'
+            # NOTE .to_s hides require from Opal
+            require 'asciidoctor/converter/docbook45'.to_s unless defined? ::Asciidoctor::Converter::DocBook45Converter
+            base_converter = DocBook45Converter.new backend, opts
+          when 'manpage'
+            # NOTE .to_s hides require from Opal
+            require 'asciidoctor/converter/manpage'.to_s unless defined? ::Asciidoctor::Converter::ManPageConverter
+            base_converter = ManPageConverter.new backend, opts
+          end
         end
 
         return base_converter unless opts.key? :template_dirs

--- a/test/converter_test.rb
+++ b/test/converter_test.rb
@@ -368,6 +368,80 @@ content
       assert converter.handles?(:paragraph)
     end
 
+    test 'should not configure converter to support templates by default' do
+      input = <<-EOS
+paragraph
+      EOS
+
+      begin
+        Asciidoctor::Converter::Factory.unregister_all
+        class CustomConverterD
+          include Asciidoctor::Converter
+          register_for 'myhtml'
+          def convert node, transform = nil, opts = {}
+            transform ||= node.node_name
+            send transform, node
+          end
+
+          def document node
+            ['<!DOCTYPE html>', '<html>', '<body>', node.content, '</body>', '</html>'] * %(\n)
+          end
+
+          def paragraph node
+            ['<div class="paragraph">', %(<p>#{node.content}</p>), '</div>'] * %(\n)
+          end
+        end
+
+        doc = document_from_string input, :backend => 'myhtml', :template_dir => (fixture_path 'custom-backends/slim/html5'), :template_cache => false
+        assert_kind_of CustomConverterD, doc.converter
+        refute doc.converter.supports_templates?
+        output = doc.convert
+        assert_xpath '//*[@class="paragraph"]/p[text()="paragraph"]', output, 1
+      ensure
+        Asciidoctor::Converter::Factory.unregister_all
+      end
+    end
+
+    test 'should wrap converter in composite converter with template converter if it declares that it supports templates' do
+      input = <<-EOS
+paragraph
+      EOS
+
+      begin
+        Asciidoctor::Converter::Factory.unregister_all
+        class CustomConverterE
+          include Asciidoctor::Converter
+          register_for 'myhtml'
+
+          def initialize *args
+            super
+            supports_templates
+          end
+
+          def convert node, transform = nil, opts = {}
+            transform ||= node.node_name
+            send transform, node
+          end
+
+          def document node
+            ['<!DOCTYPE html>', '<html>', '<body>', node.content, '</body>', '</html>'] * %(\n)
+          end
+
+          def paragraph node
+            ['<div class="paragraph">', %(<p>#{node.content}</p>), '</div>'] * %(\n)
+          end
+        end
+
+        doc = document_from_string input, :backend => 'myhtml', :template_dir => (fixture_path 'custom-backends/slim/html5'), :template_cache => false
+        assert_kind_of Asciidoctor::Converter::CompositeConverter, doc.converter
+        output = doc.convert
+        assert_xpath '//*[@class="paragraph"]/p[text()="paragraph"]', output, 0
+        assert_xpath '//body/p[text()="paragraph"]', output, 1
+      ensure
+        Asciidoctor::Converter::Factory.unregister_all
+      end
+    end
+
     test 'should fall back to catch all converter' do
       input = <<-EOS
 content
@@ -376,7 +450,7 @@ content
       begin
         Asciidoctor::Converter::Factory.unregister_all
 
-        class CustomConverterD
+        class CustomConverterF
           include Asciidoctor::Converter
           register_for '*'
           def convert node, name = nil
@@ -385,7 +459,7 @@ content
         end
 
         converters = Asciidoctor::Converter::Factory.converters
-        assert converters['*'] == CustomConverterD
+        assert converters['*'] == CustomConverterF
         output = render_string input, :backend => 'foobaz'
         assert 'foobaz content', output
       ensure

--- a/test/converter_test.rb
+++ b/test/converter_test.rb
@@ -355,6 +355,19 @@ content
       end
     end
 
+    test 'should map handles? method on converter to respond_to? by default' do
+      class CustomConverterC
+        include Asciidoctor::Converter
+        def paragraph node
+          'paragraph'
+        end
+      end
+
+      converter = CustomConverterC.new 'myhtml'
+      assert_respond_to converter, :handles?
+      assert converter.handles?(:paragraph)
+    end
+
     test 'should fall back to catch all converter' do
       input = <<-EOS
 content
@@ -363,7 +376,7 @@ content
       begin
         Asciidoctor::Converter::Factory.unregister_all
 
-        class CustomConverterC
+        class CustomConverterD
           include Asciidoctor::Converter
           register_for '*'
           def convert node, name = nil
@@ -372,7 +385,7 @@ content
         end
 
         converters = Asciidoctor::Converter::Factory.converters
-        assert converters['*'] == CustomConverterC
+        assert converters['*'] == CustomConverterD
         output = render_string input, :backend => 'foobaz'
         assert 'foobaz content', output
       ensure


### PR DESCRIPTION
- map backend info for custom converter to symbols instead of strings
- add opts argument to example in API doc for custom converter
- map handles? method for custom converter to respond_to? by default
- allow custom converter to declare that it supports templates