### PR TITLE
resolves #2928 prevent warning about invalid `:asciidoc` option

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -57,6 +57,7 @@ Fixes::
   * fix crash when restoring passthroughs if passthrough role is enclosed in single quotes (#2882, #2883)
   * don't eagerly apply subs to inline attributes in general
   * make sure encoding of output file is UTF-8
+  * prevent warning about invalid `:asciidoc` option when using custom templates with Slim 4 (#2928)
 
 Improvements::
 

--- a/asciidoctor.gemspec
+++ b/asciidoctor.gemspec
@@ -51,7 +51,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'rake', '~> 10.0.0'
   s.add_development_dependency 'rspec-expectations', '~> 2.14.0'
   # slim is needed for testing custom templates
-  s.add_development_dependency 'slim', '~> 3.0.0'
+  s.add_development_dependency 'slim', '~> 4.0.0'
   # concurrent-ruby is defined in Gemfile due to enforcement of minimum required Ruby version
   #s.add_development_dependency 'concurrent-ruby', '~> 1.0.0'
   # tilt is needed for testing custom templates

--- a/lib/asciidoctor/converter/template.rb
+++ b/lib/asciidoctor/converter/template.rb
@@ -256,6 +256,7 @@ module Asciidoctor
             unless @active_engines[extsym]
               # NOTE slim doesn't get automatically loaded by Tilt
               Helpers.require_library 'slim' unless defined? ::Slim
+              ::Slim::Engine.define_options :asciidoc => {}
               # align safe mode of AsciiDoc embedded in Slim template with safe mode of current document
               # NOTE safe mode won't get updated if using template cache and changing safe mode
               (@engine_options[extsym][:asciidoc] ||= {})[:safe] ||= @safe if @safe && ::Slim::VERSION >= '3.0'


### PR DESCRIPTION
prevent warning about invalid `:asciidoc` option when using custom templates with Slim 4