### PR TITLE
simplify regex for dlists

### DIFF
--- a/lib/asciidoctor.rb
+++ b/lib/asciidoctor.rb
@@ -667,7 +667,7 @@ module Asciidoctor
     # Detects the start of any list item.
     #
     # NOTE we only have to check as far as the blank character because we know it means non-whitespace follows.
-    AnyListRx = /^(?:[ \t]*(?:-|\*\*{0,4}|\.\.{0,4}|\u2022\u2022{0,4}|\d+\.|[a-zA-Z]\.|[IVXivx]+\))[ \t]|[ \t]*.*?(?::{2,4}|;;)(?:$|[ \t])|<?\d+>[ \t])/
+    AnyListRx = /^(?:[ \t]*(?:-|\*\*{0,4}|\.\.{0,4}|\u2022\u2022{0,4}|\d+\.|[a-zA-Z]\.|[IVXivx]+\))[ \t]|[ \t]*.*?(?::::{0,2}|;;)(?:$|[ \t])|<?\d+>[ \t])/
 
     # Matches an unordered list item (one level for hyphens, up to 5 levels for asterisks).
     #
@@ -710,35 +710,34 @@ module Asciidoctor
     # Examples
     #
     #   foo::
-    #   foo:::
-    #   foo::::
-    #   foo;;
+    #   bar:::
+    #   baz::::
+    #   blah;;
     #
-    #   # the term can be followed by a description on the same line...
+    #   # the term may be followed by a description on the same line...
     #
-    #   foo:: That which precedes 'bar' (see also, <<bar>>)
+    #   foo:: The metasyntactic variable that commonly accompanies 'bar' (see also, <<bar>>).
     #
-    #   # ...or on a separate line (optionally indented)
+    #   # ...or on a separate line, which may optionally be indented
     #
     #   foo::
-    #     That which precedes 'bar' (see also, <<bar>>)
+    #     The metasyntactic variable that commonly accompanies 'bar' (see also, <<bar>>).
     #
-    #   # the term or description may be an attribute reference
+    #   # attribute references may be used in both the term and the description
     #
-    #   {foo_term}:: {foo_def}
+    #   {foo-term}:: {foo-desc}
     #
+    # NOTE we know trailing (.*) will match at least one character because we strip trailing spaces
     # NOTE negative match for comment line is intentional since that isn't handled when looking for next list item
     # TODO check for line comment when scanning lines instead of in regex
-    #
-    DescriptionListRx = %r(^(?!//)[ \t]*(.*?)(:{2,4}|;;)(?:[ \t]+(.*))?$)
+    DescriptionListRx = %r(^(?!//)[ \t]*(.*?)(:::{0,2}|;;)(?:$|[ \t]+(.*)$))
 
     # Matches a sibling description list item (which does not include the type in the key).
     DescriptionListSiblingRx = {
-      # (?:.*?[^:])? - a non-capturing group which grabs longest sequence of characters that doesn't end w/ colon
-      '::' => %r(^(?!//)[ \t]*((?:.*[^:])?)(::)(?:[ \t]+(.*))?$),
-      ':::' => %r(^(?!//)[ \t]*((?:.*[^:])?)(:::)(?:[ \t]+(.*))?$),
-      '::::' => %r(^(?!//)[ \t]*((?:.*[^:])?)(::::)(?:[ \t]+(.*))?$),
-      ';;' => %r(^(?!//)[ \t]*(.*)(;;)(?:[ \t]+(.*))?$)
+      '::' => %r(^(?!//)[ \t]*(.*[^:]|)(::)(?:$|[ \t]+(.*)$)),
+      ':::' => %r(^(?!//)[ \t]*(.*[^:]|)(:::)(?:$|[ \t]+(.*)$)),
+      '::::' => %r(^(?!//)[ \t]*(.*[^:]|)(::::)(?:$|[ \t]+(.*)$)),
+      ';;' => %r(^(?!//)[ \t]*(.*?)(;;)(?:$|[ \t]+(.*)$))
     }
 
     # Matches a callout list item.

--- a/lib/asciidoctor/parser.rb
+++ b/lib/asciidoctor/parser.rb
@@ -1260,9 +1260,9 @@ class Parser
   def self.next_list_item(reader, list_block, match, sibling_trait = nil)
     if (list_type = list_block.context) == :dlist
       dlist = true
-      has_text = true unless match[3].nil_or_empty?
+      has_text = true if (text = match[3])
       list_term = ListItem.new(list_block, match[1])
-      list_item = ListItem.new(list_block, match[3])
+      list_item = ListItem.new(list_block, text)
       if list_block.document.sourcemap
         list_term.source_location = reader.cursor
         if has_text

--- a/test/lists_test.rb
+++ b/test/lists_test.rb
@@ -1824,6 +1824,21 @@ term2:: def2
       assert_xpath '(//dl/dt)[2]/following-sibling::dd/p[text() = "def2"]', output, 1
     end
 
+    test 'should parse sibling items using same rules' do
+      input = <<-EOS
+term1;; ;; def1
+term2;; ;; def2
+      EOS
+      output = render_string input
+      assert_xpath '//dl', output, 1
+      assert_xpath '//dl/dt', output, 2
+      assert_xpath '//dl/dt/following-sibling::dd', output, 2
+      assert_xpath '(//dl/dt)[1][normalize-space(text()) = "term1"]', output, 1
+      assert_xpath '(//dl/dt)[1]/following-sibling::dd/p[text() = ";; def1"]', output, 1
+      assert_xpath '(//dl/dt)[2][normalize-space(text()) = "term2"]', output, 1
+      assert_xpath '(//dl/dt)[2]/following-sibling::dd/p[text() = ";; def2"]', output, 1
+    end
+
     test "single-line indented adjacent elements" do
       input = <<-EOS
 term1:: def1


### PR DESCRIPTION
- condense nested groups into a single flat group
- eagerly look for eol
- switch to 0-based repeat patterns
- remove unnecessary check for empty term text
- add test to verify ;; siblings are parsed using same rules