### PR TITLE
Fixes #2963. Implement Table::Cell.block? and Table::Column.block?

### DIFF
--- a/lib/asciidoctor/table.rb
+++ b/lib/asciidoctor/table.rb
@@ -215,6 +215,10 @@ class Table::Column < AbstractNode
     end
     col_pcwidth
   end
+
+  def block?
+    false
+  end
 end
 
 # Public: Methods for managing the a cell in an AsciiDoc table.
@@ -362,6 +366,10 @@ class Table::Cell < AbstractNode
   # Public: Get the source line number where this block started
   def lineno
     @source_location && @source_location.lineno
+  end
+
+  def block?
+    false
   end
 
   def to_s

--- a/test/api_test.rb
+++ b/test/api_test.rb
@@ -1196,6 +1196,28 @@ Getting Real details the business, design, programming, and marketing principles
       assert_equal '', cell.text
     end
 
+    test 'should not crash if block? is called on Table Cell' do
+      input = <<-EOS
+|===
+|a
+|===
+      EOS
+      table = (document_from_string input).blocks[0]
+      cell = table.rows.body[0][0]
+      assert_equal false, cell.block?
+    end
+
+    test 'should not crash if block? is called on Table Column' do
+      input = <<-EOS
+|===
+|a
+|===
+      EOS
+      table = (document_from_string input).blocks[0]
+      column = table.rows.body[0][0].column
+      assert_equal false, column.block?
+    end
+
     test 'should set option on node when set_option is called' do
       input = <<-EOS
 . three


### PR DESCRIPTION
This PR simply implements the method `block?` for `Table::Cell` and `Table::Column` so that they no longer raise an exception when being called.