### PR TITLE
use cursor mark to track source location when parsing callout list

### DIFF
--- a/lib/asciidoctor/callouts.rb
+++ b/lib/asciidoctor/callouts.rb
@@ -59,7 +59,7 @@ class Callouts
   #
   # Returns A space-separated String of callout ids associated with the specified list item
   def callout_ids li_ordinal
-    current_list.map {|element| element[:ordinal] == li_ordinal ? %(#{element[:id]} ) : nil }.join.chop
+    current_list.map {|it| it[:ordinal] == li_ordinal ? %(#{it[:id]} ) : '' }.join.chop
   end
 
   # Public: The current list for which callouts are being collected

--- a/test/blocks_test.rb
+++ b/test/blocks_test.rb
@@ -694,7 +694,7 @@ ____
 
       output = render_embedded_string input
       assert_xpath '//pre[text()="La la la <1>"]', output, 1
-      assert_message @logger, :WARN, '<stdin>: line 5: no callouts refer to list item 1', Hash
+      assert_message @logger, :WARN, '<stdin>: line 5: no callout found for <1>', Hash
     end
 
     test 'should perform normal subs on a verse block' do

--- a/test/lists_test.rb
+++ b/test/lists_test.rb
@@ -4313,7 +4313,7 @@ foo::
       assert_xpath '//dl//b', output, 0
       assert_xpath '//dl/dd/p[text()="bar <1>"]', output, 1
       assert_xpath '//ol/li/p[text()="Not pointing to a callout"]', output, 1
-      assert_message logger, :WARN, '<stdin>: line 4: no callouts refer to list item 1', Hash
+      assert_message logger, :WARN, '<stdin>: line 4: no callout found for <1>', Hash
     end
   end
 
@@ -4329,7 +4329,7 @@ foo::
       assert_xpath '//ul//b', output, 0
       assert_xpath %(//ul/li/p[text()="foo\nbar <1>"]), output, 1
       assert_xpath '//ol/li/p[text()="Not pointing to a callout"]', output, 1
-      assert_message logger, :WARN, '<stdin>: line 4: no callouts refer to list item 1', Hash
+      assert_message logger, :WARN, '<stdin>: line 4: no callout found for <1>', Hash
     end
   end
 
@@ -4348,8 +4348,8 @@ Beans are fun.
       output = render_embedded_string input
       assert_xpath '//ol/li', output, 2
       assert_messages logger, [
-        [:WARN, '<stdin>: line 8: callout list item index: expected 2 got 3', Hash],
-        [:WARN, '<stdin>: line 8: no callouts refer to list item 2', Hash]
+        [:WARN, '<stdin>: line 8: callout list item index: expected 2, got 3', Hash],
+        [:WARN, '<stdin>: line 8: no callout found for <2>', Hash]
       ]
     end
   end


### PR DESCRIPTION
- use cursor mark to track source location when parsing callout list
- improve warning message when callout refernce not found
- remove redundant end of file guard
- update tests