### PR TITLE
Allow the usage of ASCIIDOCTOR_LIB_DIR in gemspec and Rakefile for loading the version

### DIFF
--- a/asciidoctor.gemspec
+++ b/asciidoctor.gemspec
@@ -1,5 +1,10 @@
 # encoding: UTF-8
-require File.expand_path '../lib/asciidoctor/version', __FILE__
+begin
+  require File.expand_path '../lib/asciidoctor/version', __FILE__
+rescue LoadError
+  require 'asciidoctor/version'
+end
+
 require 'open3' unless defined? Open3
 
 Gem::Specification.new do |s|


### PR DESCRIPTION
Hi,

This is the same idea as #2758.
Context: if you are in a build/autopkgtest environment that don't have the exact same directory structure as this, you end up having to write patch like https://salsa.debian.org/ruby-team/asciidoctor/blob/c7e30fd0010a0c6f90df492695e6d9731c0b2ce9/debian/patches/package-version.patch to change the lib directory.
This patch would allow us to use the environment variable `ASCIIDOCTOR_LIB_DIR` to specify the lib directory in those specific use cases.

Thanks
Joseph