### PR TITLE
resolve #1860 multiple revision inserted in docbook format.

### DIFF
--- a/lib/asciidoctor.rb
+++ b/lib/asciidoctor.rb
@@ -437,7 +437,8 @@ module Asciidoctor
     #   v1.0, 2013-01-01: Ring in the new year release
     #   1.0, Jan 01, 2013
     #
-    RevisionInfoLineRx = /^(?:\D*(.*?),)? *(?!:)(.*?)(?: *(?!^),?: *(.*))?$/
+    #RevisionInfoLineRx = /^(?:\D*(.*?),)? *(?!:)(.*?)(?: *(?!^),?: *(.*))?$/
+    RevisionInfoLineRx = /^(?:\D*(.*?),)? *(?!:)(.*?)(?: *(?!^),?: *(.*?))?(?: *(?!^),?: *(.*?))?$/
 
     # Matches the title and volnum in the manpage doctype.
     #

--- a/lib/asciidoctor/converter/docbook5.rb
+++ b/lib/asciidoctor/converter/docbook5.rb
@@ -693,16 +693,35 @@ module Asciidoctor
             result << '</authorgroup>'
           end
         end
-        if (doc.attr? 'revdate') && ((doc.attr? 'revnumber') || (doc.attr? 'revremark'))
-          result << %(<revhistory>
+        
+        # check if an history is present inside document
+        if (doc.attr? 'revision_list') && (doc.attr('revision_list').size > 1)
+           result << %(<revhistory>)
+           revision_list = doc.attr 'revision_list'
+           revision_list.each do |revision| 
+               if (revision['revdate'] && (revision['revnumber'] || revision['revremark']))
+                 result << %(<revision>)
+                 result << %(<revnumber>#{revision['revnumber']}</revnumber>) if revision['revnumber']
+                 result << %(<date>#{revision['revdate']}</date>) if revision['revdate']
+                 result << %(<authorinitials>#{revision['author']}</authorinitials>) if revision['author']
+                 result << %(<revremark>#{revision['revremark']}</revremark>) if revision['revremark']
+                 result << %(</revision>)
+               end
+           end
+           result << %(</revhistory>)
+        else
+          if (doc.attr? 'revdate') && ((doc.attr? 'revnumber') || (doc.attr? 'revremark'))
+            result << %(<revhistory>
 <revision>)
-          result << %(<revnumber>#{doc.attr 'revnumber'}</revnumber>) if doc.attr? 'revnumber'
-          result << %(<date>#{doc.attr 'revdate'}</date>) if doc.attr? 'revdate'
-          result << %(<authorinitials>#{doc.attr 'authorinitials'}</authorinitials>) if doc.attr? 'authorinitials'
-          result << %(<revremark>#{doc.attr 'revremark'}</revremark>) if doc.attr? 'revremark'
-          result << %(</revision>
+            result << %(<revnumber>#{doc.attr 'revnumber'}</revnumber>) if doc.attr? 'revnumber'
+            result << %(<date>#{doc.attr 'revdate'}</date>) if doc.attr? 'revdate'
+            result << %(<authorinitials>#{doc.attr 'authorinitials'}</authorinitials>) if doc.attr? 'authorinitials'
+            result << %(<revremark>#{doc.attr 'revremark'}</revremark>) if doc.attr? 'revremark'
+            result << %(</revision>
 </revhistory>)
+          end
         end
+        
         unless use_info_tag_prefix
           if (doc.attr? 'front-cover-image') || (doc.attr? 'back-cover-image')
             if (back_cover_tag = cover_tag doc, 'back')

--- a/test/document_test.rb
+++ b/test/document_test.rb
@@ -788,6 +788,65 @@ content
       assert_css 'revhistory > revision > revremark', output, 1
     end
 
+    #multiple revision tests
+    
+    test 'should insert multiple revision line when is set' do
+      input = <<-EOS
+= Document Title
+Ryan Waldron
+v1.0.0, 2016-09-07: The big 1 OH!
+v0.9.0, 2016-06-03: We're getting there
+
+content    
+      EOS
+      
+      output = render_string input, :backend => 'docbook'
+      assert_xpath '/article/info', output, 1
+      assert_xpath '/article/info/title[text() = "Document Title"]', output, 1
+      assert_xpath '/article/info/author/personname', output, 1
+      assert_xpath '/article/info/author/personname/firstname[text() = "Ryan"]', output, 1
+      assert_xpath '/article/info/author/personname/surname[text() = "Waldron"]', output, 1
+
+      assert_xpath '/article/info/revhistory', output, 1
+      assert_xpath '/article/info/revhistory/revision', output, 2
+      assert_xpath '/article/info/revhistory/revision[1]/revnumber[text() = "1.0.0"]', output, 1
+      assert_xpath '/article/info/revhistory/revision[1]/date[text() = "2016-09-07"]', output, 1
+      assert_xpath '/article/info/revhistory/revision[1]/revremark[text() = "The big 1 OH!"]', output, 1
+      assert_xpath '/article/info/revhistory/revision[2]/revnumber[text() = "0.9.0"]', output, 1
+      assert_xpath '/article/info/revhistory/revision[2]/date[text() = "2016-06-03"]', output, 1
+      assert_xpath '/article/info/revhistory/revision[2]/revremark[text() = "We\'re getting there"]', output, 1
+    end
+    
+
+  test "should decode multiple revision line with author and set default author" do
+    input = <<-EOS
+= My new document
+Ryan Waldron
+v1.0.0, 2016-09-07: The big 1 OH! 
+v0.9.0, 2016-06-03: John Doe : We're getting there
+
+content    
+    EOS
+
+      output = render_string input, :backend => 'docbook'
+      assert_xpath '/article/info', output, 1
+      assert_xpath '/article/info/title[text() = "My new document"]', output, 1
+      assert_xpath '/article/info/author/personname', output, 1
+      assert_xpath '/article/info/author/personname/firstname[text() = "Ryan"]', output, 1
+      assert_xpath '/article/info/author/personname/surname[text() = "Waldron"]', output, 1
+
+      assert_xpath '/article/info/revhistory', output, 1
+      assert_xpath '/article/info/revhistory/revision', output, 2
+      assert_xpath '/article/info/revhistory/revision[1]/revnumber[text() = "1.0.0"]', output, 1
+      assert_xpath '/article/info/revhistory/revision[1]/date[text() = "2016-09-07"]', output, 1
+      assert_xpath '/article/info/revhistory/revision[1]/authorinitials[text() = "Ryan Waldron"]', output, 1
+      assert_xpath '/article/info/revhistory/revision[1]/revremark[text() = "The big 1 OH!"]', output, 1
+      assert_xpath '/article/info/revhistory/revision[2]/revnumber[text() = "0.9.0"]', output, 1
+      assert_xpath '/article/info/revhistory/revision[2]/date[text() = "2016-06-03"]', output, 1
+      assert_xpath '/article/info/revhistory/revision[2]/authorinitials[text() = "John Doe"]', output, 1
+      assert_xpath '/article/info/revhistory/revision[2]/revremark[text() = "We\'re getting there"]', output, 1
+  end
+    
     test 'should not include revision history if revdate is not set' do
       input = <<-EOS
 = Document Title

--- a/test/parser_test.rb
+++ b/test/parser_test.rb
@@ -597,7 +597,7 @@ Ryan Waldron
 v0.0.7, 2013-12-18: The first release you can stand on
     EOS
     metadata, _ = parse_header_metadata input
-    assert_equal 9, metadata.size
+    assert_equal 10, metadata.size
     assert_equal '0.0.7', metadata['revnumber']
     assert_equal '2013-12-18', metadata['revdate']
     assert_equal 'The first release you can stand on', metadata['revremark']
@@ -609,7 +609,7 @@ Ryan Waldron
 2013-12-18
     EOS
     metadata, _ = parse_header_metadata input
-    assert_equal 7, metadata.size
+    assert_equal 8, metadata.size
     assert_equal '2013-12-18', metadata['revdate']
   end
 
@@ -619,7 +619,7 @@ Stuart Rackham
 v8.6.8,
     EOS
     metadata, _ = parse_header_metadata input
-    assert_equal 7, metadata.size
+    assert_equal 8, metadata.size
     assert_equal '8.6.8', metadata['revnumber']
     refute metadata.has_key?('revdate')
   end
@@ -631,7 +631,7 @@ Stuart Rackham
 v8.6.8
     EOS
     metadata, _ = parse_header_metadata input
-    assert_equal 7, metadata.size
+    assert_equal 8, metadata.size
     assert_equal '8.6.8', metadata['revnumber']
     refute metadata.has_key?('revdate')
   end
@@ -643,7 +643,7 @@ Ryan Waldron
 foobar
     EOS
     metadata, _ = parse_header_metadata input
-    assert_equal 7, metadata.size
+    assert_equal 8, metadata.size
     assert_equal 'foobar', metadata['revdate']
   end
 
@@ -653,7 +653,7 @@ Ryan Waldron
 2013-12-18:  The first release you can stand on
     EOS
     metadata, _ = parse_header_metadata input
-    assert_equal 8, metadata.size
+    assert_equal 9, metadata.size
     assert_equal '2013-12-18', metadata['revdate']
     assert_equal 'The first release you can stand on', metadata['revremark']
   end
@@ -720,13 +720,68 @@ release info
 v0.0.7, 2013-12-18
     EOS
     metadata, _ = parse_header_metadata input
-    assert_equal 8, metadata.size
+    assert_equal 9, metadata.size
     assert_equal 1, metadata['authorcount']
     assert_equal 'Ryan Waldron', metadata['author']
     assert_equal '0.0.7', metadata['revnumber']
     assert_equal '2013-12-18', metadata['revdate']
   end
 
+  #multiple revision list test
+  test "decoding of multiple revision line without author" do
+    input = <<-EOS
+Ryan Waldron
+v1.0.0, 2016-09-07: The big 1 OH!
+v0.9.0, 2016-06-03: We're getting there
+
+content    
+    EOS
+    metadata, _ = parse_header_metadata input
+
+    assert_equal 10, metadata.size
+    assert_equal 1, metadata['authorcount']
+    assert_equal 'Ryan Waldron', metadata['author']
+    assert_equal '1.0.0', metadata['revnumber']
+    assert_equal '2016-09-07', metadata['revdate']
+    assert_equal 2, metadata['revision_list'].size
+    assert_equal '1.0.0', metadata['revision_list'][0]['revnumber']
+    assert_equal '2016-09-07', metadata['revision_list'][0]['revdate']
+    assert_equal 'The big 1 OH!', metadata['revision_list'][0]['revremark']
+    assert_equal '0.9.0', metadata['revision_list'][1]['revnumber']
+    assert_equal '2016-06-03', metadata['revision_list'][1]['revdate']
+    assert_equal "We're getting there", metadata['revision_list'][1]['revremark']
+  end
+  
+
+  test "decoding of multiple revision line with author (set default author)" do
+    input = <<-EOS
+Ryan Waldron
+v1.0.0, 2016-09-07: The big 1 OH! 
+v0.9.0, 2016-06-03: John Doe : We're getting there
+
+content    
+    EOS
+    metadata, _ = parse_header_metadata input
+
+    assert_equal 10, metadata.size
+    assert_equal 1, metadata['authorcount']
+    assert_equal 'Ryan Waldron', metadata['author']
+    assert_equal '1.0.0', metadata['revnumber']
+    assert_equal '2016-09-07', metadata['revdate']
+    
+    assert_equal 2, metadata['revision_list'].size
+    assert_equal '1.0.0', metadata['revision_list'][0]['revnumber']
+    assert_equal '2016-09-07', metadata['revision_list'][0]['revdate']
+    assert_equal 'The big 1 OH!', metadata['revision_list'][0]['revremark']
+    assert_equal 'Ryan Waldron', metadata['revision_list'][0]['author']
+    
+    assert_equal '0.9.0', metadata['revision_list'][1]['revnumber']
+    assert_equal '2016-06-03', metadata['revision_list'][1]['revdate']
+    assert_equal "We're getting there", metadata['revision_list'][1]['revremark']
+    assert_equal 'John Doe', metadata['revision_list'][1]['author']
+  end
+
+  
   test 'break header at line with three forward slashes' do
     input = <<-EOS
 Joe Cool
@@ -735,7 +790,7 @@ v1.0
 stuff
     EOS
     metadata, _ = parse_header_metadata input
-    assert_equal 7, metadata.size
+    assert_equal 8, metadata.size
     assert_equal 1, metadata['authorcount']
     assert_equal 'Joe Cool', metadata['author']
     assert_equal '1.0', metadata['revnumber']


### PR DESCRIPTION
Hello, 

This pull request inserts a revision history section with several revisions in a docbook output.
To be able to manage several authors, I put also a author section inside revision line.
This pach keeps compatibility with previous format.


