### PR TITLE
Refactor the timezone-related tests to use the usual invoke_cli_to_buffer instead of popen3

### DIFF
--- a/test/fixtures/doctime-localtime.adoc
+++ b/test/fixtures/doctime-localtime.adoc
@@ -1,2 +1,0 @@
-{doctime}
-{localtime}

--- a/test/invoker_test.rb
+++ b/test/invoker_test.rb
@@ -665,43 +665,51 @@ Sample *AsciiDoc*
   end
 
   test 'should show timezone as UTC if system TZ is set to UTC' do
-    ruby = File.join RbConfig::CONFIG['bindir'], RbConfig::CONFIG['ruby_install_name']
-    executable = File.join ASCIIDOCTOR_PROJECT_DIR, 'bin', 'asciidoctor'
-    input_path = fixture_path 'doctime-localtime.adoc'
-    cmd = %(#{ruby} #{executable} -d inline -o - -s #{input_path})
-    old_tz = ENV['TZ']
+    old_tz = ENV.delete 'TZ'
+    # If this env variable is not unset, the timezone will always be the one set there
+    old_source_date_epoch = ENV.delete 'SOURCE_DATE_EPOCH'
     begin
       ENV['TZ'] = 'UTC'
-      result = Open3.popen3(cmd) {|_, out| out.read }
-      doctime, localtime = result.lines.map {|l| l.chomp }
-      assert doctime.end_with?(' UTC')
-      assert localtime.end_with?(' UTC')
-    rescue
-      if old_tz
-        ENV['TZ'] = old_tz
-      else
-        ENV.delete 'TZ'
-      end
-    end
-  end
-
-  test 'should show timezone as offset if system TZ is not set to UTC' do
-    ruby = File.join RbConfig::CONFIG['bindir'], RbConfig::CONFIG['ruby_install_name']
-    executable = File.join ASCIIDOCTOR_PROJECT_DIR, 'bin', 'asciidoctor'
-    input_path = fixture_path 'doctime-localtime.adoc'
-    cmd = %(#{ruby} #{executable} -d inline -o - -s #{input_path})
-    old_tz = ENV['TZ']
-    begin
-      ENV['TZ'] = 'EST+5'
-      result = Open3.popen3(cmd) {|_, out| out.read }
-      doctime, localtime = result.lines.map {|l| l.chomp }
-      assert doctime.end_with?(' -0500')
-      assert localtime.end_with?(' -0500')
+      sample_filepath = fixture_path 'sample.asciidoc'
+      invoker = invoke_cli_to_buffer %w(-o /dev/null), sample_filepath
+      doc = invoker.document
+      assert (doc.attr 'doctime').end_with?(' UTC'), %(doctime is supposed to end with ' UTC' but is equal to #{doc.attr 'doctime'})
+      assert (doc.attr 'localtime').end_with?(' UTC'), %(localtime is supposed to end with ' UTC' but is equal to #{doc.attr 'localtime'})
     ensure
       if old_tz
         ENV['TZ'] = old_tz
       else
         ENV.delete 'TZ'
+      end
+      if old_source_date_epoch
+        ENV['SOURCE_DATE_EPOCH'] = old_source_date_epoch
+      else
+        ENV.delete 'SOURCE_DATE_EPOCH'
+      end
+    end
+  end
+
+  test 'should show timezone as offset if system TZ is not set to UTC' do
+    old_tz = ENV.delete 'TZ'
+    # If this env variable is not unset, the timezone will always be the one set there
+    old_source_date_epoch = ENV.delete 'SOURCE_DATE_EPOCH'
+    begin
+      ENV['TZ'] = 'EST'
+      sample_filepath = fixture_path 'sample.asciidoc'
+      invoker = invoke_cli_to_buffer %w(-o /dev/null), sample_filepath
+      doc = invoker.document
+      assert (doc.attr 'doctime').end_with?(' -0500'), %(doctime is supposed to end with ' -0500' but is equal to #{doc.attr 'doctime'})
+      assert (doc.attr 'localtime').end_with?(' -0500'), %(localtime is supposed to end with ' -0500' but is equal to #{doc.attr 'localtime'})
+    ensure
+      if old_tz
+        ENV['TZ'] = old_tz
+      else
+        ENV.delete 'TZ'
+      end
+      if old_source_date_epoch
+        ENV['SOURCE_DATE_EPOCH'] = old_source_date_epoch
+      else
+        ENV.delete 'SOURCE_DATE_EPOCH'
       end
     end
   end


### PR DESCRIPTION
The idea is to try to keep the same way of running the tests.
It is not required to fork a new process here as the call to `::Time.now` calls glibc under the hood which will take in account the environment variable dynamically.

This PR embeds #2969. Keeping both open in case you want to handle the 2 issues separately.
If this PR is ok with you we can close #2968.