### PR TITLE
resolves #2200 don't convert inter-document xref to internal anchor if target included partially

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -55,6 +55,7 @@ Bug fixes::
   * using the shorthand syntax to set block attributes (id, roles, options) doesn't reset block style (#2174)
   * fix typo in gemspec that removed README and CONTRIBUTING files from the generated gem (PR #2650) (*@aerostitch*)
   * don't turn bare URI scheme (no host) into a link (#2609, PR #2611)
+  * don't convert inter-document xref to internal anchor unless entire target file is included into current file (#2200)
   * fix em dash replacement in manpage converter (#2604, PR #2607)
   * don't output e-mail address twice when replacing bare e-mail address in manpage output (#2654, PR #2665)
   * enforce that absolute start path passed to PathResolver#system_path is inside of jail path (#2642, PR #2644)

--- a/lib/asciidoctor/document.rb
+++ b/lib/asciidoctor/document.rb
@@ -273,7 +273,7 @@ class Document < AbstractBlock
         :images => [],
         :indexterms => [],
         :callouts => Callouts.new,
-        :includes => ::Set.new,
+        :includes => {},
       }
       # copy attributes map and normalize keys
       # attribute overrides are attributes that can only be set from the commandline

--- a/lib/asciidoctor/reader.rb
+++ b/lib/asciidoctor/reader.rb
@@ -917,7 +917,10 @@ class PreprocessorReader < Reader
         end
         shift
         # FIXME not accounting for skipped lines in reader line numbering
-        push_include inc_lines, inc_path, relpath, inc_offset, parsed_attributes if inc_offset
+        if inc_offset
+          parsed_attributes['partial-option'] = true
+          push_include inc_lines, inc_path, relpath, inc_offset, parsed_attributes
+        end
       elsif inc_tags
         inc_lines, inc_offset, inc_lineno, tag_stack, tags_used, active_tag = [], nil, 0, [], ::Set.new, nil
         if inc_tags.key? '**'
@@ -979,8 +982,11 @@ class PreprocessorReader < Reader
           logger.warn message_with_context %(tag#{missing_tags.size > 1 ? 's' : ''} '#{missing_tags * ','}' not found in include #{target_type}: #{inc_path}), :source_location => cursor
         end
         shift
-        # FIXME not accounting for skipped lines in reader line numbering
-        push_include inc_lines, inc_path, relpath, inc_offset, parsed_attributes if inc_offset
+        if inc_offset
+          parsed_attributes['partial-option'] = true unless base_select && wildcard && inc_tags.empty?
+          # FIXME not accounting for skipped lines in reader line numbering
+          push_include inc_lines, inc_path, relpath, inc_offset, parsed_attributes
+        end
       else
         begin
           # NOTE read content first so that we only advance cursor if IO operation succeeds
@@ -1082,7 +1088,8 @@ class PreprocessorReader < Reader
     end
 
     if path
-      @includes << Helpers.rootname(@path = path)
+      @path = path
+      @includes[Helpers.rootname path] = attributes['partial-option'] ? nil : true if @process_lines
     else
       @path = '<stdin>'
     end

--- a/lib/asciidoctor/substitutors.rb
+++ b/lib/asciidoctor/substitutors.rb
@@ -1049,7 +1049,7 @@ module Substitutors
         # handles: path#, path.adoc#, path#id, path.adoc#id, or path (from path.adoc)
         elsif path
           # the referenced path is this document, or its contents has been included in this document
-          if @document.attributes['docname'] == path || @document.catalog[:includes].include?(path)
+          if @document.attributes['docname'] == path || @document.catalog[:includes][path]
             if fragment
               refid, path, target = fragment, nil, %(##{fragment})
               if logger.debug?

--- a/test/fixtures/other-chapters.adoc
+++ b/test/fixtures/other-chapters.adoc
@@ -1,0 +1,11 @@
+// tag::ch2[]
+[#ch2]
+== Chapter 2
+
+The plot thickens.
+// tag::ch2[]
+
+[#ch3]
+== Chapter 3
+
+The plot runs its course, predictably.

--- a/test/links_test.rb
+++ b/test/links_test.rb
@@ -459,7 +459,7 @@ anchor:foo[b[a\]r]text'
   test 'xref using angled bracket syntax with path which has been included in this document' do
     using_memory_logger true do |logger|
       doc = document_from_string '<<tigers#about,About Tigers>>', :header_footer => false
-      doc.catalog[:includes] << 'tigers'
+      doc.catalog[:includes]['tigers'] = true
       output = doc.convert
       assert_xpath '//a[@href="#about"][text() = "About Tigers"]', output, 1
       assert_message logger, :WARN, 'invalid reference: about'
@@ -469,7 +469,7 @@ anchor:foo[b[a\]r]text'
   test 'xref using angled bracket syntax with nested path which has been included in this document' do
     using_memory_logger true do |logger|
       doc = document_from_string '<<part1/tigers#about,About Tigers>>', :header_footer => false
-      doc.catalog[:includes] << 'part1/tigers'
+      doc.catalog[:includes]['part1/tigers'] = true
       output = doc.convert
       assert_xpath '//a[@href="#about"][text() = "About Tigers"]', output, 1
       assert_message logger, :WARN, 'invalid reference: about'
@@ -636,7 +636,70 @@ See <<foobaz>>.
     end
   end
 
-  test 'should warn and create link if verbose flag is set, inter-doc xref points to current document, and reference is not found' do
+  test 'should produce an internal anchor from an inter-document xref to file included into current file' do
+    input = <<-'EOS'
+= Book Title
+:doctype: book
+
+[#ch1]
+== Chapter 1
+
+So it begins.
+
+Read <<other-chapters.adoc#ch2>> to find out what happens next!
+
+include::other-chapters.adoc[]
+    EOS
+
+    doc = document_from_string input, :safe => :safe, :base_dir => fixturedir
+    assert doc.catalog[:includes].key?('other-chapters')
+    assert doc.catalog[:includes]['other-chapters']
+    output = doc.convert
+    assert_xpath '//a[@href="#ch2"][text()="Chapter 2"]', output, 1
+  end
+
+  test 'should produce an internal anchor from an inter-document xref to file included entirely into current file using tags' do
+    input = <<-'EOS'
+= Book Title
+:doctype: book
+
+[#ch1]
+== Chapter 1
+
+So it begins.
+
+Read <<other-chapters.adoc#ch2>> to find out what happens next!
+
+include::other-chapters.adoc[tags=**]
+    EOS
+
+    output = render_embedded_string input, :safe => :safe, :base_dir => fixturedir
+    assert_xpath '//a[@href="#ch2"][text()="Chapter 2"]', output, 1
+  end
+
+  test 'should not produce an internal anchor for inter-document xref to file partially included into current file' do
+    input = <<-'EOS'
+= Book Title
+:doctype: book
+
+[#ch1]
+== Chapter 1
+
+So it begins.
+
+Read <<other-chapters.adoc#ch2,the next chapter>> to find out what happens next!
+
+include::other-chapters.adoc[tags=ch2]
+    EOS
+
+    doc = document_from_string input, :safe => :safe, :base_dir => fixturedir
+    assert doc.catalog[:includes].key?('other-chapters')
+    refute doc.catalog[:includes]['other-chapters']
+    output = doc.convert
+    assert_xpath '//a[@href="other-chapters.html#ch2"][text()="the next chapter"]', output, 1
+  end
+
+  test 'should warn and create link if debug mode is enabled, inter-document xref points to current doc, and reference not found' do
     input = <<-EOS
 [#foobar]
 == Foobar

--- a/test/reader_test.rb
+++ b/test/reader_test.rb
@@ -589,6 +589,18 @@ include::fixtures/include-file.asciidoc[]
         doc = document_from_string input, :safe => :safe, :header_footer => false, :base_dir => DIRNAME
         output = doc.convert
         assert_match(/included content/, output)
+        assert doc.catalog[:includes]['fixtures/include-file']
+      end
+
+      test 'should not track include in catalog for non-AsciiDoc include files' do
+        input = <<-EOS
+----
+include::fixtures/circle.svg[]
+----
+        EOS
+
+        doc = document_from_string input, :safe => :safe, :header_footer => false, :base_dir => DIRNAME
+        assert doc.catalog[:includes].empty?
       end
 
       test 'include directive should resolve file with spaces in name' do


### PR DESCRIPTION
- change the includes key in the document catalog from a set to a hash
- don't track file included into the current file if included partially
- don't track file included into the current file unless it's AsciiDoc