### PR TITLE
resolves #2779 track imagesdir on image node and in catalog

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -34,6 +34,7 @@ Enhancements::
   * change AbstractBlock#find_by to honor return values :skip and :skip_children from filter block to skip node and its descendants or just its descendants, respectively (#2067)
   * add API to retrieve authors as array; use API in converters (#1042) (*@mogztter*)
   * add support for start attribute on source block to set starting line number when converting to DocBook (#2915)
+  * track imagesdir for image on node and in catalog (#2779)
 
 Fixes::
 

--- a/lib/asciidoctor/document.rb
+++ b/lib/asciidoctor/document.rb
@@ -82,6 +82,10 @@ module Asciidoctor
 # can take the process to completion by calling the {Document#convert} method.
 class Document < AbstractBlock
 
+  ImageReference = ::Struct.new :target, :imagesdir do
+    alias to_s target
+  end
+
   Footnote = ::Struct.new :index, :id, :text
 
   class AttributeEntry
@@ -646,7 +650,9 @@ class Document < AbstractBlock
     when :footnotes, :indexterms
       @catalog[type] << value
     else
-      @catalog[type] << value if @options[:catalog_assets]
+      if @options[:catalog_assets]
+        @catalog[type] << (type == :images ? (ImageReference.new value[0], value[1]) : value)
+      end
     end
   end
 

--- a/lib/asciidoctor/parser.rb
+++ b/lib/asciidoctor/parser.rb
@@ -570,7 +570,7 @@ class Parser
                 end
               end
               if blk_ctx == :image
-                document.register :images, target
+                document.register :images, [target, (attributes['imagesdir'] = doc_attrs['imagesdir'])]
                 # NOTE style is the value of the first positional attribute in the block attribute line
                 attributes['alt'] ||= style || (attributes['default-alt'] = Helpers.basename(target, true).tr('_-', ' '))
                 unless (scaledwidth = attributes.delete 'scaledwidth').nil_or_empty?

--- a/lib/asciidoctor/substitutors.rb
+++ b/lib/asciidoctor/substitutors.rb
@@ -670,8 +670,8 @@ module Substitutors
           # TODO remove this special case once titles use normal substitution order
           target = sub_attributes target
         end
-        doc.register(:images, target) unless type == 'icon'
         attrs = parse_attributes m[2], posattrs, :unescape_input => true
+        doc.register :images, [target, (attrs['imagesdir'] = doc_attrs['imagesdir'])] unless type == 'icon'
         attrs['alt'] ||= (attrs['default-alt'] = Helpers.basename(target, true).tr('_-', ' '))
         Inline.new(self, :image, nil, :type => type, :target => target, :attributes => attrs).convert
       }

--- a/test/document_test.rb
+++ b/test/document_test.rb
@@ -1173,7 +1173,7 @@ image::inner.png[]
       images = doc.catalog[:images]
       refute_empty images
       assert_equal 2, images.size
-      assert_equal images, ['outer.png', 'inner.png']
+      assert_equal images.map {|it| it.target }, ['outer.png', 'inner.png']
     end
   end
 

--- a/test/substitutions_test.rb
+++ b/test/substitutions_test.rb
@@ -848,7 +848,9 @@ context 'Substitutions' do
 
       using_memory_logger do |logger|
         sect = block_from_string input, :attributes => { 'data-uri' => '', 'iconsdir' => 'fixtures', 'docdir' => testdir }, :safe => :server, :catalog_assets => true
-        assert_includes sect.document.catalog[:images], 'fixtures/dot.gif'
+        assert 1, sect.document.catalog[:images].size
+        assert_equal 'fixtures/dot.gif', sect.document.catalog[:images][0].to_s
+        assert_nil sect.document.catalog[:images][0].imagesdir
         assert logger.empty?
       end
     end


### PR DESCRIPTION
- record the value of the imagesdir document attribute on the image node
- record the value of the imagesdir document attribute when registering the image