### PR TITLE
resolves #2705 populate source_location property on cell when sourcemap option enabled

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -40,7 +40,9 @@ Enhancements::
   * add positioning option to sectanchors attribute (before or after) (#2485, PR #2486)
   * allow table stripes to be configured using stripe attribute or stripe roles on table; valid values are even, odd, all, and none (#1365, PR #2588)
   * allow nofollow rel property to be added to links and linked images by setting the nofollow option (#2605, PR #2692)
-  * assign Document#source_location when sourcemap option is enabled (#2478, PR #2488)
+  * populate Document#source_location when sourcemap option is enabled (#2478, PR #2488)
+  * populate source_location property on list items when sourcemap option is set on document (PR #2069) (@mogztter)
+  * populate Table::Cell#source_location when sourcemap option is enabled (#2705)
   * allow local include to be flagged as optional by setting optional option (#2389, PR #2413)
   * allow attribute name to contain word characters as defined by Unicode (#2376, PR #2393)
   * allow block title to begin with a period (#2358, PR #2359)
@@ -98,7 +100,6 @@ Bug fixes::
 Improvements / Refactoring::
 
   * use cursor marks to track lines more accurately; record cursor at the start of each block, list item, or table cell (PR #2701, PR #2547) (@seikichi)
-  * populate source_location property on list items when sourcemap option is set on document (PR #2069) (@mogztter)
   * log a warning message if an unterminated delimited block is detected (#1133, PR #2612)
   * log a warning when nested section is found inside special section that doesn't support nested sections (#2433, PR #2672)
   * read files in binary mode to disable automatic endline coercion (then explicitly coerce to UTF-8) (PR #2583, PR #2694)

--- a/lib/asciidoctor/abstract_block.rb
+++ b/lib/asciidoctor/abstract_block.rb
@@ -54,12 +54,12 @@ class AbstractBlock < AbstractNode
 
   # Public: Get the source file where this block started
   def file
-    @source_location ? @source_location.file : nil
+    @source_location && @source_location.file
   end
 
   # Public: Get the source line number where this block started
   def lineno
-    @source_location ? @source_location.lineno : nil
+    @source_location && @source_location.lineno
   end
 
   # Public: Get the converted String content for this Block.  If the block

--- a/lib/asciidoctor/parser.rb
+++ b/lib/asciidoctor/parser.rb
@@ -2272,7 +2272,7 @@ class Parser
     implicit_header = true unless skipped > 0 || (attributes.key? 'header-option') || (attributes.key? 'noheader-option')
 
     while (line = table_reader.read_line)
-      if (loop_idx += 1) > 0 && line.empty?
+      if (beyond_first = (loop_idx += 1) > 0) && line.empty?
         line = nil
         implicit_header_boundary += 1 if implicit_header_boundary
       elsif format == 'psv'
@@ -2294,12 +2294,15 @@ class Parser
         end
       end
 
-      # NOTE implicit header is offset by at least one blank line; implicit_header_boundary tracks size of gap
-      if loop_idx == 0 && implicit_header
-        if table_reader.has_more_lines? && table_reader.peek_line.empty?
-          implicit_header_boundary = 1
-        else
-          implicit_header = false
+      unless beyond_first
+        table_reader.mark
+        # NOTE implicit header is offset by at least one blank line; implicit_header_boundary tracks size of gap
+        if implicit_header
+          if table_reader.has_more_lines? && table_reader.peek_line.empty?
+            implicit_header_boundary = 1
+          else
+            implicit_header = false
+          end
         end
       end
 

--- a/lib/asciidoctor/table.rb
+++ b/lib/asciidoctor/table.rb
@@ -198,6 +198,9 @@ end
 
 # Public: Methods for managing the a cell in an AsciiDoc table.
 class Table::Cell < AbstractNode
+  # Public: Gets/Sets the location in the AsciiDoc source where this cell begins
+  attr_reader :source_location
+
   # Public: Get/Set the Symbol style for this cell (default: nil)
   attr_accessor :style
 
@@ -218,6 +221,7 @@ class Table::Cell < AbstractNode
 
   def initialize column, cell_text, attributes = {}, opts = {}
     super column, :cell
+    @source_location = opts[:cursor].dup if @document.sourcemap
     if column
       cell_style = column.attributes['style'] unless (in_header_row = column.table.header_row?)
       # REVIEW feels hacky to inherit all attributes from column
@@ -317,6 +321,16 @@ class Table::Cell < AbstractNode
         !@style || @style == :header ? p : Inline.new(parent, :quoted, p, :type => @style).convert
       end
     end
+  end
+
+  # Public: Get the source file where this block started
+  def file
+    @source_location && @source_location.file
+  end
+
+  # Public: Get the source line number where this block started
+  def lineno
+    @source_location && @source_location.lineno
   end
 
   def to_s

--- a/test/api_test.rb
+++ b/test/api_test.rb
@@ -277,24 +277,42 @@ content
       assert_equal 'sample.asciidoc', section_2.file
       assert_equal 18, section_2.lineno
 
+      table_block = section_2.blocks[1]
+      assert_equal :table, table_block.context
+      refute_nil table_block.source_location
+      assert_equal 'sample.asciidoc', table_block.file
+      assert_equal 22, table_block.lineno
+      first_cell = table_block.rows.body[0][0]
+      refute_nil first_cell.source_location
+      assert_equal 'sample.asciidoc', first_cell.file
+      assert_equal 23, first_cell.lineno
+      second_cell = table_block.rows.body[0][1]
+      refute_nil second_cell.source_location
+      assert_equal 'sample.asciidoc', second_cell.file
+      assert_equal 23, second_cell.lineno
+      last_cell = table_block.rows.body[-1][-1]
+      refute_nil last_cell.source_location
+      assert_equal 'sample.asciidoc', last_cell.file
+      assert_equal 24, last_cell.lineno
+
       last_block = section_2.blocks[-1]
       assert_equal :ulist, last_block.context
       refute_nil last_block.source_location
       assert_equal 'sample.asciidoc', last_block.file
-      assert_equal 23, last_block.lineno
+      assert_equal 28, last_block.lineno
 
       list_items = last_block.blocks
       refute_nil list_items[0].source_location
       assert_equal 'sample.asciidoc', list_items[0].file
-      assert_equal 23, list_items[0].lineno
+      assert_equal 28, list_items[0].lineno
 
       refute_nil list_items[1].source_location
       assert_equal 'sample.asciidoc', list_items[1].file
-      assert_equal 24, list_items[1].lineno
+      assert_equal 29, list_items[1].lineno
 
       refute_nil list_items[2].source_location
       assert_equal 'sample.asciidoc', list_items[2].file
-      assert_equal 25, list_items[2].lineno
+      assert_equal 30, list_items[2].lineno
 
       doc = Asciidoctor.load_file fixture_path('master.adoc'), :sourcemap => true, :safe => :safe
 
@@ -305,7 +323,7 @@ content
       assert_equal 1, section_1.lineno
     end
 
-    test 'wip should track file and line information on list items if sourcemap option is set' do
+    test 'should track file and line information on list items if sourcemap option is set' do
       doc = Asciidoctor.load_file fixture_path('lists.adoc'), :sourcemap => true
 
       first_section = doc.blocks[1]

--- a/test/fixtures/sample.asciidoc
+++ b/test/fixtures/sample.asciidoc
@@ -19,8 +19,12 @@ NOTE: This is test, only a test.
 
 *Section B* paragraph.
 
+|===
+|a |b |c
+|1 |2 |3
+|===
+
 .Section B list
 * Item 1
 * Item 2
 * Item 3
-

--- a/test/tables_test.rb
+++ b/test/tables_test.rb
@@ -1080,16 +1080,18 @@ output file name is used.
       refute_nil table
       tbody = table.rows.body
       assert_equal 2, tbody.size
+      body_cell_1_2 = tbody[0][1]
+      assert_equal 5, body_cell_1_2.lineno
       body_cell_1_3 = tbody[0][2]
       refute_nil body_cell_1_3.inner_document
       assert body_cell_1_3.inner_document.nested?
       assert_equal doc, body_cell_1_3.inner_document.parent_document
       assert_equal doc.converter, body_cell_1_3.inner_document.converter
-      # TODO assert that body_cell_1_3.lineno is 5 once source_location is available on cell
+      assert_equal 5, body_cell_1_3.lineno
       assert_equal 6, body_cell_1_3.inner_document.lineno
       note = (body_cell_1_3.inner_document.find_by :context => :admonition)[0]
       assert_equal 9, note.lineno
-      output = doc.convert
+      output = doc.convert :header_footer => false
 
       assert_css 'table > tbody > tr', output, 2
       assert_css 'table > tbody > tr:nth-child(1) > td:nth-child(3) div.admonitionblock', output, 1
@@ -1104,7 +1106,14 @@ a|
 a| paragraph
 |===
       EOS
-      output = render_embedded_string input
+      doc = document_from_string input, :sourcemap => true
+      table = doc.blocks[0]
+      tbody = table.rows.body
+      assert_equal 1, table.lineno
+      assert_equal 2, tbody[0][0].lineno
+      assert_equal 3, tbody[0][0].inner_document.lineno
+      assert_equal 4, tbody[1][0].lineno
+      output = doc.convert :header_footer => false
       assert_css 'td', output, 2
       assert_xpath '(//td)[1]//*[@class="literalblock"]', output, 1
       assert_xpath '(//td)[2]//*[@class="paragraph"]', output, 1


### PR DESCRIPTION

- add source_location property to Table::Cell
- add file and lineno methods to Table::Cell
- when sourcemap option is enabled, set source_location property on cell
- mark first line of table so line number for first cell is correct
- add test to verify source_location information on table cell is correct