### PR TITLE
make processing of interdoc xref more strict

### DIFF
--- a/lib/asciidoctor.rb
+++ b/lib/asciidoctor.rb
@@ -270,10 +270,10 @@ module Asciidoctor
 
   # Set of file extensions recognized as AsciiDoc documents (stored as a truth hash)
   ASCIIDOC_EXTENSIONS = {
-    '.asciidoc' => true,
     '.adoc' => true,
-    '.ad' => true,
+    '.asciidoc' => true,
     '.asc' => true,
+    '.ad' => true,
     # TODO .txt should be deprecated
     '.txt' => true
   }


### PR DESCRIPTION
- disable in compat mode
- only process file extension when ref is source-to-source; leave other file extensions alone
- allow use of any known AsciiDoc file extension when hash is present in target
- only treat target of xref macro as interdoc xref if ends with .adoc
- change order of AsciiDoc file extensions in constant
