### PR TITLE
resolves #2392 only set nowrap style on table caption of auto-width table

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -103,6 +103,7 @@ Bug fixes::
   * add block title to dlist in manpage output (#1611, PR #2434)
   * scale text to 80% in print styles (#1484, PR #2576)
   * fix alignment of abstract title when using default stylesheet (PR #2732)
+  * only set nowrap style on table caption for auto-width table (#2392)
   * output non-breaking space for man manual if absent in DocBook output (PR #2636)
 
 Improvements / Refactoring::
@@ -143,6 +144,7 @@ Improvements / Refactoring::
   * add compliance setting to disable natural cross references (#2405, PR #2460)
   * make hash in inter-document xref target optional if target has extension (#2404, PR #2406)
   * add CSS class to part that matches role (#2401, PR #2402)
+  * add fit-content class to auto-width table (#2392)
   * automatically assign parent reference when adding node to parent (#2398, PR #2403)
   * leave inline anchor in section title as is if section has ID (#2243, PR #2427)
   * align and improve error message about invalid use of partintro between HTML5 and DocBook converters

--- a/data/stylesheets/asciidoctor-default.css
+++ b/data/stylesheets/asciidoctor-default.css
@@ -185,7 +185,7 @@ body.toc2.toc-right{padding-left:0;padding-right:20em}}
 #content h1>a.link:hover,h2>a.link:hover,h3>a.link:hover,#toctitle>a.link:hover,.sidebarblock>.content>.title>a.link:hover,h4>a.link:hover,h5>a.link:hover,h6>a.link:hover{color:#a53221}
 .audioblock,.imageblock,.literalblock,.listingblock,.stemblock,.videoblock{margin-bottom:1.25em}
 .admonitionblock td.content>.title,.audioblock>.title,.exampleblock>.title,.imageblock>.title,.listingblock>.title,.literalblock>.title,.stemblock>.title,.openblock>.title,.paragraph>.title,.quoteblock>.title,table.tableblock>.title,.verseblock>.title,.videoblock>.title,.dlist>.title,.olist>.title,.ulist>.title,.qlist>.title,.hdlist>.title{text-rendering:optimizeLegibility;text-align:left;font-family:"Noto Serif","DejaVu Serif",serif;font-size:1rem;font-style:italic}
-table.tableblock>caption.title{white-space:nowrap;overflow:visible;max-width:0}
+table.tableblock.fit-content>caption.title{white-space:nowrap;width:0}
 .paragraph.lead>p,#preamble>.sectionbody>[class="paragraph"]:first-of-type p{font-size:1.21875em;line-height:1.6;font-color:rgba(0,0,0,.85)}
 table.tableblock #preamble>.sectionbody>.paragraph:first-of-type p{font-size:inherit}
 .admonitionblock>table{border-collapse:separate;border:0;background:none;width:100%}

--- a/lib/asciidoctor/converter/html5.rb
+++ b/lib/asciidoctor/converter/html5.rb
@@ -790,12 +790,12 @@ Your browser does not support the audio tag.
         classes << %(stripe-#{stripe})
       end
       styles = []
-      unless (node.option? 'autowidth') && !(node.attr? 'width', nil, false)
-        if node.attr? 'tablepcwidth', 100
-          classes << 'stretch'
-        else
-          styles << %(width: #{node.attr 'tablepcwidth'}%;)
-        end
+      if (node.option? 'autowidth') && !(node.attr? 'width', nil, false)
+        classes << 'fit-content'
+      elsif (pcwidth = node.attr 'tablepcwidth') == 100
+        classes << 'stretch'
+      else
+        styles << %(width: #{pcwidth}%;)
       end
       if (role = node.role)
         classes << role

--- a/test/tables_test.rb
+++ b/test/tables_test.rb
@@ -229,7 +229,7 @@ three
       assert_equal %(<div class="verse">  one\n  two\nthree</div>), result.to_s
     end
 
-    test 'table and col width not assigned when autowidth option is specified' do
+    test 'table and column width not assigned when autowidth option is specified' do
       input = <<-EOS
 [options="autowidth"]
 |=======
@@ -240,6 +240,7 @@ three
       EOS
       output = render_embedded_string input
       assert_css 'table', output, 1
+      assert_css 'table.fit-content', output, 1
       assert_css 'table[style*="width"]', output, 0
       assert_css 'table colgroup col', output, 3
       assert_css 'table colgroup col[style*="width"]', output, 0


### PR DESCRIPTION

- only set white-space: nowrap on table caption if table has automatic width
- add fit-content CSS class to auto-width table