### PR TITLE
Pass the environment variables to popen3 using the builtin parameter

### DIFF
--- a/test/invoker_test.rb
+++ b/test/invoker_test.rb
@@ -676,8 +676,8 @@ Sample *AsciiDoc*
     cmd = %(#{ruby} #{executable} -d inline -o - -s #{input_path})
     result = Open3.popen3({'TZ' => 'EST+5'}, cmd) {|_, out| out.read }
     doctime, localtime = result.lines.map {|l| l.chomp }
-    assert doctime.end_with?(' -0500')
-    assert localtime.end_with?(' -0500')
+    assert doctime.end_with?(' -0500'), %(doctime is supposed to end with ' -0500' but is equal to #{doctime})
+    assert localtime.end_with?(' -0500'), %(localtime is supposed to end with ' -0500' but is equal to #{localtime})
   end
 
   test 'should use SOURCE_DATE_EPOCH as modified time of input file and local time' do


### PR DESCRIPTION
This is just a nitpick.
To provide environment variables to popen3, it's best to use a hash as parameter to the popen3 method as shown in https://docs.ruby-lang.org/en/2.5.0/Open3.html#method-i-popen3
This way you also don't need a mechanism to set the environment variables that you want to change.