### PR TITLE
resolves #2770 use OS independent timezone in time attributes

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -82,6 +82,7 @@ Improvements::
   * add support for range syntax (.. delimiter) to highlight attribute on source block (#2918)
   * add support for unbounded range to highlight attribute on source block (#2918)
   * automatically assign title and caption on image block if title is set on custom block source (#2926)
+  * use OS independent timezone (UTC or time offset) in doctime and localtime attributes (#2770)
 
 Documentation::
 

--- a/lib/asciidoctor.rb
+++ b/lib/asciidoctor.rb
@@ -1338,11 +1338,9 @@ module Asciidoctor
         docdate = attrs['docdate'] = (input_mtime.strftime '%F')
         attrs['docyear'] ||= input_mtime.year.to_s
       end
-      doctime = (attrs['doctime'] ||= begin
-          input_mtime.strftime '%T %Z'
-        rescue # Asciidoctor.js fails if timezone string has characters outside basic Latin (see asciidoctor.js#23)
-          input_mtime.strftime '%T %z'
-        end)
+      # %Z is OS dependent and may contain characters that aren't UTF-8 encoded (see asciidoctor#2770 and asciidoctor.js#23)
+      # Ruby 1.8 doesn't support %:z
+      doctime = (attrs['doctime'] ||= input_mtime.strftime %(%T #{input_mtime.utc_offset == 0 ? 'UTC' : '%z'}))
       attrs['docdatetime'] = %(#{docdate} #{doctime})
     elsif input.respond_to? :readlines
       # NOTE tty, pipes & sockets can't be rewound, but can't be sniffed easily either

--- a/lib/asciidoctor/document.rb
+++ b/lib/asciidoctor/document.rb
@@ -499,11 +499,9 @@ class Document < AbstractBlock
         localdate = attrs['localdate'] = (now.strftime '%F')
         localyear = (attrs['localyear'] ||= now.year.to_s)
       end
-      localtime = (attrs['localtime'] ||= begin
-          now.strftime '%T %Z'
-        rescue # Asciidoctor.js fails if timezone string has characters outside basic Latin (see asciidoctor.js#23)
-          now.strftime '%T %z'
-        end)
+      # %Z is OS dependent and may contain characters that aren't UTF-8 encoded (see asciidoctor#2770 and asciidoctor.js#23)
+      # Ruby 1.8 doesn't support %:z
+      localtime = (attrs['localtime'] ||= now.strftime %(%T #{now.utc_offset == 0 ? 'UTC' : '%z'}))
       attrs['localdatetime'] ||= %(#{localdate} #{localtime})
 
       # docdate, doctime and docdatetime should default to

--- a/test/fixtures/doctime-localtime.adoc
+++ b/test/fixtures/doctime-localtime.adoc
@@ -1,0 +1,2 @@
+{doctime}
+{localtime}


### PR DESCRIPTION
- use timezone offset instead of OS dependent timezone string
- use UTC if offset is 0
- add tests