### PR TITLE
Allow to specify the lib path via environment variable for the tests or load the gem directly

### DIFF
--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,6 +1,7 @@
 # encoding: UTF-8
 ASCIIDOCTOR_TEST_DIR = File.expand_path File.dirname __FILE__
 ASCIIDOCTOR_PROJECT_DIR = File.dirname ASCIIDOCTOR_TEST_DIR
+ASCIIDOCTOR_LIB_PATH = ENV['ASCIIDOCTOR_LIB_PATH'] || File.join(ASCIIDOCTOR_PROJECT_DIR, 'lib', 'asciidoctor')
 Dir.chdir ASCIIDOCTOR_PROJECT_DIR
 
 if RUBY_VERSION < '1.9'
@@ -9,7 +10,11 @@ end
 
 require 'simplecov' if ENV['COVERAGE'] == 'true'
 
-require File.join(ASCIIDOCTOR_PROJECT_DIR, 'lib', 'asciidoctor')
+if File.exist? ASCIIDOCTOR_LIB_PATH
+    require ASCIIDOCTOR_LIB_PATH
+else
+    require 'asciidoctor'
+end
 
 require 'socket'
 require 'nokogiri'

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,7 +1,7 @@
 # encoding: UTF-8
 ASCIIDOCTOR_TEST_DIR = File.expand_path File.dirname __FILE__
 ASCIIDOCTOR_PROJECT_DIR = File.dirname ASCIIDOCTOR_TEST_DIR
-ASCIIDOCTOR_LIB_PATH = ENV['ASCIIDOCTOR_LIB_PATH'] || File.join(ASCIIDOCTOR_PROJECT_DIR, 'lib', 'asciidoctor')
+ASCIIDOCTOR_LIB_DIR = ENV['ASCIIDOCTOR_LIB_DIR'] || File.join(ASCIIDOCTOR_PROJECT_DIR, 'lib')
 Dir.chdir ASCIIDOCTOR_PROJECT_DIR
 
 if RUBY_VERSION < '1.9'
@@ -10,11 +10,7 @@ end
 
 require 'simplecov' if ENV['COVERAGE'] == 'true'
 
-if File.exist? ASCIIDOCTOR_LIB_PATH
-    require ASCIIDOCTOR_LIB_PATH
-else
-    require 'asciidoctor'
-end
+require File.join(ASCIIDOCTOR_LIB_DIR, 'asciidoctor')
 
 require 'socket'
 require 'nokogiri'


### PR DESCRIPTION
Hi,

Context: I am packaging the new version of asciidoctor for Debian and am trying to reduce the amount of custom stuffs we do there.

The idea of this PR is to be able to specify the tests when running them against an already installed environment.
With this PR we could either:
* use what we currently do if `ASCIIDOCTOR_LIB_PATH` is not set and the usual directory exists
* specify the `ASCIIDOCTOR_LIB_PATH` environment variable to say that the `lib/asciidoc.rb` is located in a given build directory (or in `/usr/lib/ruby/vendor_ruby/asciidoctor.rb` for example)
* try to load the gem if the usual location does not exist

Up to now we were changing the following line to `require 'asciidoctor'`:
```ruby
require File.join(ASCIIDOCTOR_PROJECT_DIR, 'lib', 'asciidoctor')
```
Having the environment variable would give us even more flexibility.

Would that be an acceptable change?

Thanks
Joseph