### PR TITLE
Accurately track source location for lists, list items, and tables

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -95,6 +95,8 @@ Bug fixes::
 
 Improvements / Refactoring::
 
+  * use cursor marks to track lines more accurately; record cursor at the start of each block, list item, or table cell (PR #2701, PR #2547) (@seikichi)
+  * populate source_location property on list items when sourcemap option is set on document (PR #2069) (@mogztter)
   * log a warning message if an unterminated delimited block is detected (#1133, PR #2612)
   * log a warning when nested section is found inside special section that doesn't support nested sections (#2433, PR #2672)
   * read files in binary mode to disable automatic endline coercion (then explicitly coerce to UTF-8) (PR #2583, PR #2694)

--- a/lib/asciidoctor/parser.rb
+++ b/lib/asciidoctor/parser.rb
@@ -612,12 +612,12 @@ class Parser
           list_item_lineno = reader.lineno
           # might want to move this check to a validate method
           unless match[1] == expected_index.to_s
-            logger.warn message_with_context %(callout list item index: expected #{expected_index} got #{match[1]}), :source_location => (reader.cursor list_item_lineno)
+            logger.warn message_with_context %(callout list item index: expected #{expected_index} got #{match[1]}), :source_location => (reader.cursor_at list_item_lineno)
           end
           if (list_item = next_list_item reader, block, match)
             block.items << list_item
             if (coids = document.callouts.callout_ids block.items.size).empty?
-              logger.warn message_with_context %(no callouts refer to list item #{block.items.size}), :source_location => (reader.cursor list_item_lineno)
+              logger.warn message_with_context %(no callouts refer to list item #{block.items.size}), :source_location => (reader.cursor_at list_item_lineno)
             else
               list_item.attributes['coids'] = coids
             end
@@ -1574,7 +1574,7 @@ class Parser
     # generate an ID if one was not embedded or specified as anchor above section title
     if (id = section.id ||= ((document.attributes.key? 'sectids') ? (Section.generate_id section.title, document) : nil))
       unless document.register :refs, [id, section, sect_reftext || section.title]
-        logger.warn message_with_context %(id assigned to section already in use: #{id}), :source_location => (reader.cursor reader.lineno - (sect_atx ? 1 : 2))
+        logger.warn message_with_context %(id assigned to section already in use: #{id}), :source_location => (reader.cursor_at reader.lineno - (sect_atx ? 1 : 2))
       end
     end
 

--- a/lib/asciidoctor/parser.rb
+++ b/lib/asciidoctor/parser.rb
@@ -850,7 +850,8 @@ class Parser
         block = build_block(block_context, :compound, terminator, parent, reader, attributes)
 
       when :table
-        block_reader = Reader.new reader.read_lines_until(:terminator => terminator, :skip_line_comments => true, :context => :table), reader.cursor
+        block_cursor = reader.cursor
+        block_reader = Reader.new reader.read_lines_until(:terminator => terminator, :skip_line_comments => true, :context => :table), block_cursor
         # NOTE it's very rare that format is set when using a format hint char, so short-circuit
         unless terminator.start_with? '|', '!'
           # NOTE infer dsv once all other format hint chars are ruled out
@@ -1028,7 +1029,8 @@ class Parser
       block_reader = reader
     else
       lines = nil
-      block_reader = Reader.new reader.read_lines_until(:terminator => terminator, :skip_processing => skip_processing, :context => block_context), reader.cursor
+      block_cursor = reader.cursor
+      block_reader = Reader.new reader.read_lines_until(:terminator => terminator, :skip_processing => skip_processing, :context => block_context), block_cursor
     end
 
     if content_model == :verbatim
@@ -1282,7 +1284,8 @@ class Parser
 
     # first skip the line with the marker / term
     reader.shift
-    list_item_reader = Reader.new read_lines_for_list_item(reader, list_type, sibling_trait, has_text), reader.cursor
+    block_cursor = reader.cursor
+    list_item_reader = Reader.new read_lines_for_list_item(reader, list_type, sibling_trait, has_text), block_cursor
     if list_item_reader.has_more_lines?
       # NOTE peek on the other side of any comment lines
       comment_lines = list_item_reader.skip_line_comments

--- a/lib/asciidoctor/parser.rb
+++ b/lib/asciidoctor/parser.rb
@@ -1325,11 +1325,7 @@ class Parser
     end
 
     if dlist
-      if list_item.text? || list_item.blocks?
-        [list_term, list_item]
-      else
-        [list_term]
-      end
+      list_item.text? || list_item.blocks? ? [list_term, list_item] : [list_term]
     else
       list_item
     end

--- a/lib/asciidoctor/reader.rb
+++ b/lib/asciidoctor/reader.rb
@@ -5,20 +5,14 @@ class Reader
   include Logging
 
   class Cursor
-    attr_accessor :file
-    attr_accessor :dir
-    attr_accessor :path
-    attr_accessor :lineno
+    attr_reader :file, :dir, :path, :lineno
 
     def initialize file, dir = nil, path = nil, lineno = nil
-      @file = file
-      @dir = dir
-      @path = path
-      @lineno = lineno
+      @file, @dir, @path, @lineno = file, dir, path, lineno
     end
 
     def line_info
-      %(#{path}: line #{lineno})
+      %(#{@path}: line #{@lineno})
     end
 
     alias to_s line_info

--- a/lib/asciidoctor/reader.rb
+++ b/lib/asciidoctor/reader.rb
@@ -516,7 +516,7 @@ class Reader
     Cursor.new @file, @dir, @path, @lineno
   end
 
-  def cursor_at lineno
+  def cursor_at_line lineno
     Cursor.new @file, @dir, @path, lineno
   end
 
@@ -529,12 +529,12 @@ class Reader
       m_file, m_dir, m_path, m_lineno = @mark
       Cursor.new m_file, m_dir, m_path, m_lineno - 1
     else
-      prev_line_cursor
+      cursor_at_prev_line
     end
   end
 
-  def prev_line_cursor
-    cursor_at @lineno - 1
+  def cursor_at_prev_line
+    cursor_at_line @lineno - 1
   end
 
   def cursor_data

--- a/lib/asciidoctor/reader.rb
+++ b/lib/asciidoctor/reader.rb
@@ -524,6 +524,15 @@ class Reader
     @mark ? Cursor.new(*@mark) : cursor
   end
 
+  def cursor_before_mark
+    if @mark
+      m_file, m_dir, m_path, m_lineno = @mark
+      Cursor.new m_file, m_dir, m_path, m_lineno - 1
+    else
+      prev_line_cursor
+    end
+  end
+
   def prev_line_cursor
     cursor_at @lineno - 1
   end

--- a/lib/asciidoctor/reader.rb
+++ b/lib/asciidoctor/reader.rb
@@ -524,6 +524,10 @@ class Reader
     Cursor.new @file, @dir, @path, lineno
   end
 
+  def cursor_data
+    [@file, @dir, @path, @lineno]
+  end
+
   def prev_line_cursor
     cursor_at @lineno - 1
   end

--- a/lib/asciidoctor/reader.rb
+++ b/lib/asciidoctor/reader.rb
@@ -516,12 +516,16 @@ class Reader
     @lines.unshift(*lines)
   end
 
-  def cursor lineno = nil
-    Cursor.new @file, @dir, @path, (lineno || @lineno)
+  def cursor
+    Cursor.new @file, @dir, @path, @lineno
+  end
+
+  def cursor_at lineno
+    Cursor.new @file, @dir, @path, lineno
   end
 
   def prev_line_cursor
-    Cursor.new @file, @dir, @path, (@lineno - 1)
+    cursor_at @lineno - 1
   end
 
   # Public: Get information about the last line read, including file name and line number.

--- a/lib/asciidoctor/table.rb
+++ b/lib/asciidoctor/table.rb
@@ -365,7 +365,7 @@ class Table::ParserContext
           xsv = '!sv'
         end
       else
-        logger.error message_with_context %(illegal table format: #{xsv}), :source_location => reader.prev_line_cursor
+        logger.error message_with_context %(illegal table format: #{xsv}), :source_location => reader.cursor_at_prev_line
         @format, xsv = 'psv', (table.document.nested? ? '!sv' : 'psv')
       end
     else

--- a/lib/asciidoctor/table.rb
+++ b/lib/asciidoctor/table.rb
@@ -353,10 +353,8 @@ class Table::ParserContext
   attr_reader :delimiter_re
 
   def initialize reader, table, attributes = {}
-    @reader = reader
+    @start_cursor_data = (@reader = reader).mark
     @table = table
-    # IMPORTANT if reader.cursor becomes a reference, this assignment would require .dup
-    @last_cursor = reader.cursor
 
     if attributes.key? 'format'
       if FORMATS.include?(xsv = attributes['format'])
@@ -523,7 +521,7 @@ class Table::ParserContext
       if (cellspec = take_cellspec)
         repeat = cellspec.delete('repeatcol') || 1
       else
-        logger.error message_with_context 'table missing leading separator, recovering automatically', :source_location => @last_cursor
+        logger.error message_with_context 'table missing leading separator, recovering automatically', :source_location => Reader::Cursor.new(*@start_cursor_data)
         cellspec = {}
         repeat = 1
       end
@@ -560,13 +558,13 @@ class Table::ParserContext
       else
         # QUESTION is this right for cells that span columns?
         unless (column = @table.columns[@current_row.size])
-          logger.error message_with_context 'dropping cell because it exceeds specified number of columns', :source_location => @last_cursor
+          logger.error message_with_context 'dropping cell because it exceeds specified number of columns', :source_location => @reader.cursor_before_mark
           return
         end
       end
 
-      cell = Table::Cell.new(column, cell_text, cellspec, :cursor => @last_cursor, :strip_text => strip_text)
-      @last_cursor = @reader.cursor
+      cell = Table::Cell.new(column, cell_text, cellspec, :cursor => @reader.cursor_before_mark, :strip_text => strip_text)
+      @reader.mark
       unless !cell.rowspan || cell.rowspan == 1
         activate_rowspan(cell.rowspan, (cell.colspan || 1))
       end

--- a/test/api_test.rb
+++ b/test/api_test.rb
@@ -283,6 +283,19 @@ content
       assert_equal 'sample.asciidoc', last_block.file
       assert_equal 23, last_block.lineno
 
+      list_items = last_block.blocks
+      refute_nil list_items[0].source_location
+      assert_equal 'sample.asciidoc', list_items[0].file
+      assert_equal 23, list_items[0].lineno
+
+      refute_nil list_items[1].source_location
+      assert_equal 'sample.asciidoc', list_items[1].file
+      assert_equal 24, list_items[1].lineno
+
+      refute_nil list_items[2].source_location
+      assert_equal 'sample.asciidoc', list_items[2].file
+      assert_equal 25, list_items[2].lineno
+
       doc = Asciidoctor.load_file fixture_path('master.adoc'), :sourcemap => true, :safe => :safe
 
       section_1 = doc.sections[0]
@@ -290,6 +303,118 @@ content
       refute_nil section_1.source_location
       assert_equal fixture_path('chapter-a.adoc'), section_1.file
       assert_equal 1, section_1.lineno
+    end
+
+    test 'wip should track file and line information on list items if sourcemap option is set' do
+      doc = Asciidoctor.load_file fixture_path('lists.adoc'), :sourcemap => true
+
+      first_section = doc.blocks[1]
+
+      unordered_basic_list = first_section.blocks[0]
+      assert_equal 11, unordered_basic_list.lineno
+
+      unordered_basic_list_items = unordered_basic_list.find_by :context => :list_item
+      assert_equal 11, unordered_basic_list_items[0].lineno
+      assert_equal 12, unordered_basic_list_items[1].lineno
+      assert_equal 13, unordered_basic_list_items[2].lineno
+
+      unordered_max_nesting = first_section.blocks[1]
+      assert_equal 16, unordered_max_nesting.lineno
+      unordered_max_nesting_items = unordered_max_nesting.find_by :context => :list_item
+      assert_equal 16, unordered_max_nesting_items[0].lineno
+      assert_equal 17, unordered_max_nesting_items[1].lineno
+      assert_equal 18, unordered_max_nesting_items[2].lineno
+      assert_equal 19, unordered_max_nesting_items[3].lineno
+      assert_equal 20, unordered_max_nesting_items[4].lineno
+      assert_equal 21, unordered_max_nesting_items[5].lineno
+
+      checklist = first_section.blocks[2]
+      assert_equal 24, checklist.lineno
+      checklist_list_items = checklist.find_by :context => :list_item
+      assert_equal 24, checklist_list_items[0].lineno
+      assert_equal 25, checklist_list_items[1].lineno
+      assert_equal 26, checklist_list_items[2].lineno
+      assert_equal 27, checklist_list_items[3].lineno
+
+      ordered_basic = first_section.blocks[3]
+      assert_equal 30, ordered_basic.lineno
+      ordered_basic_list_items = ordered_basic.find_by :context => :list_item
+      assert_equal 30, ordered_basic_list_items[0].lineno
+      assert_equal 31, ordered_basic_list_items[1].lineno
+      assert_equal 32, ordered_basic_list_items[2].lineno
+
+      ordered_nested = first_section.blocks[4]
+      assert_equal 35, ordered_nested.lineno
+      ordered_nested_list_items = ordered_nested.find_by :context => :list_item
+      assert_equal 35, ordered_nested_list_items[0].lineno
+      assert_equal 36, ordered_nested_list_items[1].lineno
+      assert_equal 37, ordered_nested_list_items[2].lineno
+      assert_equal 38, ordered_nested_list_items[3].lineno
+      assert_equal 39, ordered_nested_list_items[4].lineno
+
+      ordered_max_nesting = first_section.blocks[5]
+      assert_equal 42, ordered_max_nesting.lineno
+      ordered_max_nesting_items = ordered_max_nesting.find_by :context => :list_item
+      assert_equal 42, ordered_max_nesting_items[0].lineno
+      assert_equal 43, ordered_max_nesting_items[1].lineno
+      assert_equal 44, ordered_max_nesting_items[2].lineno
+      assert_equal 45, ordered_max_nesting_items[3].lineno
+      assert_equal 46, ordered_max_nesting_items[4].lineno
+      assert_equal 47, ordered_max_nesting_items[5].lineno
+
+      labeled_singleline = first_section.blocks[6]
+      assert_equal 50, labeled_singleline.lineno
+      labeled_singleline_items = labeled_singleline.find_by :context => :list_item
+      assert_equal 50, labeled_singleline_items[0].lineno
+      assert_equal 50, labeled_singleline_items[1].lineno
+      assert_equal 51, labeled_singleline_items[2].lineno
+      assert_equal 51, labeled_singleline_items[3].lineno
+
+      labeled_multiline = first_section.blocks[7]
+      assert_equal 54, labeled_multiline.lineno
+      labeled_multiline_items = labeled_multiline.find_by :context => :list_item
+      assert_equal 54, labeled_multiline_items[0].lineno
+      assert_equal 55, labeled_multiline_items[1].lineno
+      assert_equal 56, labeled_multiline_items[2].lineno
+      assert_equal 57, labeled_multiline_items[3].lineno
+
+      qanda = first_section.blocks[8]
+      assert_equal 61, qanda.lineno
+      qanda_items = qanda.find_by :context => :list_item
+      assert_equal 61, qanda_items[0].lineno
+      assert_equal 62, qanda_items[1].lineno
+      assert_equal 63, qanda_items[2].lineno
+      assert_equal 63, qanda_items[3].lineno
+
+      mixed = first_section.blocks[9]
+      assert_equal 66, mixed.lineno
+      mixed_items = mixed.find_by(:context => :list_item) {|block| block.text? }
+      assert_equal 66, mixed_items[0].lineno
+      assert_equal 67, mixed_items[1].lineno
+      assert_equal 68, mixed_items[2].lineno
+      assert_equal 69, mixed_items[3].lineno
+      assert_equal 70, mixed_items[4].lineno
+      assert_equal 71, mixed_items[5].lineno
+      assert_equal 72, mixed_items[6].lineno
+      assert_equal 73, mixed_items[7].lineno
+      assert_equal 74, mixed_items[8].lineno
+      assert_equal 75, mixed_items[9].lineno
+      assert_equal 77, mixed_items[10].lineno
+      assert_equal 78, mixed_items[11].lineno
+      assert_equal 79, mixed_items[12].lineno
+      assert_equal 80, mixed_items[13].lineno
+      assert_equal 81, mixed_items[14].lineno
+      assert_equal 82, mixed_items[15].lineno
+      assert_equal 83, mixed_items[16].lineno
+
+      unordered_complex_list = first_section.blocks[10]
+      assert_equal 86, unordered_complex_list.lineno
+      unordered_complex_items = unordered_complex_list.find_by :context => :list_item
+      assert_equal 86, unordered_complex_items[0].lineno
+      assert_equal 87, unordered_complex_items[1].lineno
+      assert_equal 88, unordered_complex_items[2].lineno
+      assert_equal 92, unordered_complex_items[3].lineno
+      assert_equal 96, unordered_complex_items[4].lineno
     end
 
     test 'should assign correct source location if section occurs on last line of input' do

--- a/test/attributes_test.rb
+++ b/test/attributes_test.rb
@@ -762,7 +762,7 @@ content
       EOS
       doc = document_from_string input
       assert_nil doc.attr('hey')
-      assert_message @logger, :WARN, '<stdin>: line 6: unterminated comment block', Hash
+      assert_message @logger, :WARN, '<stdin>: line 3: unterminated comment block', Hash
     end
 
     test 'substitutes inside block title' do

--- a/test/blocks_test.rb
+++ b/test/blocks_test.rb
@@ -218,7 +218,7 @@ supposed to be after sidebar block, except it got swallowed by block comment
       EOS
 
       render_embedded_string input
-      assert_message @logger, :WARN, '<stdin>: line 8: unterminated comment block', Hash
+      assert_message @logger, :WARN, '<stdin>: line 5: unterminated comment block', Hash
     end
 
     # WARNING if first line of content is a directive, it will get interpretted before we know it's a comment block

--- a/test/blocks_test.rb
+++ b/test/blocks_test.rb
@@ -202,7 +202,7 @@ supposed to be after comment block, except it got swallowed by block comment
       EOS
 
       render_embedded_string input
-      assert_message @logger, :WARN, '<stdin>: line 6: unterminated comment block', Hash
+      assert_message @logger, :WARN, '<stdin>: line 3: unterminated comment block', Hash
     end
 
     test 'should warn if unterminated comment block is detected inside another block' do
@@ -218,7 +218,7 @@ supposed to be after sidebar block, except it got swallowed by block comment
       EOS
 
       render_embedded_string input
-      assert_message @logger, :WARN, '<stdin>: line 5: unterminated comment block', Hash
+      assert_message @logger, :WARN, '<stdin>: line 4: unterminated comment block', Hash
     end
 
     # WARNING if first line of content is a directive, it will get interpretted before we know it's a comment block
@@ -840,7 +840,7 @@ eof
 
       output = render_embedded_string input
       assert_xpath '/*[@class="exampleblock"]', output, 1
-      assert_message @logger, :WARN, '<stdin>: line 8: unterminated example block', Hash
+      assert_message @logger, :WARN, '<stdin>: line 3: unterminated example block', Hash
     end
   end
 
@@ -3083,7 +3083,7 @@ eof
 
       output = render_embedded_string input
       assert_xpath '/*[@class="listingblock"]', output, 1
-      assert_message @logger, :WARN, '<stdin>: line 8: unterminated listing block', Hash
+      assert_message @logger, :WARN, '<stdin>: line 3: unterminated listing block', Hash
     end
   end
 

--- a/test/fixtures/lists.adoc
+++ b/test/fixtures/lists.adoc
@@ -1,0 +1,96 @@
+= Document Title
+Doc Writer <thedoc@asciidoctor.org>
+
+Preamble paragraph.
+
+NOTE: This is test, only a test.
+
+== Lists
+
+.Unordered, basic
+* Edgar Allen Poe
+* Sheri S. Tepper
+* Bill Bryson
+
+.Unordered, max nesting
+* level 1
+** level 2
+*** level 3
+**** level 4
+***** level 5
+* level 1
+
+.Checklist
+- [*] checked
+- [x] also checked
+- [ ] not checked
+-     normal list item
+
+.Ordered, basic
+. Step 1
+. Step 2
+. Step 3
+
+.Ordered, nested
+. Step 1
+. Step 2
+.. Step 2a
+.. Step 2b
+. Step 3
+
+.Ordered, max nesting
+. level 1
+.. level 2
+... level 3
+.... level 4
+..... level 5
+. level 1
+
+.Labeled, single-line
+first term:: definition of first term
+section term:: definition of second term
+
+.Labeled, multi-line
+first term::
+definition of first term
+second term::
+definition of second term
+
+.Q&A
+[qanda]
+What is Asciidoctor?::
+  An implementation of the AsciiDoc processor in Ruby.
+What is the answer to the Ultimate Question?:: 42
+
+.Mixed
+Operating Systems::
+  Linux:::
+    . Fedora
+      * Desktop
+    . Ubuntu
+      * Desktop
+      * Server
+  BSD:::
+    . FreeBSD
+    . NetBSD
+
+Cloud Providers::
+  PaaS:::
+    . OpenShift
+    . CloudBees
+  IaaS:::
+    . Amazon EC2
+    . Rackspace
+
+.Unordered, complex
+* level 1
+** level 2
+*** level 3
+This is a new line inside an unordered list using {plus} symbol.
+We can even force content to start on a separate line... +
+Amazing, isn't it?
+**** level 4
++
+The {plus} symbol is on a new line.
+
+***** level 5

--- a/test/lists_test.rb
+++ b/test/lists_test.rb
@@ -1540,6 +1540,23 @@ Item one, paragraph two
     end
 =end
 
+    test 'should warn if unterminated block is detected in list item' do
+      input = <<-EOS
+* item
++
+====
+example
+* swallowed item
+      EOS
+
+      using_memory_logger do |logger|
+        output = render_embedded_string input
+        assert_xpath '//ul/li', output, 1
+        assert_xpath '//ul/li/*[@class="exampleblock"]', output, 1
+        assert_xpath %(//p[text()="example\n* swallowed item"]), output, 1
+        assert_message logger, :WARN, '<stdin>: line 3: unterminated example block', Hash
+      end
+    end
   end
 end
 

--- a/test/lists_test.rb
+++ b/test/lists_test.rb
@@ -4628,5 +4628,11 @@ listing block in list item 1
     assert_equal 1, lists[0].lineno
     assert_equal 2, lists[1].lineno
     assert_equal 3, lists[2].lineno
+
+    list_items = doc.find_by :context => :list_item
+    assert_equal 1, list_items[0].lineno
+    assert_equal 2, list_items[1].lineno
+    assert_equal 3, list_items[2].lineno
+    assert_equal 4, list_items[3].lineno
   end
 end

--- a/test/lists_test.rb
+++ b/test/lists_test.rb
@@ -4615,4 +4615,18 @@ listing block in list item 1
     assert_equal '`three`', list.items[2].text
     assert_equal '<mark>four</mark>', list.items[3].text
   end
+
+  test 'should set lineno to line number in source where list starts' do
+    input = <<-EOS
+* bullet 1
+** bullet 1.1
+*** bullet 1.1.1
+* bullet 2
+    EOS
+    doc = document_from_string input, :sourcemap => true
+    lists = doc.find_by :context => :ulist
+    assert_equal 1, lists[0].lineno
+    assert_equal 2, lists[1].lineno
+    assert_equal 3, lists[2].lineno
+  end
 end

--- a/test/reader_test.rb
+++ b/test/reader_test.rb
@@ -389,7 +389,7 @@ not captured
         refute reader.unterminated
       end
 
-      test 'should mark reader as unterminated if reader reaches end of source without finding terminator' do
+      test 'should flag reader as unterminated if reader reaches end of source without finding terminator' do
         lines = <<-EOS.each_line.to_a
 ****
 captured
@@ -404,11 +404,11 @@ captured yet again
         using_memory_logger do |logger|
           doc = empty_safe_document :base_dir => DIRNAME
           reader = Asciidoctor::PreprocessorReader.new doc, lines, nil, :normalize => true
-          terminator = reader.read_line
-          result = reader.read_lines_until :terminator => terminator, :skip_processing => true
+          terminator = reader.peek_line
+          result = reader.read_lines_until :terminator => terminator, :skip_first_line => true, :skip_processing => true
           assert_equal expected, result
           assert reader.unterminated
-          assert_message logger, :WARN, '<stdin>: line 6: unterminated **** block', Hash
+          assert_message logger, :WARN, '<stdin>: line 1: unterminated **** block', Hash
         end
       end
     end

--- a/test/reader_test.rb
+++ b/test/reader_test.rb
@@ -260,10 +260,10 @@ third line
         assert_equal 'sample.adoc: line 2', reader.cursor.to_s
       end
 
-      test 'prev_line_cursor should return file name and line number of previous line read' do
+      test 'cursor_at_prev_line should return file name and line number of previous line read' do
         reader = Asciidoctor::Reader.new SAMPLE_DATA, 'sample.adoc'
         reader.read_line
-        assert_equal 'sample.adoc: line 1', reader.prev_line_cursor.to_s
+        assert_equal 'sample.adoc: line 1', reader.cursor_at_prev_line.to_s
       end
     end
 
@@ -657,7 +657,7 @@ include::fixtures/parent-include.adoc[]
 
         assert_equal 'first line of parent', reader.read_line
 
-        assert_equal 'fixtures/parent-include.adoc: line 1', reader.prev_line_cursor.to_s
+        assert_equal 'fixtures/parent-include.adoc: line 1', reader.cursor_at_prev_line.to_s
         assert_equal parent_include_docfile, reader.file
         assert_equal fixtures_dir, reader.dir
         assert_equal 'fixtures/parent-include.adoc', reader.path
@@ -666,7 +666,7 @@ include::fixtures/parent-include.adoc[]
 
         assert_equal 'first line of child', reader.read_line
 
-        assert_equal 'fixtures/child-include.adoc: line 1', reader.prev_line_cursor.to_s
+        assert_equal 'fixtures/child-include.adoc: line 1', reader.cursor_at_prev_line.to_s
         assert_equal child_include_docfile, reader.file
         assert_equal fixtures_dir, reader.dir
         assert_equal 'fixtures/child-include.adoc', reader.path
@@ -675,7 +675,7 @@ include::fixtures/parent-include.adoc[]
 
         assert_equal 'first line of grandchild', reader.read_line
 
-        assert_equal 'fixtures/grandchild-include.adoc: line 1', reader.prev_line_cursor.to_s
+        assert_equal 'fixtures/grandchild-include.adoc: line 1', reader.cursor_at_prev_line.to_s
         assert_equal grandchild_include_docfile, reader.file
         assert_equal fixtures_dir, reader.dir
         assert_equal 'fixtures/grandchild-include.adoc', reader.path
@@ -692,7 +692,7 @@ include::fixtures/parent-include.adoc[]
 
         assert_equal 'last line of parent', reader.read_line
 
-        assert_equal 'fixtures/parent-include.adoc: line 5', reader.prev_line_cursor.to_s
+        assert_equal 'fixtures/parent-include.adoc: line 5', reader.cursor_at_prev_line.to_s
         assert_equal parent_include_docfile, reader.file
         assert_equal fixtures_dir, reader.dir
         assert_equal 'fixtures/parent-include.adoc', reader.path

--- a/test/tables_test.rb
+++ b/test/tables_test.rb
@@ -1072,7 +1072,7 @@ DocBook outputs. If the input file is the standard input then the
 output file name is used.
 |===
       EOS
-      doc = document_from_string input
+      doc = document_from_string input, :sourcemap => true
       table = doc.blocks.first
       refute_nil table
       tbody = table.rows.body
@@ -1082,6 +1082,7 @@ output file name is used.
       assert body_cell_1_3.inner_document.nested?
       assert_equal doc, body_cell_1_3.inner_document.parent_document
       assert_equal doc.converter, body_cell_1_3.inner_document.converter
+      assert_equal 6, body_cell_1_3.inner_document.lineno
       output = doc.convert
 
       assert_css 'table > tbody > tr', output, 2

--- a/test/tables_test.rb
+++ b/test/tables_test.rb
@@ -150,20 +150,22 @@ context 'Tables' do
       input = <<-EOS
 |===
 A | here| a | there
+| x
+| y
+| z
+| end
 |===
       EOS
       using_memory_logger do |logger|
         output = render_embedded_string input
         assert_css 'table', output, 1
-        assert_css 'table > colgroup > col', output, 4
-        assert_css 'table > tbody > tr', output, 1
-        assert_css 'table > tbody > tr > td', output, 4
-        assert_xpath '/table/tbody/tr/td[1]/p[text()="A"]', output, 1
-        assert_xpath '/table/tbody/tr/td[2]/p[text()="here"]', output, 1
-        assert_xpath '/table/tbody/tr/td[3]/p[text()="a"]', output, 1
-        assert_xpath '/table/tbody/tr/td[4]/p[text()="there"]', output, 1
-        # FIXME line number is wrong
-        assert_message logger, :ERROR, '~table missing leading separator', Hash
+        assert_css 'table > tbody > tr', output, 2
+        assert_css 'table > tbody > tr > td', output, 8
+        assert_xpath '/table/tbody/tr[1]/td[1]/p[text()="A"]', output, 1
+        assert_xpath '/table/tbody/tr[1]/td[2]/p[text()="here"]', output, 1
+        assert_xpath '/table/tbody/tr[1]/td[3]/p[text()="a"]', output, 1
+        assert_xpath '/table/tbody/tr[1]/td[4]/p[text()="there"]', output, 1
+        assert_message logger, :ERROR, '<stdin>: line 2: table missing leading separator, recovering automatically', Hash
       end
     end
 
@@ -866,7 +868,7 @@ d|9 2+>|10
 
     test 'ignores cell with colspan that exceeds colspec' do
       input = <<-EOS
-[cols="1,1"]
+[cols=2*]
 |===
 3+|A
 |B
@@ -879,8 +881,7 @@ more C
         output = render_embedded_string input
         assert_css 'table', output, 1
         assert_css 'table *', output, 0
-        # FIXME line number is wrong
-        assert_message logger, :ERROR, '~exceeds specified number of columns', Hash
+        assert_message logger, :ERROR, '<stdin>: line 5: dropping cell because it exceeds specified number of columns', Hash
       end
     end
 
@@ -1055,9 +1056,11 @@ doctype={doctype}
 |badges |xhtml11, html5 |
 Link badges ('XHTML 1.1' and 'CSS') in document footers.
 
-NOTE: The path names of images, icons and scripts are relative path
+[NOTE]
+====
+The path names of images, icons and scripts are relative path
 names to the output document not the source document.
-
+====
 |[[X97]] docinfo, docinfo1, docinfo2 |All backends |
 These three attributes control which document information
 files will be included in the the header of the output file:
@@ -1082,7 +1085,10 @@ output file name is used.
       assert body_cell_1_3.inner_document.nested?
       assert_equal doc, body_cell_1_3.inner_document.parent_document
       assert_equal doc.converter, body_cell_1_3.inner_document.converter
-      assert_equal 6, body_cell_1_3.inner_document.lineno
+      assert_equal 5, body_cell_1_3.inner_document.lineno
+      note = (body_cell_1_3.inner_document.find_by :context => :admonition)[0]
+      # NOTE lineno is off by one due to leading blank line being stripped
+      assert_equal 8, note.lineno
       output = doc.convert
 
       assert_css 'table > tbody > tr', output, 2
@@ -1400,6 +1406,30 @@ eof
         output = render_embedded_string input
         assert_xpath '/table', output, 1
         assert_message logger, :WARN, '<stdin>: line 3: unterminated table block', Hash
+      end
+    end
+
+    test 'should show correct line number in warning about unterminated block inside AsciiDoc table cell' do
+      input = <<-EOS
+outside
+
+* list item
++
+|===
+|cell
+a|inside
+
+====
+unterminated example block
+|===
+
+eof
+      EOS
+
+      using_memory_logger do |logger|
+        output = render_embedded_string input
+        assert_xpath '//ul//table', output, 1
+        assert_message logger, :WARN, '<stdin>: line 9: unterminated example block', Hash
       end
     end
   end

--- a/test/tables_test.rb
+++ b/test/tables_test.rb
@@ -1399,7 +1399,7 @@ eof
       using_memory_logger do |logger|
         output = render_embedded_string input
         assert_xpath '/table', output, 1
-        assert_message logger, :WARN, '<stdin>: line 9: unterminated table block', Hash
+        assert_message logger, :WARN, '<stdin>: line 3: unterminated table block', Hash
       end
     end
   end


### PR DESCRIPTION
- fix incorrect line number on lists and tables (@seikichi)
- populate source_location on list items if sourcemap is enabled (@Mogztter)
- consolidate cursor data in Parser.next_block into an array
- consolidate definition of Cursor class
- split Reader#cursor and Reader#cursor_at methods
- introduce a mark system for tracking line numbers more accurately
- add Reader#mark method to mark position of cursor (store internally)
- add Reader#cursor_at_mark method to build Cursor from previously saved mark
- mark position of cursor after reading block attribute lines in Parser.next_block
- use Reader#cursor_at_mark to retrieve/record source location in Parser.next_block
- add cursor option to Reader#read_lines_until so unterminated block warning reports start location of block
- allow value of cursor option passed to Reader#read_lines_until to be :at_mark to read cursor from mark
- mark and save cursor data when creating parsing context for table
- use cursor at mark when creating cells
- rename cursor_at to cursor_at_line
- rename prev_line_cursor to cursor_at_prev_line

This PR supersedes #2547 and #2069. The changes from those PRs have been incorporated into this one. 