### PR TITLE
resolves #2839 substitute attributes in target of custom block macro

### DIFF
--- a/lib/asciidoctor/parser.rb
+++ b/lib/asciidoctor/parser.rb
@@ -581,6 +581,11 @@ class Parser
             elsif block_macro_extensions && CustomBlockMacroRx =~ this_line &&
                 (extension = extensions.registered_for_block_macro? $1)
               target, content = $2, $3
+              if (target.include? ATTR_REF_HEAD) && (target = parent.sub_attributes target).empty? &&
+                (doc_attrs['attribute-missing'] || Compliance.attribute_missing) == 'drop-line'
+                attributes.clear
+                return
+              end
               if extension.config[:content_model] == :attributes
                 if content
                   document.parse_attributes content, extension.config[:pos_attrs] || [], :sub_input => true, :sub_result => false, :into => attributes


### PR DESCRIPTION
- substitute attributes in target of custom block macro
- drop custom block macro if target references missing attribute and attribute-missing is drop-line