### PR TITLE
resolves #2738 use part-signifier and chapter-signifer, if set

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -17,6 +17,7 @@ For a detailed view of what has changed, refer to the {uri-repo}/commits/master[
 
 Enhancements::
 
+  * if set, add value of part-signifier and chapter-signifier attributes to part and chapter titles (#2738)
   * allow position (float) and alignment (align) to be set on video block (#2425)
   * substitute attribute references in attrlist of include directive (#2761)
   * add Document#set_header_attribute method for adding method directly to document header during parsing (#2820)
@@ -65,6 +66,7 @@ Fixes::
 
 Improvements::
 
+  * change trailing delimiter on part number to colon (:) (#2738)
   * interpret open line range as infinite (#2914)
   * rename number property on AbstractBlock to numeral, but keep number as deprecated alias
   * use CSS class instead of hard-coded inline float style on tables and images (#2753)

--- a/test/sections_test.rb
+++ b/test/sections_test.rb
@@ -1436,8 +1436,60 @@ content
       EOS
 
       output = convert_string input
-      assert_xpath '//h1[@id="_language"][text() = "I. Language"]', output, 1
-      assert_xpath '//h1[@id="_processor"][text() = "II. Processor"]', output, 1
+      assert_xpath '//h1[@id="_language"][text() = "I: Language"]', output, 1
+      assert_xpath '//h1[@id="_processor"][text() = "II: Processor"]', output, 1
+    end
+
+    test 'should prepend value of part-signifier attribute to title of numbered part' do
+      input = <<-EOS
+= Book Title
+:doctype: book
+:sectnums:
+:partnums:
+:part-signifier: Part
+
+= Language
+
+== Syntax
+
+content
+
+= Processor
+
+== CLI
+
+content
+      EOS
+
+      output = convert_string input
+      assert_xpath '//h1[@id="_language"][text() = "Part I: Language"]', output, 1
+      assert_xpath '//h1[@id="_processor"][text() = "Part II: Processor"]', output, 1
+    end
+
+    test 'should prepend value of chapter-signifier attribute to title of numbered chapter' do
+      input = <<-EOS
+= Book Title
+:doctype: book
+:sectnums:
+:partnums:
+:chapter-signifier: Chapter
+
+= Language
+
+== Syntax
+
+content
+
+= Processor
+
+== CLI
+
+content
+      EOS
+
+      output = convert_string input
+      assert_xpath '//h2[@id="_syntax"][text() = "Chapter 1. Syntax"]', output, 1
+      assert_xpath '//h2[@id="_cli"][text() = "Chapter 2. CLI"]', output, 1
     end
 
     test 'blocks should have level' do


### PR DESCRIPTION
- add value of part-signifier attribute to beginning of title for numbered part
- add value of chapter-signifier attribute to beginning of title for numbered chapter
- change trailing delimiter of part number from period to colon