### PR TITLE
Take in account SOURCE_DATE_EPOCH when testing against timezones

### DIFF
--- a/test/invoker_test.rb
+++ b/test/invoker_test.rb
@@ -686,8 +686,6 @@ Sample *AsciiDoc*
       end
       if old_source_date_epoch
           ENV['SOURCE_DATE_EPOCH'] = old_source_date_epoch
-      else
-          ENV.delete 'SOURCE_DATE_EPOCH'
       end
     end
   end

--- a/test/invoker_test.rb
+++ b/test/invoker_test.rb
@@ -670,6 +670,8 @@ Sample *AsciiDoc*
     input_path = fixture_path 'doctime-localtime.adoc'
     cmd = %(#{ruby} #{executable} -d inline -o - -s #{input_path})
     old_tz = ENV['TZ']
+    # If this env variable is not unset, the timezone will always be the one set there
+    old_source_date_epoch = ENV.delete 'SOURCE_DATE_EPOCH'
     begin
       ENV['TZ'] = 'UTC'
       result = Open3.popen3(cmd) {|_, out| out.read }
@@ -682,6 +684,11 @@ Sample *AsciiDoc*
       else
         ENV.delete 'TZ'
       end
+      if old_source_date_epoch
+          ENV['SOURCE_DATE_EPOCH'] = old_source_date_epoch
+      else
+          ENV.delete 'SOURCE_DATE_EPOCH'
+      end
     end
   end
 
@@ -691,6 +698,8 @@ Sample *AsciiDoc*
     input_path = fixture_path 'doctime-localtime.adoc'
     cmd = %(#{ruby} #{executable} -d inline -o - -s #{input_path})
     old_tz = ENV['TZ']
+    # If this env variable is not unset, the timezone will always be the one set there
+    old_source_date_epoch = ENV.delete 'SOURCE_DATE_EPOCH'
     begin
       ENV['TZ'] = 'EST+5'
       result = Open3.popen3(cmd) {|_, out| out.read }
@@ -702,6 +711,11 @@ Sample *AsciiDoc*
         ENV['TZ'] = old_tz
       else
         ENV.delete 'TZ'
+      end
+      if old_source_date_epoch
+          ENV['SOURCE_DATE_EPOCH'] = old_source_date_epoch
+      else
+          ENV.delete 'SOURCE_DATE_EPOCH'
       end
     end
   end


### PR DESCRIPTION
Just lost 3 hours trying to figure out why, when running in a reproducible build environment, this timezone test was failing. Silly me! :laughing: 
Anyway, this patch allows you to run the tests properly in a reproducible builds environment (aka with `SOURCE_DATE_EPOCH` set).