### PR TITLE
Remove LOAD_PATH manipulation

### DIFF
--- a/lib/asciidoctor.rb
+++ b/lib/asciidoctor.rb
@@ -18,9 +18,6 @@ else
   autoload :StringScanner, 'strscan'
 end
 
-# ideally we should use require_relative instead of modifying the LOAD_PATH
-$:.unshift File.dirname __FILE__
-
 require 'asciidoctor/logging'
 
 # Public: Methods for parsing AsciiDoc input files and converting documents


### PR DESCRIPTION
We should rely on rubygems or bundler to add lib/ to $LOAD_PATH.