### PR TITLE
resolves #2878 fix bug caused by unclosed quote in CSV table data

### DIFF
--- a/lib/asciidoctor/table.rb
+++ b/lib/asciidoctor/table.rb
@@ -591,11 +591,18 @@ class Table::ParserContext
       @buffer = ''
       cellspec = nil
       repeat = 1
-      if @format == 'csv' && !cell_text.empty? && cell_text.include?('"')
-        # this may not be perfect logic, but it hits the 99%
-        if cell_text.start_with?('"') && cell_text.end_with?('"')
-          # unquote
-          cell_text = cell_text.slice(1, cell_text.length - 2).strip
+      if @format == 'csv'
+        if 2 > cell_text.length
+          logger.error message_with_context 'malformed csv cell data', :source_location => @reader.cursor_at_prev_line
+        elsif !cell_text.empty? && cell_text.include?('"')
+          # this may not be perfect logic, but it hits the 99%
+          if cell_text.start_with?('"') && cell_text.end_with?('"')
+            # unquote
+            cell_text = cell_text.slice(1, cell_text.length - 2).strip
+          end
+
+          # collapse escaped quotes
+          cell_text = cell_text.squeeze('"')
         end
 
         # collapse escaped quotes

--- a/test/tables_test.rb
+++ b/test/tables_test.rb
@@ -1820,6 +1820,22 @@ C1,C2
       assert_xpath '/table/tbody/tr[2]/td[1]/p[text()="B1"]', output, 1
     end
 
+    test 'should log error but not crash if cell data has unclosed quote' do
+      input = <<-EOS
+,===
+a,b
+c,"
+,===
+      EOS
+      using_memory_logger do |logger|
+        output = convert_string_to_embedded input
+        assert_css 'table', output, 1
+        assert_css 'table td', output, 4
+        assert_xpath '(/table/td)[4]/p', output, 0
+        assert_message logger, :ERROR, '<stdin>: line 3: unclosed quote in CSV data; setting cell to empty', Hash
+      end
+    end
+
     test 'should preserve newlines in quoted CSV values' do
       input = <<-EOS
 [cols="1,1,1l"]


### PR DESCRIPTION
Fixes https://github.com/asciidoctor/asciidoctor/issues/2878

This fix prevents a `NoMethodError` crash from a strip call on nil, caused by a quotation mark character. This may not be the best fix and perhaps this code could use a makeover, but this solves the issue without changing anything else.