### PR TITLE
resolves #2059 enable linkattrs behavior implicitly (except in compat mode)

### DIFF
--- a/test/substitutions_test.rb
+++ b/test/substitutions_test.rb
@@ -608,12 +608,12 @@ context 'Substitutions' do
     end
 
     test 'a mailto macro with text and subject should be interpreted as a mailto link' do
-      para = block_from_string('mailto:doc.writer@asciidoc.org[Doc Writer, Pull request]', :attributes => {'linkattrs' => ''})
+      para = block_from_string('mailto:doc.writer@asciidoc.org[Doc Writer, Pull request]')
       assert_equal %q{<a href="mailto:doc.writer@asciidoc.org?subject=Pull%20request">Doc Writer</a>}, para.sub_macros(para.source)
     end
 
     test 'a mailto macro with text, subject and body should be interpreted as a mailto link' do
-      para = block_from_string('mailto:doc.writer@asciidoc.org[Doc Writer, Pull request, Please accept my pull request]', :attributes => {'linkattrs' => ''})
+      para = block_from_string('mailto:doc.writer@asciidoc.org[Doc Writer, Pull request, Please accept my pull request]')
       assert_equal %q{<a href="mailto:doc.writer@asciidoc.org?subject=Pull%20request&amp;body=Please%20accept%20my%20pull%20request">Doc Writer</a>}, para.sub_macros(para.source)
     end
 


### PR DESCRIPTION
- parse text of link macro as attributes if text contains an equal sign
- parse text of mailto macro if text contains a comma
- remove use of linkattrs attributes from test suite