### PR TITLE
resolves #2381 parse attributes in xref macro if attribute signature is detected

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -18,6 +18,7 @@ For a detailed view of what has changed, refer to the {uri-repo}/commits/master[
 Enhancements::
 
   * BREAKING: drop XML tags, character refs, and non-word characters (except hyphen and space) when generating ID for section (#794)
+  * parse text of xref macro as attributes if attribute signature found (equal sign) (#2381)
   * route messages through a logger instead of using Kernel#warn (#44, PR #2660)
   * add MemoryLogger for capturing messages sent to logger into memory (#44, PR #2660)
   * add NullLogger to prevent messages from being logged (#44, PR #2660)

--- a/features/xref.feature
+++ b/features/xref.feature
@@ -846,3 +846,129 @@ Feature: Cross References
           |refer to
           a< href='#Section One' [Section One]
       """
+
+    Scenario: Parses text of xref macro as attributes if attribute signature found
+    Given the AsciiDoc source
+      """
+      == Section One
+
+      content
+
+      == Section Two
+
+      refer to xref:_section_one[role=next]
+      """
+    When it is converted to html
+    Then the result should match the HTML structure
+      """
+      .sect1
+        h2#_section_one
+          |Section One
+        .sectionbody: .paragraph: p content
+      .sect1
+        h2#_section_two Section Two
+        .sectionbody: .paragraph: p
+          |refer to
+          a< href='#_section_one' class='next' Section One
+      """
+
+    Scenario: Does not parse text of xref macro as attribute if attribute signature not found
+    Given the AsciiDoc source
+      """
+      == Section One
+
+      content
+
+      == Section Two
+
+      refer to xref:_section_one[One, Section One]
+      """
+    When it is converted to html
+    Then the result should match the HTML structure
+      """
+      .sect1
+        h2#_section_one
+          |Section One
+        .sectionbody: .paragraph: p content
+      .sect1
+        h2#_section_two Section Two
+        .sectionbody: .paragraph: p
+          |refer to
+          a< href='#_section_one' One, Section One
+      """
+
+    Scenario: Uses whole text of xref macro as link text if attribute signature found and text is enclosed in double quotes
+    Given the AsciiDoc source
+      """
+      == Section One
+
+      content
+
+      == Section Two
+
+      refer to xref:_section_one["Section One == Starting Point"]
+      """
+    When it is converted to html
+    Then the result should match the HTML structure
+      """
+      .sect1
+        h2#_section_one
+          |Section One
+        .sectionbody: .paragraph: p content
+      .sect1
+        h2#_section_two Section Two
+        .sectionbody: .paragraph: p
+          |refer to
+          a< href='#_section_one'
+            |Section One == Starting Point
+      """
+
+    Scenario: Does not parse text of xref macro as text if enclosed in double quotes but attribute signature not found
+    Given the AsciiDoc source
+      """
+      == Section One
+
+      content
+
+      == Section Two
+
+      refer to xref:_section_one["The Premier Section"]
+      """
+    When it is converted to html
+    Then the result should match the HTML structure
+      """
+      .sect1
+        h2#_section_one
+          |Section One
+        .sectionbody: .paragraph: p content
+      .sect1
+        h2#_section_two Section Two
+        .sectionbody: .paragraph: p
+          |refer to
+          a< href='#_section_one' "The Premier Section"
+      """
+
+    Scenario: Can escape double quotes in text of xref macro using backslashes when text is parsed as attributes
+    Given the AsciiDoc source
+      """
+      == Section One
+
+      content
+
+      == Section Two
+
+      refer to xref:_section_one["\"The Premier Section\"",role=spotlight]
+      """
+    When it is converted to html
+    Then the result should match the HTML structure
+      """
+      .sect1
+        h2#_section_one
+          |Section One
+        .sectionbody: .paragraph: p content
+      .sect1
+        h2#_section_two Section Two
+        .sectionbody: .paragraph: p
+          |refer to
+          a< href='#_section_one' class='spotlight' "The Premier Section"
+      """

--- a/lib/asciidoctor/converter/html5.rb
+++ b/lib/asciidoctor/converter/html5.rb
@@ -557,7 +557,7 @@ Your browser does not support the audio tag.
       end
       img ||= %(<img src="#{node.image_uri target}" alt="#{encode_quotes node.alt}"#{width_attr}#{height_attr}#{@void_element_slash}>)
       if node.attr? 'link', nil, false
-        img = %(<a class="image" href="#{node.attr 'link'}"#{(append_anchor_constraint_attrs node).join}>#{img}</a>)
+        img = %(<a class="image" href="#{node.attr 'link'}"#{(append_link_constraint_attrs node).join}>#{img}</a>)
       end
       id_attr = node.id ? %( id="#{node.id}") : ''
       classes = ['imageblock', node.role].compact
@@ -1038,23 +1038,27 @@ Your browser does not support the video tag.
     def inline_anchor node
       case node.type
       when :xref
-        unless (text = node.text) || (text = node.attributes['path'])
-          if AbstractNode === (ref = node.document.catalog[:refs][refid = node.attributes['refid']])
-            text = ref.xreftext((@xrefstyle ||= node.document.attributes['xrefstyle'])) || %([#{refid}])
-          else
-            text = %([#{refid}])
+        if (path = node.attributes['path'])
+          attrs = (append_link_constraint_attrs node, node.role ? [%( class="#{node.role}")] : []).join
+          text = node.text || path
+        else
+          attrs = node.role ? %( class="#{node.role}") : ''
+          unless (text = node.text)
+            if AbstractNode === (ref = node.document.catalog[:refs][refid = node.attributes['refid']])
+              text = ref.xreftext((@xrefstyle ||= node.document.attributes['xrefstyle'])) || %([#{refid}])
+            else
+              text = %([#{refid}])
+            end
           end
         end
-        %(<a href="#{node.target}">#{text}</a>)
+        %(<a href="#{node.target}"#{attrs}>#{text}</a>)
       when :ref
         %(<a id="#{node.id}"></a>)
       when :link
         attrs = node.id ? [%( id="#{node.id}")] : []
-        if (role = node.role)
-          attrs << %( class="#{role}")
-        end
+        attrs << %( class="#{node.role}") if node.role
         attrs << %( title="#{node.attr 'title'}") if node.attr? 'title', nil, false
-        %(<a href="#{node.target}"#{(append_anchor_constraint_attrs node, attrs).join}>#{node.text}</a>)
+        %(<a href="#{node.target}"#{(append_link_constraint_attrs node, attrs).join}>#{node.text}</a>)
       when :bibref
         # NOTE technically node.text should be node.reftext, but subs have already been applied to text
         %(<a id="#{node.id}"></a>#{node.text})
@@ -1121,7 +1125,7 @@ Your browser does not support the video tag.
         img ||= %(<img src="#{type == 'icon' ? (node.icon_uri target) : (node.image_uri target)}" alt="#{encode_quotes node.alt}"#{attrs}#{@void_element_slash}>)
       end
       if node.attr? 'link', nil, false
-        img = %(<a class="image" href="#{node.attr 'link'}"#{(append_anchor_constraint_attrs node).join}>#{img}</a>)
+        img = %(<a class="image" href="#{node.attr 'link'}"#{(append_link_constraint_attrs node).join}>#{img}</a>)
       end
       class_attr_val = (role = node.role) ? %(#{type} #{role}) : type
       style_attr = (node.attr? 'float') ? %( style="float: #{node.attr 'float'}") : ''
@@ -1190,10 +1194,10 @@ Your browser does not support the video tag.
 </div>)
     end
 
-    def append_anchor_constraint_attrs node, attrs = []
+    def append_link_constraint_attrs node, attrs = []
       rel = 'nofollow' if node.option? 'nofollow'
-      if node.attr? 'window', nil, false
-        attrs << %( target="#{window = node.attr 'window'}")
+      if (window = node.attributes['window'])
+        attrs << %( target="#{window}")
         attrs << (rel ? %( rel="#{rel} noopener") : ' rel="noopener"') if window == '_blank' || (node.option? 'noopener')
       elsif rel
         attrs << %( rel="#{rel}")

--- a/lib/asciidoctor/substitutors.rb
+++ b/lib/asciidoctor/substitutors.rb
@@ -1022,7 +1022,7 @@ module Substitutors
           if (text = m[3])
             text = text.gsub ESC_R_SB, R_SB if text.include? R_SB
             # NOTE if an equal sign (=) is present, parse text as attributes
-            text = (parse_attributes text, [], :into => attrs)[1] if (text.include? '=') && !@document.compat_mode
+            text = ((AttributeList.new text, self).parse_into attrs)[1] if (text.include? '=') && !@document.compat_mode
           end
         end
 

--- a/lib/asciidoctor/substitutors.rb
+++ b/lib/asciidoctor/substitutors.rb
@@ -1004,9 +1004,9 @@ module Substitutors
   end
 
   # Internal: Substitute cross reference links
-  def sub_inline_xrefs(text, found = nil)
-    if ((found ? found[:macroish] : (text.include? '[')) && (text.include? 'xref:')) || ((text.include? '&') && (text.include? 'lt;&'))
-      text = text.gsub(InlineXrefMacroRx) {
+  def sub_inline_xrefs(content, found = nil)
+    if ((found ? found[:macroish] : (content.include? '[')) && (content.include? 'xref:')) || ((content.include? '&') && (content.include? 'lt;&'))
+      content = content.gsub(InlineXrefMacroRx) {
         # alias match for Ruby 1.8.7 compat
         m = $~
         # honor the escape
@@ -1014,35 +1014,35 @@ module Substitutors
           next m[0][1..-1]
         end
         attrs = {}
-        if (id = m[1])
-          id, reftext = id.split ',', 2
-          reftext = reftext.lstrip if reftext
+        if (refid = m[1])
+          refid, text = refid.split ',', 2
+          text = text.lstrip if text
         else
-          id = m[2]
-          if (reftext = m[3])
-            reftext = reftext.gsub ESC_R_SB, R_SB if reftext.include? R_SB
-            # NOTE if an equal sign (=) is present, parse reftext as attributes
-            reftext = (parse_attributes reftext, [], :into => attrs)[1] if (reftext.include? '=') && !@document.compat_mode
+          refid = m[2]
+          if (text = m[3])
+            text = text.gsub ESC_R_SB, R_SB if text.include? R_SB
+            # NOTE if an equal sign (=) is present, parse text as attributes
+            text = (parse_attributes text, [], :into => attrs)[1] if (text.include? '=') && !@document.compat_mode
           end
         end
 
-        if (hash_idx = id.index '#')
+        if (hash_idx = refid.index '#')
           if hash_idx > 0
-            if (fragment_len = id.length - hash_idx - 1) > 0
-              path, fragment = (id.slice 0, hash_idx), (id.slice hash_idx + 1, fragment_len)
+            if (fragment_len = refid.length - hash_idx - 1) > 0
+              path, fragment = (refid.slice 0, hash_idx), (refid.slice hash_idx + 1, fragment_len)
             else
-              path = id.slice 0, hash_idx
+              path = refid.slice 0, hash_idx
             end
             if (ext_idx = path.rindex '.') && ASCIIDOC_EXTENSIONS[path.slice ext_idx, path.length]
               path = path.slice 0, ext_idx
             end
           else
-            target, fragment = id, (id.slice 1, id.length)
+            target, fragment = refid, (refid.slice 1, refid.length)
           end
-        elsif (ext_idx = id.rindex '.') && ASCIIDOC_EXTENSIONS[id.slice ext_idx, id.length]
-          path = id.slice 0, ext_idx
+        elsif (ext_idx = refid.rindex '.') && ASCIIDOC_EXTENSIONS[refid.slice ext_idx, refid.length]
+          path = refid.slice 0, ext_idx
         else
-          fragment = id
+          fragment = refid
         end
 
         # handles: #id
@@ -1065,9 +1065,9 @@ module Substitutors
             path = %(#{@document.attributes['relfileprefix']}#{path}#{@document.attributes.fetch 'outfilesuffix', '.html'})
             target = fragment ? %(#{path}##{fragment}) : path
           end
-        # handles: id or Section Title
+        # handles: id or Node Title or Reference Text
         else
-          # resolve fragment as reftext if it's not a known ID and resembles reftext (includes space or has uppercase char)
+          # do reverse lookup on fragment if not a known ID and resembles reftext (contains a space or uppercase char)
           unless @document.catalog[:ids].key? fragment
             if Compliance.natural_xrefs && !@document.compat_mode &&
                 ((fragment.include? ' ') || fragment.downcase != fragment) &&
@@ -1080,11 +1080,11 @@ module Substitutors
           refid, target = fragment, %(##{fragment})
         end
         attrs['path'], attrs['fragment'], attrs['refid'] = path, fragment, refid
-        Inline.new(self, :anchor, reftext, :type => :xref, :target => target, :attributes => attrs).convert
+        Inline.new(self, :anchor, text, :type => :xref, :target => target, :attributes => attrs).convert
       }
     end
 
-    text
+    content
   end
 
   # Public: Substitute callout source references
@@ -1221,7 +1221,7 @@ module Substitutors
     end
   end
 
-  # Internal: Strip bounding whitespace, fold endlines and unescaped closing
+  # Internal: Strip bounding whitespace, fold endlines and unescape closing
   # square brackets from text extracted from brackets
   def unescape_bracketed_text text
     if (text = text.strip.tr LF, ' ').include? R_SB


### PR DESCRIPTION
- parse text of xref macro as attributes if attribute signature (equal sign) detected
- if role is set on xref, add it to class attribute of `<a>` element in HTML5 converter
- rename append_anchor_constraint_attrs to append_link_constraint_attrs
- add link contraint attributes to `<a>` element of interdoc xref
- rename variables in sub_inline_xrefs to be consistent with terminology