### PR TITLE
resolves #2712 preserve leading indentation in AsciiDoc table cell if starts w/ newline

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -55,6 +55,7 @@ Enhancements::
 Bug fixes::
 
   * set :to_dir option correctly when output file is specified (#2382)
+  * preserve leading indentation in contents of AsciiDoc table cell if contents starts with a newline (#2712)
   * using the shorthand syntax on the style to set block attributes (id, roles, options) no longer resets block style (#2174)
   * match include tags anywhere on line as long as offset by word boundary on left and space or newline on right (#2369, PR #2683)
   * warn if an include tag specified in the include directive is unclosed in the included file (#2361, PR #2696)

--- a/lib/asciidoctor/document.rb
+++ b/lib/asciidoctor/document.rb
@@ -283,7 +283,7 @@ class Document < AbstractBlock
       (options[:attributes] || {}).each do |key, val|
         if key.end_with? '@'
           if key.start_with? '!'
-            key, val = (key.slice 1, key.length - 1), false
+            key, val = (key.slice 1, key.length), false
           elsif key.end_with? '!@'
             key, val = (key.slice 0, key.length - 2), false
           else

--- a/lib/asciidoctor/reader.rb
+++ b/lib/asciidoctor/reader.rb
@@ -529,12 +529,12 @@ class Reader
       m_file, m_dir, m_path, m_lineno = @mark
       Cursor.new m_file, m_dir, m_path, m_lineno - 1
     else
-      cursor_at_prev_line
+      Cursor.new @file, @dir, @path, @lineno - 1
     end
   end
 
   def cursor_at_prev_line
-    cursor_at_line @lineno - 1
+    Cursor.new @file, @dir, @path, @lineno - 1
   end
 
   def cursor_data

--- a/lib/asciidoctor/reader.rb
+++ b/lib/asciidoctor/reader.rb
@@ -11,6 +11,10 @@ class Reader
       @file, @dir, @path, @lineno = file, dir, path, lineno
     end
 
+    def advance num
+      @lineno += num
+    end
+
     def line_info
       %(#{@path}: line #{@lineno})
     end

--- a/lib/asciidoctor/substitutors.rb
+++ b/lib/asciidoctor/substitutors.rb
@@ -726,7 +726,7 @@ module Substitutors
               if text.end_with? ')'
                 text, visible = (text.slice 1, text.length - 2), false
               else
-                text, before, after = (text.slice 1, text.length - 1), '(', ''
+                text, before, after = (text.slice 1, text.length), '(', ''
               end
             elsif text.end_with? ')'
               text, before, after = (text.slice 0, text.length - 1), '', ')'

--- a/lib/asciidoctor/table.rb
+++ b/lib/asciidoctor/table.rb
@@ -231,7 +231,7 @@ class Table::Cell < AbstractNode
       if opts[:strip_text]
         if cell_style == :literal || cell_style == :verse
           cell_text = cell_text.rstrip
-          cell_text = cell_text.slice 1, cell_text.length - 1 while cell_text.start_with? LF
+          cell_text = cell_text.slice 1, cell_text.length while cell_text.start_with? LF
         else
           cell_text = cell_text.strip
         end

--- a/lib/asciidoctor/table.rb
+++ b/lib/asciidoctor/table.rb
@@ -201,6 +201,9 @@ class Table::Cell < AbstractNode
   # Public: Get/Set the Symbol style for this cell (default: nil)
   attr_accessor :style
 
+  # Public: Substitutions to be applied to content in this cell
+  attr_accessor :subs
+
   # Public: An Integer of the number of columns this cell will span (default: nil)
   attr_accessor :colspan
 
@@ -240,7 +243,7 @@ class Table::Cell < AbstractNode
         else
           cell_text = cell_text.lstrip
         end
-      elsif cell_style == :literal || cell_style == :verse
+      elsif (literal = cell_style == :literal) || cell_style == :verse
         cell_text = cell_text.rstrip
         # QUESTION should we use same logic as :asciidoc cell? strip leading space if text doesn't start with newline?
         cell_text = cell_text.slice 1, cell_text.length while cell_text.start_with? LF
@@ -270,6 +273,11 @@ class Table::Cell < AbstractNode
       end unless inner_document_lines.empty?
       @inner_document = Document.new(inner_document_lines, :header_footer => false, :parent => @document, :cursor => inner_document_cursor)
       @document.attributes['doctitle'] = parent_doctitle unless parent_doctitle.nil?
+      @subs = nil
+    elsif literal
+      @subs = BASIC_SUBS
+    else
+      @subs = NORMAL_SUBS
     end
     @text = cell_text
     @style = cell_style
@@ -284,7 +292,7 @@ class Table::Cell < AbstractNode
   #
   # Returns the converted String text for this Cell
   def text
-    apply_subs @text, (@style == :literal ? BASIC_SUBS : NORMAL_SUBS)
+    apply_subs @text, @subs
   end
 
   # Public: Set the String text.

--- a/lib/asciidoctor/table.rb
+++ b/lib/asciidoctor/table.rb
@@ -231,9 +231,12 @@ class Table::Cell < AbstractNode
         update_attributes attributes
       end
       if (asciidoc = cell_style == :asciidoc)
+        inner_document_cursor = opts[:cursor]
         if (cell_text = cell_text.rstrip).start_with? LF
-          while (cell_text = cell_text.slice 1, cell_text.length).start_with? LF
-          end
+          lines_advanced = 1
+          lines_advanced += 1 while (cell_text = cell_text.slice 1, cell_text.length).start_with? LF
+          # NOTE this only works if we remain in the same file
+          inner_document_cursor.advance lines_advanced
         else
           cell_text = cell_text.lstrip
         end
@@ -265,7 +268,7 @@ class Table::Cell < AbstractNode
           inner_document_lines.unshift(*preprocessed_lines) unless preprocessed_lines.empty?
         end
       end unless inner_document_lines.empty?
-      @inner_document = Document.new(inner_document_lines, :header_footer => false, :parent => @document, :cursor => opts[:cursor])
+      @inner_document = Document.new(inner_document_lines, :header_footer => false, :parent => @document, :cursor => inner_document_cursor)
       @document.attributes['doctitle'] = parent_doctitle unless parent_doctitle.nil?
     end
     @text = cell_text

--- a/test/tables_test.rb
+++ b/test/tables_test.rb
@@ -1096,6 +1096,22 @@ output file name is used.
       assert_css 'table > tbody > tr:nth-child(2) > td:nth-child(3) div.dlist', output, 1
     end
 
+    test 'should preserve leading indentation in contents of AsciiDoc table cell if contents starts with newline' do
+      input = <<-EOS
+|===
+a|
+ $ command
+a| paragraph
+|===
+      EOS
+      output = render_embedded_string input
+      assert_css 'td', output, 2
+      assert_xpath '(//td)[1]//*[@class="literalblock"]', output, 1
+      assert_xpath '(//td)[2]//*[@class="paragraph"]', output, 1
+      assert_xpath '(//pre)[1][text()="$ command"]', output, 1
+      assert_xpath '(//p)[1][text()="paragraph"]', output, 1
+    end
+
     test 'preprocessor directive on first line of an AsciiDoc table cell should be processed' do
       input = <<-EOS
 |===

--- a/test/tables_test.rb
+++ b/test/tables_test.rb
@@ -1085,10 +1085,10 @@ output file name is used.
       assert body_cell_1_3.inner_document.nested?
       assert_equal doc, body_cell_1_3.inner_document.parent_document
       assert_equal doc.converter, body_cell_1_3.inner_document.converter
-      assert_equal 5, body_cell_1_3.inner_document.lineno
+      # TODO assert that body_cell_1_3.lineno is 5 once source_location is available on cell
+      assert_equal 6, body_cell_1_3.inner_document.lineno
       note = (body_cell_1_3.inner_document.find_by :context => :admonition)[0]
-      # NOTE lineno is off by one due to leading blank line being stripped
-      assert_equal 8, note.lineno
+      assert_equal 9, note.lineno
       output = doc.convert
 
       assert_css 'table > tbody > tr', output, 2


### PR DESCRIPTION
- preserve leading indentation in AsciiDoc table cell if starts w/ newline
- adjust line number for AsciiDoc table cell document if contents starts w/ newline
- compute subs for table cell in Table:Cell#initialize; allow access to subs property on Table::Cell
- drop strip_text option when creating table cell (as it is implied when the attributes argument is defined)
- remove delegation when creating Cursor object 
- don't subtract 1 from length when slicing off first character of string