### PR TITLE
New attributes for Ruby constants (ruby-version, ruby-revision, etc).

### DIFF
--- a/lib/asciidoctor/document.rb
+++ b/lib/asciidoctor/document.rb
@@ -385,6 +385,14 @@ class Document < AbstractBlock
     attr_overrides['asciidoctor'] = ''
     attr_overrides['asciidoctor-version'] = VERSION
 
+    # Ruby constants added by Paulo França Lacerda (BlaisePoint Informática)
+    attr_overrides['ruby-engine']       = RUBY_ENGINE
+    attr_overrides['ruby-version']      = RUBY_VERSION
+    attr_overrides['ruby-revision']     = RUBY_REVISION
+    attr_overrides['ruby-patchlevel']   = RUBY_PATCHLEVEL
+    attr_overrides['ruby-platform']     = RUBY_PLATFORM
+    attr_overrides['ruby-release-date'] = RUBY_RELEASE_DATE
+
     attr_overrides['safe-mode-name'] = (safe_mode_name = SafeMode.name_for_value @safe)
     attr_overrides["safe-mode-#{safe_mode_name}"] = ''
     attr_overrides['safe-mode-level'] = @safe


### PR DESCRIPTION
Firstly, I'm embarrassingly newbie about SVN and such. Never used it in my whole life, so, please, forgive for any stupid thing I might have done here and, obviously, lead me in the right direction.

I've added Ruby constants ("ruby-version", "ruby-revision", etc) for informational purposes.
One of them I personally use in my doc's footer, like this:

ADOC:
`:last-update-label: Made with Asciidoctor {asciidoctor-version} (on Ruby {ruby-version} for Windows) in`

RESULT:
`Made with Asciidoctor 1.5.8 (on Ruby 2.5.3 for Windows) in 2018-10-22 13:17:18 -0300`
![footer](https://user-images.githubusercontent.com/17791112/47813167-04479d80-dd29-11e8-987c-94a211bbc599.png)
