### PR TITLE
resolves #1926 use correct parse mode when parsing blocks for list item

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -66,6 +66,7 @@ Bug fixes::
   * using the shorthand syntax on the style to set block attributes (id, roles, options) no longer resets block style (#2174)
   * match include tags anywhere on line as long as offset by word boundary on left and space or newline on right (#2369, PR #2683)
   * warn if an include tag specified in the include directive is unclosed in the included file (#2361, PR #2696)
+  * use correct parse mode when parsing blocks attached to list item (#1926)
   * fix typo in gemspec that removed README and CONTRIBUTING files from the generated gem (PR #2650) (*@aerostitch*)
   * preserve id, role, title, and reftext on open block when converting to DocBook; wrap in `<para>` or `<formalpara>` (#2276)
   * don't turn bare URI scheme (no host) into a link (#2609, PR #2611)

--- a/lib/asciidoctor/parser.rb
+++ b/lib/asciidoctor/parser.rb
@@ -1343,11 +1343,15 @@ class Parser
         content_adjacent = false
       end
 
-      attrs, opts = {}, { :text => !has_text }
+      # reader is confined to boundaries of list, which means only blocks will be found (no sections)
+      if (block = next_block(list_item_reader, list_item, (attrs = {}), :text => !has_text))
+        list_item.blocks << block
+      end
 
-      # we can look for blocks until lines are exhausted without worrying about
-      # sections since reader is confined to boundaries of list
-      while ((block = next_block list_item_reader, list_item, attrs, opts) && list_item.blocks << block) || list_item_reader.has_more_lines?
+      while list_item_reader.has_more_lines?
+        if (block = next_block(list_item_reader, list_item, attrs))
+          list_item.blocks << block
+        end
       end
 
       list_item.fold_first(continuation_connects_first_block, content_adjacent)

--- a/test/lists_test.rb
+++ b/test/lists_test.rb
@@ -355,6 +355,48 @@ NOTE: This is a note.
       assert_xpath '//ul/li/*[@class="admonitionblock note"]//td[@class="content"][normalize-space(text())="This is a note."]', output, 1
     end
 
+    test 'paragraph-like blocks attached to an ancestory list item by a list continuation should produce blocks' do
+      input = <<-EOS
+* parent
+ ** child
+
++
+NOTE: This is a note.
+
+* another parent
+ ** another child
+
++
+'''
+      EOS
+
+      output = render_embedded_string input
+      assert_css 'ul ul .admonitionblock.note', output, 0
+      assert_xpath '(//ul)[1]/li/*[@class="admonitionblock note"]', output, 1
+      assert_css 'ul ul hr', output, 0
+      assert_xpath '(//ul)[1]/li/hr', output, 1
+    end
+
+    test 'should continue to parse blocks attached by a list continuation after block is dropped' do
+      input = <<-EOS
+* item
++
+paragraph
++
+[comment]
+comment
++
+====
+example
+====
+'''
+      EOS
+
+      output = render_embedded_string input
+      assert_css 'ul > li > .paragraph', output, 1
+      assert_css 'ul > li > .exampleblock', output, 1
+    end
+
     test 'appends line as paragraph if attached by continuation following line comment' do
       input = <<-EOS
 - list item 1


### PR DESCRIPTION
- only use text mode for parsing list text, not subsequent blocks
- don't call next_block when parsing list item if reader is empty