### PR TITLE
resolves #2381 allow xrefstyle to be overridden per xref using the xrefstyle attribute

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -18,13 +18,14 @@ For a detailed view of what has changed, refer to the {uri-repo}/commits/master[
 Enhancements::
 
   * BREAKING: drop XML tags, character refs, and non-word characters (except hyphen and space) when generating ID for section (#794)
-  * parse text of xref macro as attributes if attribute signature found (equal sign) (#2381)
   * route messages through a logger instead of using Kernel#warn (#44, PR #2660)
   * add MemoryLogger for capturing messages sent to logger into memory (#44, PR #2660)
   * add NullLogger to prevent messages from being logged (#44, PR #2660)
   * log message containing source location / cursor as an object; provides more context (#44, PR #2660)
   * add :logger option to API to set logger instance (#44, PR #2660)
   * add --failure-level=LEVEL option to CLI to force non-zero exit code if specified logging level is reached (#2003, PR #2674)
+  * parse text of xref macro as attributes if attribute signature found (equal sign) (#2381)
+  * allow xrefstyle to be specified per xref by assigning the xrefstyle attribute on the xref macro (#2365)
   * resolve nested includes in remote documents relative to URI (#2506, PR #2511)
   * support name!@, !name@, name!=@, and !name=@ syntax to soft unset attribute from API or CLI (#642, PR #2649)
   * allow modifier to be placed at end of name to soft set an attribute (e.g., icons@=font) (#642, PR #2649)

--- a/features/xref.feature
+++ b/features/xref.feature
@@ -375,7 +375,7 @@ Feature: Cross References
     """
 
   @wip
-  Scenario: Create a cross reference to a part using a custom chapter reference signifier
+  Scenario: Create a cross reference to a part using a custom part reference signifier
   Given the AsciiDoc source
     """
     :doctype: book
@@ -971,4 +971,69 @@ Feature: Cross References
         .sectionbody: .paragraph: p
           |refer to
           a< href='#_section_one' class='spotlight' "The Premier Section"
+      """
+
+    Scenario: Override xrefstyle for a given part of the document
+    Given the AsciiDoc source
+      """
+      :xrefstyle: full
+      :doctype: book
+      :sectnums:
+
+      == Foo
+
+      refer to <<#_bar>>
+
+      == Bar
+      :xrefstyle: short
+
+      refer to xref:#_foo[xrefstyle=short]
+      """
+    When it is converted to html
+    Then the result should match the HTML structure
+      """
+      .sect1
+        h2#_foo 1. Foo
+        .sectionbody: .paragraph: p
+          |refer to
+          a< href='#_bar' Chapter 2, <em>Bar</em>
+      .sect1
+        h2#_bar 2. Bar
+        .sectionbody: .paragraph: p
+          |refer to
+          a< href='#_foo' Chapter 1
+      """
+
+    Scenario: Override xrefstyle for a specific reference by assigning the xrefstyle attribute on the xref macro
+    Given the AsciiDoc source
+      """
+      :xrefstyle: full
+      :doctype: book
+      :sectnums:
+
+      == Foo
+
+      content
+
+      == Bar
+
+      refer to <<#_foo>>
+
+      refer to xref:#_foo[xrefstyle=short]
+      """
+    When it is converted to html
+    Then the result should match the HTML structure
+      """
+      .sect1
+        h2#_foo 1. Foo
+        .sectionbody: .paragraph: p content
+      .sect1
+        h2#_bar 2. Bar
+        .sectionbody
+          .paragraph: p
+            |refer to
+            a< href='#_foo' Chapter 1, <em>Foo</em>
+          .paragraph: p
+            |refer to
+            a< href='#_foo' Chapter 1
       """

--- a/lib/asciidoctor/converter/html5.rb
+++ b/lib/asciidoctor/converter/html5.rb
@@ -1044,8 +1044,9 @@ Your browser does not support the video tag.
         else
           attrs = node.role ? %( class="#{node.role}") : ''
           unless (text = node.text)
-            if AbstractNode === (ref = node.document.catalog[:refs][refid = node.attributes['refid']])
-              text = ref.xreftext((@xrefstyle ||= node.document.attributes['xrefstyle'])) || %([#{refid}])
+            refid = node.attributes['refid']
+            if AbstractNode === (ref = (@refs ||= node.document.catalog[:refs])[refid])
+              text = (ref.xreftext node.attr('xrefstyle')) || %([#{refid}])
             else
               text = %([#{refid}])
             end


### PR DESCRIPTION
- allow xrefstyle to be overridden per xref by assigning xrefstyle attribute on xref macro
- allow xrefstyle to be overridden in different parts of the document