### PR TITLE
resolves #2918 add support for range syntax to highlight attribute on source block

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -74,6 +74,8 @@ Improvements::
   * normalize all whitespace in value of manpurpose attribute
   * make space before callout number after custom line comment character optional
   * parse attrlist on inline passthrough as a shorthand attribute syntax or literal role (#2910)
+  * add support for range syntax (.. delimiter) to highlight attribute on source block (#2918)
+  * add support for unbounded range to highlight attribute on source block (#2918)
 
 Documentation::
 

--- a/test/blocks_test.rb
+++ b/test/blocks_test.rb
@@ -3028,6 +3028,34 @@ puts 'Hello, World!'
       assert_xpath '//td[@class="line-numbers"]', output, 1
     end
 
+    test 'should highlight lines specified in highlight attribute if linenums is set and source-highlighter is coderay' do
+      %w(highlight="1,4-6" highlight=1;4..6 highlight=1;4..;!7).each do |highlight_attr|
+        input = <<-EOS
+:source-highlighter: coderay
+
+[source%linenums,java,#{highlight_attr}]
+----
+import static java.lang.System.out;
+
+public class HelloWorld {
+  public static void main(String[] args) {
+    out.println("Hello, World!");
+  }
+}
+----
+        EOS
+        output = convert_string_to_embedded input, :safe => Asciidoctor::SafeMode::SAFE
+        assert_css 'strong.highlighted', output, 4
+        assert_xpath '//strong[@class="highlighted"][text()="1"]', output, 1
+        assert_xpath '//strong[@class="highlighted"][text()="2"]', output, 0
+        assert_xpath '//strong[@class="highlighted"][text()="3"]', output, 0
+        assert_xpath '//strong[@class="highlighted"][text()="4"]', output, 1
+        assert_xpath '//strong[@class="highlighted"][text()="5"]', output, 1
+        assert_xpath '//strong[@class="highlighted"][text()="6"]', output, 1
+        assert_xpath '//strong[@class="highlighted"][text()="7"]', output, 0
+      end
+    end
+
     test 'should read source language from source-language document attribute if not specified on source block' do
       input = <<-EOS
 :source-highlighter: coderay


### PR DESCRIPTION
- add support for range syntax (.. delimiter) to highlight attribute on source block
- add support for unbounded range to highlight attribute on source block
- add test for highlight attribute on source block