### PR TITLE
resolves #2751 use alternate macro to switch on monospaced text

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -80,6 +80,7 @@ Bug fixes::
   * don't convert inter-document xref to internal anchor unless entire target file is included into current file (#2200)
   * fix em dash replacement in manpage converter (#2604, PR #2607)
   * don't output e-mail address twice when replacing bare e-mail address in manpage output (#2654, PR #2665)
+  * use alternate macro for monospaced text in manpage output to not conflict w/ AsciiDoc macros (#2751)
   * enforce that absolute start path passed to PathResolver#system_path is inside of jail path (#2642, PR #2644)
   * fix behavior of PathResolver#descends_from? when base path equals / (#2642, PR #2644)
   * automatically recover if start path passed to PathResolver#system_path is outside of jail path (#2642, PR #2644)

--- a/lib/asciidoctor/converter/manpage.rb
+++ b/lib/asciidoctor/converter/manpage.rb
@@ -680,7 +680,7 @@ allbox tab(:);'
       when :strong
         %(#{ESC_BS}fB<BOUNDARY>#{node.text}</BOUNDARY>#{ESC_BS}fP)
       when :monospaced
-        %(#{ESC_BS}f[CR]<BOUNDARY>#{node.text}</BOUNDARY>#{ESC_BS}fP)
+        %[#{ESC_BS}f(CR<BOUNDARY>#{node.text}</BOUNDARY>#{ESC_BS}fP]
       when :single
         %[#{ESC_BS}(oq<BOUNDARY>#{node.text}</BOUNDARY>#{ESC_BS}(cq]
       when :double

--- a/test/manpage_test.rb
+++ b/test/manpage_test.rb
@@ -150,7 +150,7 @@ BBB this line and the one above it should be visible)
 
 "`hello`" '`goodbye`' *strong* _weak_ `even`)
       output = Asciidoctor.convert input, :backend => :manpage
-      assert_equal '\(lqhello\(rq \(oqgoodbye\(cq \fBstrong\fP \fIweak\fP \f[CR]even\fP', output.lines.entries.last.chomp
+      assert_equal '\(lqhello\(rq \(oqgoodbye\(cq \fBstrong\fP \fIweak\fP \f(CReven\fP', output.lines.entries.last.chomp
     end
 
     test 'should escape backslashes in content' do
@@ -267,6 +267,17 @@ Please search |link:http://discuss.asciidoctor.org[the forums]| before asking.)
 Please search |\c
 .URL "http://discuss.asciidoctor.org" "the forums" "|"
 before asking.', output.lines.entries[-4..-1].join
+    end
+
+    test 'should be able to use monospaced text inside a link' do
+      input = %(#{SAMPLE_MANPAGE_HEADER}
+
+Enter the link:cat[`cat`] command.)
+      output = Asciidoctor.convert input, :backend => :manpage
+      assert_equal '.sp
+Enter the \c
+.URL "cat" "\f(CRcat\fP" " "
+command.', output.lines.entries[-4..-1].join
     end
   end
 


### PR DESCRIPTION
- use alternate groff macro \f(CR which does not conflict with / break AsciiDoc macros