### PR TITLE
resolves #1360 preserve comment guard on callout when icons not enabled

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -27,6 +27,7 @@ Enhancements::
   * substitute attribute references in target of custom block macro (honoring attribute-missing setting) (#2839)
   * interpret `<.>` as an auto-numbered callout in verbatim blocks and callout lists (#2871)
   * require marker for items in callout list to have circumfix brackets (e.g., `<1>` instead of `1>`) (#2871)
+  * preserve comment guard in front of callout number in verbatim block if icons is not enabled (#1360)
 
 Fixes::
 

--- a/lib/asciidoctor.rb
+++ b/lib/asciidoctor.rb
@@ -757,15 +757,15 @@ module Asciidoctor
     #   <.> (auto-numbered)
     #
     # NOTE extract regexps are applied line-by-line, so we can use $ as end-of-line char
-    CalloutExtractRx = %r((?:(?://|#|--|;;) ?)?(\\)?<!?(|--)(\d+|\.)\2>(?=(?: ?\\?<!?\2(?:\d+|\.)\2>)*$))
+    CalloutExtractRx = %r(((?://|#|--|;;) ?)?(\\)?<!?(|--)(\d+|\.)\3>(?=(?: ?\\?<!?\3(?:\d+|\.)\3>)*$))
     CalloutExtractRxt = '(\\\\)?<()(\\d+|\\.)>(?=(?: ?\\\\?<(?:\\d+|\\.)>)*$)'
-    CalloutExtractRxMap = ::Hash.new {|h, k| h[k] = /(?:#{::Regexp.escape k} ?)?#{CalloutExtractRxt}/ }
+    CalloutExtractRxMap = ::Hash.new {|h, k| h[k] = /(#{::Regexp.escape k} ?)?#{CalloutExtractRxt}/ }
     # NOTE special characters have not been replaced when scanning
     CalloutScanRx = /\\?<!?(|--)(\d+|\.)\1>(?=(?: ?\\?<!?\1(?:\d+|\.)\1>)*#{CC_EOL})/
     # NOTE special characters have already been replaced when converting to an SGML format
-    CalloutSourceRx = %r((?:(?://|#|--|;;) ?)?(\\)?&lt;!?(|--)(\d+|\.)\2&gt;(?=(?: ?\\?&lt;!?\2(?:\d+|\.)\2&gt;)*#{CC_EOL}))
+    CalloutSourceRx = %r(((?://|#|--|;;) ?)?(\\)?&lt;!?(|--)(\d+|\.)\3&gt;(?=(?: ?\\?&lt;!?\3(?:\d+|\.)\3&gt;)*#{CC_EOL}))
     CalloutSourceRxt = "(\\\\)?&lt;()(\\d+|\\.)&gt;(?=(?: ?\\\\?&lt;(?:\\d+|\\.)&gt;)*#{CC_EOL})"
-    CalloutSourceRxMap = ::Hash.new {|h, k| h[k] = /(?:#{::Regexp.escape k} ?)?#{CalloutSourceRxt}/ }
+    CalloutSourceRxMap = ::Hash.new {|h, k| h[k] = /(#{::Regexp.escape k} ?)?#{CalloutSourceRxt}/ }
 
     # A Hash of regexps for lists used for dynamic access.
     ListRxMap = {

--- a/lib/asciidoctor/converter/html5.rb
+++ b/lib/asciidoctor/converter/html5.rb
@@ -1083,7 +1083,7 @@ Your browser does not support the video tag.
         src = node.icon_uri("callouts/#{node.text}")
         %(<img src="#{src}" alt="#{node.text}"#{@void_element_slash}>)
       else
-        %(<b class="conum">(#{node.text})</b>)
+        %(#{node.attributes['guard']}<b class="conum">(#{node.text})</b>)
       end
     end
 

--- a/lib/asciidoctor/substitutors.rb
+++ b/lib/asciidoctor/substitutors.rb
@@ -1102,11 +1102,11 @@ module Substitutors
     autonum = 0
     text.gsub(callout_rx) {
       # honor the escape
-      if $1
+      if $2
         # use sub since it might be behind a line comment
         $&.sub(RS, '')
       else
-        Inline.new(self, :callout, $3 == '.' ? (autonum += 1).to_s : $3, :id => @document.callouts.read_next_id).convert
+        Inline.new(self, :callout, $4 == '.' ? (autonum += 1).to_s : $4, :id => @document.callouts.read_next_id, :attributes => { 'guard' => $1 }).convert
       end
     }
   end
@@ -1448,11 +1448,11 @@ module Substitutors
         lineno = lineno + 1
         line.gsub(callout_rx) {
           # honor the escape
-          if $1
+          if $2
             # use sub since it might be behind a line comment
             $&.sub(RS, '')
           else
-            (callout_marks[lineno] ||= []) << $3
+            (callout_marks[lineno] ||= []) << [$1, $4]
             last = lineno
             nil
           end
@@ -1534,9 +1534,10 @@ module Substitutors
             end
           end
           if conums.size == 1
-            %(#{line}#{Inline.new(self, :callout, conums[0] == '.' ? (autonum += 1).to_s : conums[0], :id => @document.callouts.read_next_id).convert}#{tail})
+            guard, conum = conums[0]
+            %(#{line}#{Inline.new(self, :callout, conum == '.' ? (autonum += 1).to_s : conum, :id => @document.callouts.read_next_id, :attributes => { 'guard' => guard }).convert}#{tail})
           else
-            conums_markup = conums.map {|conum| Inline.new(self, :callout, conum == '.' ? (autonum += 1).to_s : conum, :id => @document.callouts.read_next_id).convert }.join ' '
+            conums_markup = conums.map {|guard, conum| Inline.new(self, :callout, conum == '.' ? (autonum += 1).to_s : conum, :id => @document.callouts.read_next_id, :attributes => { 'guard' => guard }).convert }.join ' '
             %(#{line}#{conums_markup}#{tail})
           end
         else

--- a/test/blocks_test.rb
+++ b/test/blocks_test.rb
@@ -3082,10 +3082,10 @@ exit 0 # <5><6>
 <6> Reports success
       EOS
       output = convert_string_to_embedded input, :safe => Asciidoctor::SafeMode::SAFE
-      assert_match(/<span class="content">coderay<\/span>.* <b class="conum">\(1\)<\/b>$/, output)
-      assert_match(/<span class="content">puts 'Hello, world!'<\/span>.* <b class="conum">\(2\)<\/b>$/, output)
-      assert_match(/puts html * <b class="conum">\(3\)<\/b> <b class="conum">\(4\)<\/b>$/, output)
-      assert_match(/exit.* <b class="conum">\(5\)<\/b> <b class="conum">\(6\)<\/b><\/code>/, output)
+      assert_match(/<span class="content">coderay<\/span>.* # <b class="conum">\(1\)<\/b>$/, output)
+      assert_match(/<span class="content">puts 'Hello, world!'<\/span>.* # <b class="conum">\(2\)<\/b>$/, output)
+      assert_match(/puts html.* # <b class="conum">\(3\)<\/b> <b class="conum">\(4\)<\/b>$/, output)
+      assert_match(/exit.* # <b class="conum">\(5\)<\/b> <b class="conum">\(6\)<\/b><\/code>/, output)
     end
 
     test 'should support autonumbered callout marks if source-highlighter attribute is coderay' do
@@ -3105,9 +3105,9 @@ puts html # <.>
 <.> Print to stdout
       EOS
       output = convert_string_to_embedded input, :safe => Asciidoctor::SafeMode::SAFE
-      assert_match(/<span class="content">coderay<\/span>.* <b class="conum">\(1\)<\/b> <b class="conum">\(2\)<\/b>$/, output)
-      assert_match(/<span class="content">puts 'Hello, world!'<\/span>.* <b class="conum">\(3\)<\/b>$/, output)
-      assert_match(/puts html * <b class="conum">\(4\)<\/b><\/code>/, output)
+      assert_match(/<span class="content">coderay<\/span>.* # <b class="conum">\(1\)<\/b> <b class="conum">\(2\)<\/b>$/, output)
+      assert_match(/<span class="content">puts 'Hello, world!'<\/span>.* # <b class="conum">\(3\)<\/b>$/, output)
+      assert_match(/puts html.* # <b class="conum">\(4\)<\/b><\/code>/, output)
       assert_css '.colist ol', output, 1
       assert_css '.colist ol li', output, 4
     end
@@ -3133,10 +3133,10 @@ exit 0 # <5><6>
 <6> Reports success
       EOS
       output = convert_string_to_embedded input, :safe => Asciidoctor::SafeMode::SAFE
-      assert_match(/<span class="content">coderay<\/span>.* <b class="conum">\(1\)<\/b>$/, output)
-      assert_match(/<span class="content">puts 'Hello, world!'<\/span>.* <b class="conum">\(2\)<\/b>$/, output)
-      assert_match(/puts html * <b class="conum">\(3\)<\/b> <b class="conum">\(4\)<\/b>$/, output)
-      assert_match(/exit.* <b class="conum">\(5\)<\/b> <b class="conum">\(6\)<\/b><\/pre>/, output)
+      assert_match(/<span class="content">coderay<\/span>.* # <b class="conum">\(1\)<\/b>$/, output)
+      assert_match(/<span class="content">puts 'Hello, world!'<\/span>.* # <b class="conum">\(2\)<\/b>$/, output)
+      assert_match(/puts html.* # <b class="conum">\(3\)<\/b> <b class="conum">\(4\)<\/b>$/, output)
+      assert_match(/exit.* # <b class="conum">\(5\)<\/b> <b class="conum">\(6\)<\/b><\/pre>/, output)
     end
 
     test 'should preserve space before callout on final line' do
@@ -3172,7 +3172,7 @@ print 'value' #<1>
       inputs.each do |input|
         output = convert_string_to_embedded input, :safe => Asciidoctor::SafeMode::SAFE, :attributes => { 'source-highlighter' => 'coderay' }
         output = output.gsub(/<\/?span.*?>/, '')
-        assert_includes output, '\'value\' <b class="conum">(1)</b>'
+        assert_includes output, '\'value\' #<b class="conum">(1)</b>'
       end
     end
 


### PR DESCRIPTION
- when icons are not enabled, preserve the comment guard in front of the callout number in verbatim blocks