### PR TITLE
resolves #2257 catalog anchors at start of select list items and table cells

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -140,6 +140,7 @@ Improvements / Refactoring::
   * leave inline anchor in section title as is if section has ID (#2243, PR #2427)
   * align and improve error message about invalid use of partintro between HTML5 and DocBook converters
   * rephrase warning when level 0 sections are found and the doctype is not book
+  * report correct line number when duplicate bibliography anchor is found
   * only warn if thread_safe gem is missing when using built-in template cache
   * rename enumerate_section to assign_numeral; update API docs
   * drop deprecated compact option from CLI; remove from manpage

--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -46,6 +46,7 @@ Enhancements::
   * allow local include to be flagged as optional by setting optional option (#2389, PR #2413)
   * allow attribute name to contain word characters as defined by Unicode (#2376, PR #2393)
   * allow block title to begin with a period (#2358, PR #2359)
+  * catalog inline anchor at start of list item in ordered and unordered lists, description list term, and table cell (#2257)
   * register document in catalog if id is set; assign reftext to document attributes if specified in a block attribute line (#2301, PR #2428)
   * use the quote element in DocBook converter for smart quotes (#2272, PR #2356) (*@bk2204*)
   * parse and pass all manpage names to output document master (shadown man pages) (#1811, #2543, PR #2414)

--- a/lib/asciidoctor.rb
+++ b/lib/asciidoctor.rb
@@ -841,6 +841,9 @@ module Asciidoctor
     # Scans for a non-escaped anchor (i.e., id + optional reference text) in the flow of text.
     InlineAnchorScanRx = /(?:^|[^\\\[])\[\[([#{CC_ALPHA}_:][#{CC_WORD}:.-]*)(?:, *(.+?))?\]\]|(?:^|[^\\])anchor:([#{CC_ALPHA}_:][#{CC_WORD}:.-]*)\[(?:\]|(.*?[^\\])\])/
 
+    # Scans for a leading, non-escaped anchor (i.e., id + optional reference text).
+    LeadingInlineAnchorRx = /^\[\[([#{CC_ALPHA}_:][#{CC_WORD}:.-]*)(?:, *(.+?))?\]\]/
+
     # Matches a bibliography anchor at the start of the list item text (in a bibliography list).
     #
     # Examples

--- a/lib/asciidoctor/parser.rb
+++ b/lib/asciidoctor/parser.rb
@@ -634,13 +634,13 @@ class Parser
         if Section === parent && parent.sectname == 'bibliography'
           style = attributes['style'] = 'bibliography'
         end unless style
-        block = next_item_list(reader, :ulist, parent, style)
+        block = next_list(reader, :ulist, parent, style)
         break
 
       elsif (match = OrderedListRx.match(this_line))
         reader.unshift_line this_line
-        block = next_item_list(reader, :olist, parent)
-        # FIXME move this logic into next_item_list
+        block = next_list(reader, :olist, parent)
+        # FIXME move this logic into next_list
         unless style
           marker = block.items[0].marker
           if marker.start_with? '.'
@@ -1092,15 +1092,15 @@ class Parser
     end
   end
 
-  # Internal: Parse and construct an item list (ordered or unordered) from the current position of the Reader
+  # Internal: Parse and construct an ordered or unordered list at the current position of the Reader
   #
-  # reader    - The Reader from which to retrieve the outline list
+  # reader    - The Reader from which to retrieve the list
   # list_type - A Symbol representing the list type (:olist for ordered, :ulist for unordered)
-  # parent    - The parent Block to which this outline list belongs
+  # parent    - The parent Block to which this list belongs
   # style     - The block style assigned to this list (optional, default: nil)
   #
-  # Returns the Block encapsulating the parsed outline (unordered or ordered) list
-  def self.next_item_list(reader, list_type, parent, style = nil)
+  # Returns the Block encapsulating the parsed unordered or ordered list
+  def self.next_list(reader, list_type, parent, style = nil)
     list_block = List.new(parent, list_type)
     list_block.level = parent.context == list_type ? (parent.level + 1) : 1
 
@@ -1254,9 +1254,9 @@ class Parser
     list_block
   end
 
-  # Internal: Parse and construct the next ListItem for the current bulleted
-  # (unordered or ordered) list Block, callout lists included, or the next
-  # term ListItem and description ListItem pair for the description list Block.
+  # Internal: Parse and construct the next ListItem for the current list Block
+  # (unordered, ordered, or callout list) or the term ListItem and description
+  # ListItem pair for the description list Block.
   #
   # First collect and process all the lines that constitute the next list
   # item for the parent list (according to its type). Next, parse those lines

--- a/test/lists_test.rb
+++ b/test/lists_test.rb
@@ -2870,6 +2870,23 @@ last question::
       assert_css 'bibliodiv > bibliomixed:nth-child(2) > bibliomisc > anchor[xreflabel="[walsh-muellner]"]', output, 1
     end
 
+    test 'should warn if a bibliography ID is already in use' do
+      input = <<-EOS
+[bibliography]
+* [[[Fowler]]] Fowler M. _Analysis Patterns: Reusable Object Models_.
+Addison-Wesley. 1997.
+* [[[Fowler]]] Fowler M. _Analysis Patterns: Reusable Object Models_.
+Addison-Wesley. 1997.
+      EOS
+      using_memory_logger do |logger|
+        output = render_embedded_string input
+        assert_css '.ulist.bibliography', output, 1
+        assert_css '.ulist.bibliography ul li:nth-child(1) p a#Fowler', output, 1
+        assert_css '.ulist.bibliography ul li:nth-child(2) p a#Fowler', output, 1
+        assert_message logger, :WARN, '<stdin>: line 4: id assigned to bibliography anchor already in use: Fowler', Hash
+      end
+    end
+
     test 'should automatically add bibliography style to top-level lists in bibliography section' do
       input = <<-EOS
 [bibliography]

--- a/test/tables_test.rb
+++ b/test/tables_test.rb
@@ -1150,6 +1150,31 @@ content
       assert_xpath '//a[@href="#_more"][text()="More"]', result, 1
     end
 
+    test 'should discover anchor at start of cell and register it as a reference' do
+      input = <<-EOS
+The highest peak in the Front Range is <<grays-peak>>, which tops <<mount-evans>> by just a few feet.
+
+[cols="1s,1"]
+|===
+|[[mount-evans,Mount Evans]]Mount Evans
+|14,271 feet
+
+h|[[grays-peak,Grays Peak]]
+Grays Peak
+|14,278 feet
+|===
+      EOS
+      doc = document_from_string input
+      refs = doc.catalog[:refs]
+      assert refs.key?('mount-evans')
+      assert refs.key?('grays-peak')
+      output = doc.convert :header_footer => false
+      assert_xpath '(//p)[1]/a[@href="#grays-peak"][text()="Grays Peak"]', output, 1
+      assert_xpath '(//p)[1]/a[@href="#mount-evans"][text()="Mount Evans"]', output, 1
+      assert_xpath '(//table/tbody/tr)[1]//td//a[@id="mount-evans"]', output, 1
+      assert_xpath '(//table/tbody/tr)[2]//th//a[@id="grays-peak"]', output, 1
+    end
+
     test 'footnotes should not be shared between an AsciiDoc table cell and the main document' do
       input = <<-EOS
 |===


### PR DESCRIPTION
- resolves #2257 catalog anchor at start of list item in an ordered or unordered list
- resolves #1675 catalog anchor at start of term in description list
- catalog anchor at start of table cell (unless the style is literal or asciidoc)