### PR TITLE
Fix crash caused by empty data after line continuation symbol

### DIFF
--- a/lib/asciidoctor/parser.rb
+++ b/lib/asciidoctor/parser.rb
@@ -2128,7 +2128,7 @@ class Parser
         value = ''
       elsif value.end_with? LINE_CONTINUATION, LINE_CONTINUATION_LEGACY
         con, value = value.slice(-2, 2), (value.slice 0, value.length - 2).rstrip
-        while reader.advance && !(next_line = reader.peek_line.lstrip).empty?
+        while reader.advance && (next_line = reader.peek_line) && !(next_line = next_line.lstrip).empty?
           if (keep_open = next_line.end_with? con)
             next_line = (next_line.slice 0, next_line.length - 2).rstrip
           end

--- a/test/document_test.rb
+++ b/test/document_test.rb
@@ -684,6 +684,12 @@ text
       assert_css '#content h1', output, 0
     end
 
+    test 'document with multiline attribute entry but only one line should not crash' do
+      input = ':foo: bar' + Asciidoctor::LINE_CONTINUATION
+      doc = document_from_string input
+      assert_equal 'bar', doc.attributes['foo']
+    end
+
     test 'should sanitize contents of HTML title element' do
       input = <<-EOS
 = *Document* image:logo.png[] _Title_ image:another-logo.png[another logo]


### PR DESCRIPTION
Fixes https://github.com/asciidoctor/asciidoctor/issues/2880

This is a simple fix that checks that `next_line` is not nil before attempting to call `lstrip` on it. It can be tested by checking that the following example `:t: t +` does not throw an Exception.