### PR TITLE
resolves #2931 fix crash when child section of part is out of sequence

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -54,6 +54,7 @@ Fixes::
   * consolidate inner whitespace in prose in manpage output (#2890)
   * only apply subs to node attribute value if enclosed in single quotes (#2905)
   * don't hide URI scheme if target of link macro is a bare URI scheme
+  * fix crash when child section of part is out of sequence and section numbering is enabled (#2931)
   * fix crash when restoring passthroughs if passthrough role is enclosed in single quotes (#2882, #2883)
   * don't eagerly apply subs to inline attributes in general
   * make sure encoding of output file is UTF-8

--- a/lib/asciidoctor/section.rb
+++ b/lib/asciidoctor/section.rb
@@ -116,7 +116,8 @@ class Section < AbstractBlock
     elsif @level > 1
       Section === @parent ? %(#{@parent.sectnum(delimiter, delimiter)}#{@numeral}#{append}) : %(#{@numeral}#{append})
     else # @level == 0
-      %(#{Helpers.int_to_roman @numeral}#{append})
+      # NOTE coerce @numeral to int just in case not set; can happen if section nesting is out of sequence
+      %(#{Helpers.int_to_roman @numeral.to_i}#{append})
     end
   end
 

--- a/test/sections_test.rb
+++ b/test/sections_test.rb
@@ -1397,6 +1397,24 @@ text
       assert_xpath '//h3[@id="_section_2_2"][starts-with(text(), "2.2. ")]', output, 1
     end
 
+    test 'should not crash if child section of part is out of sequence and part numbering is disabled' do
+      input = <<-EOS
+= Document Title
+:doctype: book
+:sectnums:
+
+= Part
+
+=== Out of Sequence Section
+      EOS
+
+      using_memory_logger do |logger|
+        output = convert_string input
+        assert_xpath '//h1[text()="Part"]', output, 1
+        assert_xpath '//h3[text()=".1. Out of Sequence Section"]', output, 1 
+      end
+    end
+
     test 'should number parts when doctype is book and partnums attributes is set' do
       input = <<-EOS
 = Book Title


### PR DESCRIPTION
- fix crash when child section of part is out of sequence and section numbering is enabled