### PR TITLE
Escape quotation marks in image URI HTML attribute.

### DIFF
--- a/lib/asciidoctor/converter/html5.rb
+++ b/lib/asciidoctor/converter/html5.rb
@@ -551,11 +551,11 @@ Your browser does not support the audio tag.
         if svg
           img = (read_svg_contents node, target) || %(<span class="alt">#{node.alt}</span>)
         elsif obj
-          fallback = (node.attr? 'fallback') ? %(<img src="#{node.image_uri(node.attr 'fallback')}" alt="#{encode_quotes node.alt}"#{width_attr}#{height_attr}#{@void_element_slash}>) : %(<span class="alt">#{node.alt}</span>)
-          img = %(<object type="image/svg+xml" data="#{node.image_uri target}"#{width_attr}#{height_attr}>#{fallback}</object>)
+          fallback = (node.attr? 'fallback') ? %(<img src="#{encode_quotes node.image_uri(node.attr 'fallback')}" alt="#{encode_quotes node.alt}"#{width_attr}#{height_attr}#{@void_element_slash}>) : %(<span class="alt">#{node.alt}</span>)
+          img = %(<object type="image/svg+xml" data="#{encode_quotes node.image_uri target}"#{width_attr}#{height_attr}>#{fallback}</object>)
         end
       end
-      img ||= %(<img src="#{node.image_uri target}" alt="#{encode_quotes node.alt}"#{width_attr}#{height_attr}#{@void_element_slash}>)
+      img ||= %(<img src="#{encode_quotes node.image_uri target}" alt="#{encode_quotes node.alt}"#{width_attr}#{height_attr}#{@void_element_slash}>)
       if node.attr? 'link', nil, false
         img = %(<a class="image" href="#{node.attr 'link'}"#{(append_link_constraint_attrs node).join}>#{img}</a>)
       end

--- a/test/blocks_test.rb
+++ b/test/blocks_test.rb
@@ -2446,6 +2446,18 @@ image::#{image_uri}[Dot]
       assert_xpath %(/*[@class="imageblock"]//img[@src="#{image_uri}"][@alt="Dot"]), output, 1
     end
 
+    test 'escapes image uri when quotes are used in URI' do
+      input = <<-EOS
+image::"foo.png"[Dot]
+      EOS
+
+      output = using_test_webserver do
+        render_embedded_string input, :safe => :safe
+      end
+
+      assert_xpath %(/*[@class="imageblock"]//img[@src='"foo.png"'][@alt="Dot"]), output, 1
+    end
+
     test 'can handle embedded data uri images' do
       input = <<-EOS
 image::data:image/gif;base64,R0lGODlhAQABAIAAAAUEBAAAACwAAAAAAQABAAACAkQBADs=[Dot]


### PR DESCRIPTION
Fixes #2862.

This changes the HTML backend to escape quotes in image URI, since it is valid, albeit unusual, for an image URI to contain quote characters. This also adds a short test demonstrating this case.