### PR TITLE
resolves #2369 change strategy for finding tags inside circumfix comments

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -54,7 +54,8 @@ Enhancements::
 Bug fixes::
 
   * set :to_dir option correctly when output file is specified (#2382)
-  * using the shorthand syntax to set block attributes (id, roles, options) doesn't reset block style (#2174)
+  * using the shorthand syntax on the style to set block attributes (id, roles, options) no longer resets block style (#2174)
+  * match include tags anywhere on line as long as offset by word boundary on left and space or newline on right (#2369, PR #2683)
   * fix typo in gemspec that removed README and CONTRIBUTING files from the generated gem (PR #2650) (*@aerostitch*)
   * don't turn bare URI scheme (no host) into a link (#2609, PR #2611)
   * don't convert inter-document xref to internal anchor unless entire target file is included into current file (#2200)

--- a/lib/asciidoctor.rb
+++ b/lib/asciidoctor.rb
@@ -373,17 +373,6 @@ module Asciidoctor
   # header) because it has semantic meaning; ex. sectnums
   FLEXIBLE_ATTRIBUTES = ['sectnums']
 
-  # map of file extension to comment affixes for languages that only support circumfix comments
-  CIRCUMFIX_COMMENTS = {
-    ['/*', '*/'] => ['.css'],
-    ['(*', '*)'] => ['.ml', '.mli', '.nb'],
-    ['<!--', '-->'] => ['.html', '.xhtml', '.xml', '.xsl', '.plist'],
-    ['<%--', '--%>'] => ['.asp', '.jsp']
-  }.inject({}) {|accum, (affixes, exts)|
-    exts.each {|ext| accum[ext] = { :prefix => affixes[0], :suffix => affixes[-1] } }
-    accum
-  }
-
   # A collection of regular expressions used by the parser.
   #
   # NOTE: The following pattern, which appears frequently, captures the
@@ -512,7 +501,11 @@ module Asciidoctor
     #     log(e);
     #   }
     #   // end::try-catch[]
-    TagDirectiveRx = /\b(?:tag|(end))::(\S+)\[\]$/
+    if RUBY_ENGINE == 'opal'
+      TagDirectiveRx = /\b(?:tag|(e)nd)::(\S+)\[\](?=$| )/m
+    else
+      TagDirectiveRx = /\b(?:tag|(e)nd)::(\S+)\[\](?=$| )/
+    end
 
     ## Attribute entries and references
 

--- a/lib/asciidoctor/reader.rb
+++ b/lib/asciidoctor/reader.rb
@@ -929,19 +929,14 @@ class PreprocessorReader < Reader
           select = base_select = !(inc_tags.value? true)
           wildcard = inc_tags.delete '*'
         end
-        inc_path_str = target_type == :uri ? inc_path.path : inc_path
-        if (ext_idx = inc_path_str.rindex '.') && (circ_cmt = CIRCUMFIX_COMMENTS[inc_path_str.slice ext_idx, inc_path_str.length])
-          cmt_suffix_len = (tag_suffix = %([] #{circ_cmt[:suffix]})).length - 2
-        end
         begin
           open(inc_path, 'r') do |f|
+            dbl_co, dbl_sb = '::', '[]'
             f.each_line do |l|
               inc_lineno += 1
               # must force encoding since we're performing String operations on line
               l.force_encoding ::Encoding::UTF_8 if FORCE_ENCODING
-              if (((tl = l.chomp).end_with? '[]') ||
-                  (tag_suffix && (tl.end_with? tag_suffix) && (tl = tl.slice 0, tl.length - cmt_suffix_len))) &&
-                  TagDirectiveRx =~ tl
+              if (l.include? dbl_co) && (l.include? dbl_sb) && TagDirectiveRx =~ l
                 if $1 # end tag
                   if (this_tag = $2) == active_tag
                     tag_stack.pop

--- a/test/fixtures/include-file.jsx
+++ b/test/fixtures/include-file.jsx
@@ -1,0 +1,8 @@
+const element = (
+  <div>
+    <h1>Hello, Programmer!</h1>
+    <!-- tag::snippet[] -->
+    <p>Welcome to the club.</p>
+    <!-- end::snippet[] -->
+  </div>
+)

--- a/test/reader_test.rb
+++ b/test/reader_test.rb
@@ -971,12 +971,13 @@ include::fixtures/include-file.asciidoc[tags=snippetA;snippetB]
       test 'include directive supports tagged selection in language that uses circumfix comments' do
         {
           'include-file.xml' => '<snippet>content</snippet>',
-          'include-file.ml' => 'let s = SS.empty;;'
+          'include-file.ml' => 'let s = SS.empty;;',
+          'include-file.jsx' => '<p>Welcome to the club.</p>'
         }.each do |filename, expect|
           input = <<-EOS
-[source,xml,indent=0]
+[source,xml]
 ----
-include::fixtures/#{filename}[tag=snippet]
+include::fixtures/#{filename}[tag=snippet,indent=0]
 ----
           EOS
 


### PR DESCRIPTION
- allow any content after a tag directive if offset by a space
- add test to verify tag is found inside HTML inside a string in a source file