### PR TITLE
resolves #2605 add support for rel=nofollow on links

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -37,6 +37,7 @@ Enhancements::
   * add syntax for adding hard line breaks in block AsciiMath equations (#2497, PR #2579) (*@dimztimz*)
   * add positioning option to sectanchors attribute (before or after) (#2485, PR #2486)
   * allow table stripes to be configured using stripe attribute or stripe roles on table; valid values are even, odd, all, and none (#1365, PR #2588)
+  * allow nofollow rel property to be added to links and linked images by setting the nofollow option (#2605, PR #2692)
   * assign Document#source_location when sourcemap option is enabled (#2478, PR #2488)
   * allow local include to be flagged as optional by setting optional option (#2389, PR #2413)
   * allow attribute name to contain word characters as defined by Unicode (#2376, PR #2393)
@@ -106,6 +107,7 @@ Improvements / Refactoring::
   * allow paragraph to masquerade as open block (PR #2412)
   * move callouts into document catalog (PR #2394)
   * document ID defined in block attribute line takes precedence over ID defined inside document title line
+  * don't look for link and window attributes on document when resolving these attributes for an image
   * when linkattrs is set, only parse attributes in link macro if equals follows first comma
   * skip line comments in name section of manpage (#2584, PR #2585)
   * always activate extension registry passed to processor (PR #2379)

--- a/lib/asciidoctor/converter/html5.rb
+++ b/lib/asciidoctor/converter/html5.rb
@@ -557,9 +557,8 @@ Your browser does not support the audio tag.
         end
       end
       img ||= %(<img src="#{node.image_uri target}" alt="#{encode_quotes node.alt}"#{width_attr}#{height_attr}#{@void_element_slash}>)
-      if node.attr? 'link'
-        window_attr = %( target="#{window = node.attr 'window'}"#{window == '_blank' || (node.option? 'noopener') ? ' rel="noopener"' : ''}) if node.attr? 'window'
-        img = %(<a class="image" href="#{node.attr 'link'}"#{window_attr}>#{img}</a>)
+      if node.attr? 'link', nil, false
+        img = %(<a class="image" href="#{node.attr 'link'}"#{(append_anchor_constraint_attrs node).join}>#{img}</a>)
       end
       id_attr = node.id ? %( id="#{node.id}") : ''
       classes = ['imageblock', node.role].compact
@@ -1056,8 +1055,7 @@ Your browser does not support the video tag.
           attrs << %( class="#{role}")
         end
         attrs << %( title="#{node.attr 'title'}") if node.attr? 'title', nil, false
-        attrs << %( target="#{window = node.attr 'window'}"#{window == '_blank' || (node.option? 'noopener') ? ' rel="noopener"' : ''}) if node.attr? 'window', nil, false
-        %(<a href="#{node.target}"#{attrs.join}>#{node.text}</a>)
+        %(<a href="#{node.target}"#{(append_anchor_constraint_attrs node, attrs).join}>#{node.text}</a>)
       when :bibref
         # NOTE technically node.text should be node.reftext, but subs have already been applied to text
         %(<a id="#{node.id}"></a>#{node.text})
@@ -1123,9 +1121,8 @@ Your browser does not support the video tag.
         end
         img ||= %(<img src="#{type == 'icon' ? (node.icon_uri target) : (node.image_uri target)}" alt="#{encode_quotes node.alt}"#{attrs}#{@void_element_slash}>)
       end
-      if node.attr? 'link'
-        window_attr = %( target="#{window = node.attr 'window'}"#{window == '_blank' || (node.option? 'noopener') ? ' rel="noopener"' : ''}) if node.attr? 'window'
-        img = %(<a class="image" href="#{node.attr 'link'}"#{window_attr}>#{img}</a>)
+      if node.attr? 'link', nil, false
+        img = %(<a class="image" href="#{node.attr 'link'}"#{(append_anchor_constraint_attrs node).join}>#{img}</a>)
       end
       class_attr_val = (role = node.role) ? %(#{type} #{role}) : type
       style_attr = (node.attr? 'float') ? %( style="float: #{node.attr 'float'}") : ''
@@ -1192,6 +1189,17 @@ Your browser does not support the video tag.
 <div class="sectionbody">
 <p>#{node.attr 'manname'} - #{node.attr 'manpurpose'}</p>
 </div>)
+    end
+
+    def append_anchor_constraint_attrs node, attrs = []
+      rel = 'nofollow' if node.option? 'nofollow'
+      if node.attr? 'window', nil, false
+        attrs << %( target="#{window = node.attr 'window'}")
+        attrs << (rel ? %( rel="#{rel} noopener") : ' rel="noopener"') if window == '_blank' || (node.option? 'noopener')
+      elsif rel
+        attrs << %( rel="#{rel}")
+      end
+      attrs
     end
 
     def read_svg_contents node, target

--- a/test/blocks_test.rb
+++ b/test/blocks_test.rb
@@ -2006,6 +2006,15 @@ image::images/tiger.png[Tiger,link=http://en.wikipedia.org/wiki/Tiger,window=nam
       assert_xpath '/*[@class="imageblock"]//a[@class="image"][@href="http://en.wikipedia.org/wiki/Tiger"][@target="name"][@rel="noopener"]/img[@src="images/tiger.png"][@alt="Tiger"]', output, 1
     end
 
+    test 'adds rel=nofollow attribute to block image with a link when the nofollow option is set' do
+      input = <<-EOS
+image::images/tiger.png[Tiger,link=http://en.wikipedia.org/wiki/Tiger,opts=nofollow]
+      EOS
+
+      output = render_embedded_string input
+      assert_xpath '/*[@class="imageblock"]//a[@class="image"][@href="http://en.wikipedia.org/wiki/Tiger"][@rel="nofollow"]/img[@src="images/tiger.png"][@alt="Tiger"]', output, 1
+    end
+
     test 'can render block image with caption' do
       input = <<-EOS
 .The AsciiDoc Tiger

--- a/test/links_test.rb
+++ b/test/links_test.rb
@@ -236,6 +236,10 @@ context 'Links' do
     assert_xpath '//a[@href="http://google.com"][@rel="noopener"]', result, 0
   end
 
+  test 'rel=nofollow should be added to a link when the nofollow option is set' do
+    assert_xpath '//a[@href="http://google.com"][@target="name"][@rel="nofollow noopener"]', render_embedded_string('http://google.com[Google,window=name,opts="nofollow,noopener"]', :attributes => {'linkattrs' => ''}), 1
+  end
+
   test 'id attribute on link are processed when linkattrs is set' do
     assert_xpath '//a[@href="http://google.com"][@id="link-1"]', render_embedded_string('http://google.com[Google, id="link-1"]', :attributes => {'linkattrs' => ''}), 1
   end

--- a/test/substitutions_test.rb
+++ b/test/substitutions_test.rb
@@ -766,6 +766,12 @@ context 'Substitutions' do
           para.sub_macros(para.source).gsub(/>\s+</, '><')
     end
 
+    test 'rel=nofollow should be added to an image with a link when the nofollow option is set' do
+      para = block_from_string 'image:tiger.png[Tiger,link=http://en.wikipedia.org/wiki/Tiger,opts=nofollow]'
+      assert_equal %{<span class="image"><a class="image" href="http://en.wikipedia.org/wiki/Tiger" rel="nofollow"><img src="tiger.png" alt="Tiger"></a></span>},
+          para.sub_macros(para.source).gsub(/>\s+</, '><')
+    end
+
     test 'a multi-line image macro with text and dimensions should be interpreted as an image with alt text and dimensions' do
       para = block_from_string(%(image:tiger.png[Another\nAwesome\nTiger, 200,\n100]))
       assert_equal %{<span class="image"><img src="tiger.png" alt="Another Awesome Tiger" width="200" height="100"></span>},


### PR DESCRIPTION
- extract code to produces window and rel attributes into shared method
- don't look for window and link on document when resolving image link
- set rel=nofollow on anchor or linked image when nofollow option is set