### PR TITLE
duplicate arrays using .drop(0) instead of .dup

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -38,6 +38,7 @@ Improvements::
   * allow hyphen to be used custom block macro name as long as it's not the first character (#2620)
   * use shorthands %F and %T instead of %Y-%m-%d and %H:%M:%S to format time
   * read file in binary mode whenever contents are being normalized
+  * use .drop(0) to duplicate arrays (roughly 1.5x as fast as .dup)
 
 // tag::compact[]
 == 1.5.7.1 (2018-05-10) - @mojavelinux

--- a/lib/asciidoctor.rb
+++ b/lib/asciidoctor.rb
@@ -1211,7 +1211,7 @@ module Asciidoctor
     [:subscript, :unconstrained, /\\?(?:\[([^\]]+)\])?~(\S+?)~/]
   ]
 
-  compat_quote_subs = quote_subs.dup
+  compat_quote_subs = quote_subs.drop 0
   # ``quoted''
   compat_quote_subs[2] = [:double, :constrained, /(^|[^#{CC_WORD};:}])(?:\[([^\]]+)\])?``(\S|\S#{CC_ALL}*?\S)''(?!#{CG_WORD})/m]
   # `quoted'
@@ -1352,7 +1352,7 @@ module Asciidoctor
     elsif ::String === input
       lines = ::RUBY_MIN_VERSION_2 ? input.lines : input.each_line.to_a
     elsif ::Array === input
-      lines = input.dup
+      lines = input.drop 0
     else
       raise ::ArgumentError, %(unsupported input type: #{input.class})
     end

--- a/lib/asciidoctor/block.rb
+++ b/lib/asciidoctor/block.rb
@@ -61,7 +61,7 @@ class Block < AbstractBlock
         # e.g., :subs => [:quotes]
         # subs attribute is not honored
         elsif ::Array === subs
-          @default_subs = subs.dup
+          @default_subs = subs.drop 0
           @attributes.delete 'subs'
         # e.g., :subs => :normal or :subs => 'normal'
         # subs attribute is not honored
@@ -90,7 +90,7 @@ class Block < AbstractBlock
     elsif ::String === raw_source
       @lines = Helpers.normalize_lines_from_string raw_source
     else
-      @lines = raw_source.dup
+      @lines = raw_source.drop 0
     end
   end
 

--- a/lib/asciidoctor/list.rb
+++ b/lib/asciidoctor/list.rb
@@ -57,7 +57,7 @@ class ListItem < AbstractBlock
     super parent, :list_item
     @text = text
     @level = parent.level
-    @subs = NORMAL_SUBS.dup
+    @subs = NORMAL_SUBS.drop 0
   end
 
   # Public: A convenience method that checks whether the text of this list item

--- a/lib/asciidoctor/reader.rb
+++ b/lib/asciidoctor/reader.rb
@@ -60,7 +60,7 @@ class Reader
       @lineno = cursor.lineno || 1 # IMPORTANT lineno assignment must proceed prepare_lines call!
     end
     @lines = data ? (prepare_lines data, opts) : []
-    @source_lines = @lines.dup
+    @source_lines = @lines.drop 0
     @mark = nil
     @look_ahead = 0
     @process_lines = true
@@ -91,7 +91,7 @@ class Reader
     elsif opts[:normalize]
       Helpers.normalize_lines_array data
     else
-      data.dup
+      data.drop 0
     end
   end
 
@@ -556,7 +556,7 @@ class Reader
   #
   # Returns A copy of the String Array of lines remaining in this Reader
   def lines
-    @lines.dup
+    @lines.drop 0
   end
 
   # Public: Get a copy of the remaining lines managed by this Reader joined as a String
@@ -1195,9 +1195,9 @@ class PreprocessorReader < Reader
   def skip_front_matter! data, increment_linenos = true
     front_matter = nil
     if data[0] == '---'
-      original_data = data.dup
-      front_matter = []
+      original_data = data.drop 0
       data.shift
+      front_matter = []
       @lineno += 1 if increment_linenos
       while !data.empty? && data[0] != '---'
         front_matter << data.shift

--- a/lib/asciidoctor/substitutors.rb
+++ b/lib/asciidoctor/substitutors.rb
@@ -1357,7 +1357,7 @@ module Substitutors
       end
 
       if modifier_operation
-        candidates ||= (defaults ? defaults.dup : [])
+        candidates ||= (defaults ? (defaults.drop 0) : [])
         case modifier_operation
         when :append
           candidates += resolved_keys
@@ -1614,7 +1614,7 @@ module Substitutors
     if (custom_subs = @attributes['subs'])
       @subs = (resolve_block_subs custom_subs, default_subs, @context) || []
     else
-      @subs = default_subs.dup
+      @subs = default_subs.drop 0
     end
 
     # QUESION delegate this logic to a method?


### PR DESCRIPTION
Using .drop(0) is 1.5x as fast as .dup.