### PR TITLE
resolves #2106 make syntax highlighter pluggable

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,7 @@ env:
   global:
   # use system libraries to speed up installation of nokogiri
   - NOKOGIRI_USE_SYSTEM_LIBRARIES=true
+  - PYGMENTS=true
 script: bundle exec rake coverage test:all
 after_success: bundle exec rake build:dependents
 #notifications:

--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -19,6 +19,7 @@ Enhancements::
 
   * drop support for Ruby < 2.3 and JRuby < 9.1 and remove workarounds (#2764)
   * drop support for Slim < 3 (#2998)
+  * make syntax highlighter pluggable; extract all logic into adapter classes (#2106)
   * add support for start attribute when using prettify to highlight source blocks with line numbering enabled
   * use String#encode to encode String as UTF-8 instead of using String#force_encoding (#2764)
   * add FILE_READ_MODE, URI_READ_MODE, and FILE_WRITE_MODE constants to control open mode when reading files and URIs and writing files (#2764)
@@ -27,21 +28,23 @@ Enhancements::
   * add support for the `muted` option on vimeo videos (allows autoplay to work in Chrome) (#3014)
   * use value of prettify-theme attribute as is if it starts with http:// or https:// (#3020)
   * allow icontype to be set using icons attribute (#2953)
+  * when using a server-side syntax highlighter, highlight content of source block even if source language is not set (#3027)
 
 Improvements::
 
   * propagate document ID to DocBook output (#3011)
-  * highlight contents of source block even if source language is not set (#3027)
   * refactor code to use modern Hash syntax
   * define LIB_DIR constant; rename *_PATH constants to *_DIR constants to be consistent with RubyGems terminology (#2764)
   * only define ROOT_DIR if not already defined (for compatibility with Asciidoctor.js)
   * move custom docinfo content in footer below built-in docinfo content in footer in HTML converter (#3017)
   * read and write files using File methods instead of IO methods (#2995)
   * value comparison in AbstractNode#attr? is only performed if expected value is truthy
+  * align default CodeRay style with style for other syntax highlighters (#2106)
 
 Bug Fixes::
 
   * don't fail to parse Markdown-style quote block that only contains attribution line (#2989)
+  * don't fail if value of pygments-style attribute is not recognized; gracefully fallback to default style (#2106)
   * do not alter the $LOAD_PATH (#2764)
   * remove conditional comment for IE in output of built-in HTML converter; fixes sidebar table of contents (#2983)
   * fix styling of source blocks with linenums enabled when using prettify as syntax highlighter (#640)
@@ -57,6 +60,7 @@ Bug Fixes::
   * Reader#push_include should not fail if data is nil
   * fix deprecated ERB trim mode that was causing warning (#3006)
   * move time anchor after query string on vimeo video to avoid dropping options
+  * allow color for generic text, line numbers, and line number border to inherit from Pygments style (#2106)
 
 Build / Infrastructure::
 

--- a/Gemfile
+++ b/Gemfile
@@ -3,6 +3,10 @@ source 'https://rubygems.org'
 # Look in asciidoctor.gemspec for runtime and development dependencies
 gemspec
 
+group :development do
+  gem 'pygments.rb' if ENV['PYGMENTS']
+end
+
 group :doc do
   gem 'yard'
   gem 'yard-tomdoc'

--- a/data/stylesheets/asciidoctor-default.css
+++ b/data/stylesheets/asciidoctor-default.css
@@ -111,6 +111,7 @@ h1 strong,h2 strong,h3 strong,#toctitle strong,.sidebarblock>.content>.title str
 :not(pre)>code.nowrap{white-space:nowrap}
 pre{color:rgba(0,0,0,.9);font-family:"Droid Sans Mono","DejaVu Sans Mono",monospace;line-height:1.45;text-rendering:optimizeSpeed}
 pre code,pre pre{color:inherit;font-size:inherit;line-height:inherit}
+pre.nowrap,pre.nowrap pre{white-space:pre;word-wrap:normal}
 em em{font-style:normal}
 strong strong{font-weight:400}
 .keyseq{color:rgba(51,51,51,.8)}
@@ -203,31 +204,32 @@ table.tableblock #preamble>.sectionbody>[class="paragraph"]:first-of-type p{font
 .sidebarblock>:last-child{margin-bottom:0}
 .sidebarblock>.content>.title{color:#7a2518;margin-top:0;text-align:center}
 .exampleblock>.content>:last-child>:last-child,.exampleblock>.content .olist>ol>li:last-child>:last-child,.exampleblock>.content .ulist>ul>li:last-child>:last-child,.exampleblock>.content .qlist>ol>li:last-child>:last-child,.sidebarblock>.content>:last-child>:last-child,.sidebarblock>.content .olist>ol>li:last-child>:last-child,.sidebarblock>.content .ulist>ul>li:last-child>:last-child,.sidebarblock>.content .qlist>ol>li:last-child>:last-child{margin-bottom:0}
-.literalblock pre,.listingblock pre:not(.highlight),.listingblock pre[class="highlight"],.listingblock pre[class^="highlight "],.listingblock pre.CodeRay{background:#f7f7f8}
-.sidebarblock .literalblock pre,.sidebarblock .listingblock pre:not(.highlight),.sidebarblock .listingblock pre[class="highlight"],.sidebarblock .listingblock pre[class^="highlight "],.sidebarblock .listingblock pre.CodeRay{background:#f2f1f1}
-.literalblock pre,.literalblock pre[class],.listingblock pre,.listingblock pre[class]{-webkit-border-radius:4px;border-radius:4px;word-wrap:break-word;overflow-x:auto;padding:1em;font-size:.8125em}
-@media screen and (min-width:768px){.literalblock pre,.literalblock pre[class],.listingblock pre,.listingblock pre[class]{font-size:.90625em}}
-@media screen and (min-width:1280px){.literalblock pre,.literalblock pre[class],.listingblock pre,.listingblock pre[class]{font-size:1em}}
-.literalblock pre.nowrap,.literalblock pre.nowrap pre,.listingblock pre.nowrap,.listingblock pre.nowrap pre{white-space:pre;word-wrap:normal}
+.literalblock pre,.listingblock>.content>pre{-webkit-border-radius:4px;border-radius:4px;word-wrap:break-word;overflow-x:auto;padding:1em;font-size:.8125em}
+@media screen and (min-width:768px){.literalblock pre,.listingblock>.content>pre{font-size:.90625em}}
+@media screen and (min-width:1280px){.literalblock pre,.listingblock>.content>pre{font-size:1em}}
 .literalblock.output pre{color:#f7f7f8;background:rgba(0,0,0,.9)}
-.listingblock pre.highlightjs{padding:0}
-.listingblock pre.highlightjs>code{padding:1em;-webkit-border-radius:4px;border-radius:4px}
+.listingblock>.content>pre:not(.highlight),.listingblock>.content>pre[class="highlight"],.listingblock>.content>pre[class^="highlight "]{background:#f7f7f8}
+.sidebarblock .listingblock>.content>pre:not(.highlight),.sidebarblock .listingblock>.content>pre[class="highlight"],.sidebarblock .listingblock>.content>pre[class^="highlight "]{background:#f2f1f1}
 .listingblock>.content{position:relative}
 .listingblock code[data-lang]::before{display:none;content:attr(data-lang);position:absolute;font-size:.75em;top:.425rem;right:.5rem;line-height:1;text-transform:uppercase;color:inherit;opacity:.5}
 .listingblock:hover code[data-lang]::before{display:block}
 .listingblock.terminal pre .command::before{content:attr(data-prompt);padding-right:.5em;color:inherit;opacity:.5}
 .listingblock.terminal pre .command:not([data-prompt])::before{content:"$"}
+.listingblock pre.highlightjs{padding:0}
+.listingblock pre.highlightjs>code{padding:1em;-webkit-border-radius:4px;border-radius:4px}
 .listingblock pre.prettyprint{border-width:0}
+.prettyprint{background:#f7f7f8}
 pre.prettyprint .linenums{line-height:1.45;margin-left:2em}
 pre.prettyprint li{background:none;list-style-type:inherit;padding-left:0}
 pre.prettyprint li code[data-lang]::before{opacity:1}
 pre.prettyprint li:not(:first-child) code[data-lang]::before{display:none}
-table.pyhltable{border-collapse:separate;border:0;margin-bottom:0;background:none}
-table.pyhltable td{color:inherit;vertical-align:top;padding:0;line-height:1.45}
-table.pyhltable td.code{padding-left:.75em}
-pre.pygments .lineno,table.pyhltable td:not(.code){border-right:1px solid currentColor;opacity:.35;padding-right:.5em}
-pre.pygments .lineno{display:inline-block;margin-right:.25em}
-table.pyhltable .linenodiv{background:none!important;padding-right:0!important}
+table.pygments-table{border-collapse:separate;border:0;margin-bottom:0;background:none}
+table.pygments-table td{color:inherit;vertical-align:top;padding:0;line-height:inherit;white-space:normal}
+table.pygments-table td.code{padding-left:.75em}
+pre.pygments .lineno,table.pygments-table td:not(.code){border-right:1px solid currentColor;opacity:.35}
+pre.pygments .lineno{display:inline-block;margin-right:.75em}
+pre.pygments .lineno::before{content:"";margin-right:-.125em}
+table.pygments-table td:not(.code){padding-right:.5em}
 .quoteblock{margin:0 1em 1.25em 1.5em;display:table}
 .quoteblock>.title{margin-left:-1.5em;margin-bottom:.75em}
 .quoteblock blockquote,.quoteblock p{color:rgba(0,0,0,.85);font-size:1.15rem;line-height:1.75;word-spacing:.1em;letter-spacing:0;font-style:italic;text-align:justify}

--- a/data/stylesheets/coderay-asciidoctor.css
+++ b/data/stylesheets/coderay-asciidoctor.css
@@ -1,14 +1,12 @@
 /* Stylesheet for CodeRay to match GitHub theme | MIT License | http://foundation.zurb.com */
-/*pre.CodeRay {background-color:#f7f7f8;}*/
-.CodeRay .line-numbers{border-right:1px solid #d8d8d8;padding:0 0.5em 0 .25em}
-.CodeRay span.line-numbers{display:inline-block;margin-right:.5em;color:rgba(0,0,0,.3)}
-.CodeRay .line-numbers strong{color:rgba(0,0,0,.4)}
-table.CodeRay{border-collapse:separate;border-spacing:0;margin-bottom:0;border:0;background:none}
-table.CodeRay td{vertical-align: top;line-height:1.45}
+pre.CodeRay{background:#f7f7f8}
+.CodeRay .line-numbers{border-right:1px solid currentColor;opacity:.35;padding:0 .5em 0 0}
+.CodeRay span.line-numbers{display:inline-block;margin-right:.75em}
+.CodeRay .line-numbers strong{color:#000}
+table.CodeRay{border-collapse:separate;border:0;margin-bottom:0;background:none}
+table.CodeRay td{vertical-align:top;line-height:inherit}
 table.CodeRay td.line-numbers{text-align:right}
-table.CodeRay td.line-numbers>pre{padding:0;color:rgba(0,0,0,.3)}
-table.CodeRay td.code{padding:0 0 0 .5em}
-table.CodeRay td.code>pre{padding:0}
+table.CodeRay td.code{padding:0 0 0 .75em}
 .CodeRay .debug{color:#fff !important;background:#000080 !important}
 .CodeRay .annotation{color:#007}
 .CodeRay .attribute-name{color:#000080}

--- a/lib/asciidoctor.rb
+++ b/lib/asciidoctor.rb
@@ -1485,9 +1485,8 @@ module Asciidoctor
             copy_user_stylesheet = true
           end
         end
-        copy_coderay_stylesheet = (doc.attr? 'source-highlighter', 'coderay') && (doc.attr 'coderay-css', 'class') == 'class'
-        copy_pygments_stylesheet = (doc.attr? 'source-highlighter', 'pygments') && (doc.attr 'pygments-css', 'class') == 'class'
-        if copy_asciidoctor_stylesheet || copy_user_stylesheet || copy_coderay_stylesheet || copy_pygments_stylesheet
+        copy_syntax_hl_stylesheet = (syntax_hl = doc.syntax_highlighter) && (syntax_hl.write_stylesheet? doc)
+        if copy_asciidoctor_stylesheet || copy_user_stylesheet || copy_syntax_hl_stylesheet
           stylesoutdir = doc.normalize_system_path(stylesdir, outdir, doc.safe >= SafeMode::SAFE ? outdir : nil)
           if mkdirs
             Helpers.mkdir_p stylesoutdir
@@ -1512,12 +1511,7 @@ module Asciidoctor
               ::File.write stylesheet_dest, stylesheet_data, mode: FILE_WRITE_MODE
             end
           end
-
-          if copy_coderay_stylesheet
-            Stylesheets.instance.write_coderay_stylesheet stylesoutdir
-          elsif copy_pygments_stylesheet
-            Stylesheets.instance.write_pygments_stylesheet stylesoutdir, (doc.attr 'pygments-style')
-          end
+          syntax_hl.write_stylesheet doc, stylesoutdir if copy_syntax_hl_stylesheet
         end
       end
       doc
@@ -1600,6 +1594,7 @@ require_relative 'asciidoctor/path_resolver'
 require_relative 'asciidoctor/reader'
 require_relative 'asciidoctor/section'
 require_relative 'asciidoctor/stylesheets'
+require_relative 'asciidoctor/syntax_highlighter'
 require_relative 'asciidoctor/table'
 
 # this require is satisfied by the Asciidoctor.js build; it supplies compile and runtime overrides for Asciidoctor.js

--- a/lib/asciidoctor/syntax_highlighter.rb
+++ b/lib/asciidoctor/syntax_highlighter.rb
@@ -1,0 +1,232 @@
+module Asciidoctor
+  # Public: A pluggable adapter for integrating a syntax (aka code) highlighter into AsciiDoc processing.
+  #
+  # There are two types of syntax highlighter adapters. The first performs syntax highlighting during the convert phase.
+  # This adapter type must define a highlight? method that returns true. The companion highlight method will then be
+  # called to handle the :specialcharacters substitution for source blocks. The second assumes syntax highlighting is
+  # performed on the client (e.g., when the HTML document is loaded). This adapter type must define a docinfo? method
+  # that returns true. The companion docinfo method will then be called to insert markup into the output document. The
+  # docinfo functionality is available to both adapter types.
+  #
+  # Asciidoctor provides several built-in adapters, including coderay, pygments, highlight.js, html-pipeline, and
+  # prettify. Additional adapters can be registered using SyntaxHighlighter.register or by supplying a custom factory.
+  module SyntaxHighlighter
+    # Public: Returns the String name of this syntax highlighter for referencing it in messages and option names.
+    attr_reader :name
+
+    def initialize name, backend = 'html5', opts = {}
+      @name = @pre_class = name
+    end
+
+    # Public: Indicates whether this syntax highlighter has docinfo (i.e., markup) to insert into the output document at
+    # the specified location.
+    #
+    # location - The Symbol representing the location slot (:head or :footer).
+    #
+    # Returns a Boolean indicating whether the docinfo method should be called for this location.
+    def docinfo? location; end
+
+    # Public: Generates docinfo markup to insert in the output document at the specified location.
+    #
+    # location - The Symbol representing the location slot (:head or :footer).
+    #
+    # Return the String markup to insert.
+    def docinfo location
+      raise ::NotImplementedError, %(#{SyntaxHighlighter.name} must implement the docinfo method if the docinfo? method returns true)
+    end
+
+    # Public: Indicates whether highlighting is handled by this syntax highlighter or by the client.
+    #
+    # Returns a Boolean indicating whether the highlight method should be used to handle the :specialchars substitution.
+    def highlight?; end
+
+    # Public: Highlights the specified source when this source block is being converted.
+    #
+    # If the source contains callout marks, the caller assumes the source remains on the same lines and no closing tags
+    # are added to the end of each line. If the source gets shifted by one or more lines, this method must return a
+    # tuple containing the highlighted source and the number of lines by which the source was shifted.
+    #
+    # node   - The source Block to syntax highlight.
+    # source - The raw source text String of this source block (after preprocessing).
+    # lang   - The source language String specified on this block (e.g., ruby).
+    # opts   - A Hash of options that control syntax highlighting:
+    #          :callouts - A Hash of callouts extracted from the source, indexed by line number (1-based) (optional).
+    #          :css_mode - The Symbol CSS mode (:class or :inline).
+    #          :highlight_lines - A 1-based Array of Integer line numbers to highlight (i.e., tint) (optional).
+    #          :line_numbers - A Symbol indicating whether line numbers are enabled (:table or :inline) (optional).
+    #          :start_line_number - The Integer line number (1-based) to start with when numbering lines (default: 1).
+    #          :style - The String style (aka theme) to use for colorizing the code (optional).
+    #
+    # Returns the highlighted source String or a tuple of the highlighted source String and an Integer line offset.
+    def highlight node, source, lang, opts
+      raise ::NotImplementedError, %(#{SyntaxHighlighter.name} must implement the highlight method if the highlight? method returns true)
+    end
+
+    # Public: Format the highlighted source for inclusion in an HTML document.
+    #
+    # node   - The source Block being processed.
+    # lang   - The source language String for this Block (e.g., ruby).
+    # opts   - A Hash of options that control syntax highlighting:
+    #          :nowrap - A Boolean that indicates whether wrapping should be disabled (optional).
+    #
+    # Returns the highlighted source String wrapped in preformatted tags (e.g., pre and code)
+    def format node, lang, opts
+      raise ::NotImplementedError, %(#{SyntaxHighlighter.name} must implement the format method)
+    end
+
+    # Public: Indicates whether this syntax highlighter wants to write a stylesheet to disk.
+    #
+    # Only called if both the linkcss and copycss attributes are set on the document.
+    #
+    # doc - The Document in which this syntax highlighter is being used.
+    #
+    # Returns a Boolean indicating whether the write_stylesheet method should be called.
+    def write_stylesheet? doc; end
+
+    # Public: Writes the stylesheet to support the highlighted source(s) to disk.
+    #
+    # doc    - The Document in which this syntax highlighter is being used.
+    # to_dir - The absolute String path of the stylesheet output directory.
+    #
+    # Returns nothing.
+    def write_stylesheet doc, to_dir
+      raise ::NotImplementedError, %(#{SyntaxHighlighter.name} must implement the write_stylesheet method if the write_stylesheet? method returns true)
+    end
+
+    private_class_method def self.included into
+      into.extend Config
+    end
+
+    module Config
+      # Public: Statically register the current class in the registry for the specified names.
+      #
+      # Returns nothing.
+      private def register_for *names
+        SyntaxHighlighter.register self, *names
+      end
+    end
+
+    module Factory
+      # Public: Associates the syntax highlighter class or object with the specified names.
+      #
+      # Returns nothing.
+      def register syntax_highlighter, *names
+        names.each {|name| registry[name] = syntax_highlighter }
+      end
+
+      # Public: Retrieves the syntax highlighter class or object registered for the specified name.
+      #
+      # name - The String name of the syntax highlighter to retrieve.
+      #
+      # Returns the SyntaxHighlighter class or instance registered for this name.
+      def for name
+        registry[name]
+      end
+
+      # Public: Resolves the name to a syntax highlighter instance, if found in the registry.
+      #
+      # name    - The String name of the syntax highlighter to create.
+      # backend - The String name of the backend for which this syntax highlighter is being used (default: 'html5').
+      # opts    - A Hash of options providing information about the context in which this syntax highlighter is used:
+      #           :doc - The Document for which this syntax highlighter was created.
+      #
+      # Returns a SyntaxHighlighter instance for the specified name.
+      def create name, backend = 'html5', opts = {}
+        if (syntax_hl = self.for name)
+          syntax_hl = syntax_hl.new name, backend, opts if ::Class === syntax_hl
+          raise ::NameError, %(#{syntax_hl.class.name} must specify a value for `name') unless syntax_hl.name
+          syntax_hl
+        end
+      end
+
+      private def registry
+        @registry ||= {}
+      end
+    end
+
+    module DefaultFactory
+      include Factory
+
+      private
+
+      def registry
+        @@registry
+      end
+
+      @@registry = {}
+
+      unless RUBY_ENGINE == 'opal'
+        public
+
+        def register syntax_highlighter, *names
+          @@mutex.owned? ? super : @@mutex.synchronize { super }
+        end
+
+        # In addition to retrieving the syntax highlighter class or object registered for the specified name, this
+        # method will lazy require and register additional built-in implementations (coderay, pygments, and prettify).
+        # Refer to {Factory#for} for parameters and return value.
+        def for name
+          @@registry.fetch name do
+            @@mutex.synchronize do
+              @@registry.fetch name do
+                if (script_path = PROVIDED[name])
+                  require_relative script_path
+                  @@registry[name]
+                else
+                  @@registry[name] = nil
+                end
+              end
+            end
+          end
+        end
+
+        private
+
+        @@mutex = ::Mutex.new
+
+        PROVIDED = {
+          'coderay' => 'syntax_highlighter/coderay',
+          'prettify' => 'syntax_highlighter/prettify',
+          'pygments' => 'syntax_highlighter/pygments',
+        }
+      end
+    end
+
+    class CustomFactory
+      include Factory
+
+      def initialize registry = nil
+        @registry = registry
+      end
+    end
+
+    class DefaultFactoryProxy < CustomFactory
+      include DefaultFactory
+
+      def for name
+        (@registry.key? name) ? @registry[name] : super
+      end
+    end
+
+    extend DefaultFactory # exports static methods
+
+    class Base
+      include SyntaxHighlighter
+
+      def format node, lang, opts
+        class_attr_val = opts[:nowrap] ? %(#{@pre_class} highlight nowrap) : %(#{@pre_class} highlight)
+        if (transform = opts[:transform])
+          pre = { 'class' => class_attr_val }
+          code = lang ? { 'data-lang' => lang } : {}
+          transform[pre, code]
+          %(<pre#{pre.map {|k, v| %[ #{k}="#{v}"] }.join}><code#{code.map {|k, v| %[ #{k}="#{v}"] }.join}>#{node.content}</code></pre>)
+        else
+          %(<pre class="#{class_attr_val}"><code#{lang ? %[ data-lang="#{lang}"] : ''}>#{node.content}</code></pre>)
+        end
+      end
+    end
+  end
+end
+
+require_relative 'syntax_highlighter/highlightjs'
+require_relative 'syntax_highlighter/html_pipeline'

--- a/lib/asciidoctor/syntax_highlighter/coderay.rb
+++ b/lib/asciidoctor/syntax_highlighter/coderay.rb
@@ -1,0 +1,86 @@
+module Asciidoctor
+  class SyntaxHighlighter::CodeRay < SyntaxHighlighter::Base
+    register_for 'coderay'
+
+    def initialize *args
+      super
+      @pre_class = 'CodeRay'
+      @requires_stylesheet = nil
+    end
+
+    def highlight?
+      library_available?
+    end
+
+    def highlight node, source, lang, opts
+      @requires_stylesheet = true if (css_mode = opts[:css_mode]) == :class
+      # NOTE CodeRay::Duo gracefully falls back to no highlighting if lang isn't recognized
+      highlighted = ::CodeRay::Duo[lang ? lang.to_sym : :text, :html,
+        css: css_mode,
+        line_numbers: (line_numbers = opts[:line_numbers]),
+        line_number_start: opts[:start_line_number],
+        line_number_anchors: false,
+        highlight_lines: opts[:highlight_lines],
+        bold_every: false,
+      ].highlight source
+      if line_numbers == :table && opts[:callouts]
+        [highlighted, (idx = highlighted.index CodeCellStartTagCs) ? idx + CodeCellStartTagCs.length : nil]
+      else
+        highlighted
+      end
+    end
+
+    def docinfo? location
+      @requires_stylesheet && location == :footer
+    end
+
+    def docinfo location, doc, opts
+      if opts[:linkcss]
+        %(<link rel="stylesheet" href="#{doc.normalize_web_path stylesheet_basename, (doc.attr 'stylesdir', ''), false}"#{opts[:self_closing_tag_slash]}>)
+      else
+        %(<style>
+#{read_stylesheet}
+</style>)
+      end
+    end
+
+    def write_stylesheet? doc
+      @requires_stylesheet
+    end
+
+    def write_stylesheet doc, to_dir
+      ::File.write (::File.join to_dir, stylesheet_basename), read_stylesheet, mode: FILE_WRITE_MODE
+    end
+
+    module Loader
+      private
+
+      def library_available?
+        (@@library_status ||= load_library) == :loaded ? true : nil
+      end
+
+      def load_library
+        (defined? ::CodeRay::Duo) ? :loaded : (Helpers.require_library 'coderay', true, :warn).nil? ? :unavailable : :loaded
+      end
+    end
+
+    module Styles
+      include Loader
+
+      def read_stylesheet
+        @@stylesheet_cache ||= (::File.read (::File.join Stylesheets::STYLESHEETS_DIR, stylesheet_basename), mode: FILE_READ_MODE).rstrip
+      end
+
+      def stylesheet_basename
+        'coderay-asciidoctor.css'
+      end
+    end
+
+    extend Styles # exports static methods
+    include Loader, Styles # adds methods to instance
+
+    CodeCellStartTagCs = '<td class="code"><pre>'
+
+    private_constant :CodeCellStartTagCs
+  end
+end

--- a/lib/asciidoctor/syntax_highlighter/highlightjs.rb
+++ b/lib/asciidoctor/syntax_highlighter/highlightjs.rb
@@ -1,0 +1,25 @@
+module Asciidoctor
+  class SyntaxHighlighter::HighlightJs < SyntaxHighlighter::Base
+    register_for 'highlightjs', 'highlight.js'
+
+    def initialize *args
+      super
+      @name = @pre_class = 'highlightjs'
+    end
+
+    def format node, lang, opts
+      super node, lang, (opts.merge transform: -> _, code { code['class'] = %(language-#{lang || 'none'} hljs) } )
+    end
+
+    def docinfo? location
+      location == :footer
+    end
+
+    def docinfo location, doc, opts
+      base_url = doc.attr 'highlightjsdir', %(#{opts[:cdn_base_url]}/highlight.js/9.13.1)
+      %(<link rel="stylesheet" href="#{base_url}/styles/#{doc.attr 'highlightjs-theme', 'github'}.min.css"#{opts[:self_closing_tag_slash]}>
+<script src="#{base_url}/highlight.min.js"></script>
+<script>hljs.initHighlighting()</script>)
+    end
+  end
+end

--- a/lib/asciidoctor/syntax_highlighter/html_pipeline.rb
+++ b/lib/asciidoctor/syntax_highlighter/html_pipeline.rb
@@ -1,0 +1,9 @@
+module Asciidoctor
+  class SyntaxHighlighter::HtmlPipeline < SyntaxHighlighter::Base
+    register_for 'html-pipeline'
+
+    def format node, lang, opts
+      %(<pre#{lang ? %[ lang="#{lang}"] : ''}><code>#{node.content}</code></pre>)
+    end
+  end
+end

--- a/lib/asciidoctor/syntax_highlighter/prettify.rb
+++ b/lib/asciidoctor/syntax_highlighter/prettify.rb
@@ -1,0 +1,28 @@
+module Asciidoctor
+  class SyntaxHighlighter::Prettify < SyntaxHighlighter::Base
+    register_for 'prettify'
+
+    def initialize *args
+      super
+      @pre_class = 'prettyprint'
+    end
+
+    def format node, lang, opts
+      if node.attr? 'linenums', nil, false
+        opts[:transform] = -> pre, _ { pre['class'] += %( #{(start = node.attr 'start', nil, false) ? %[linenums:#{start}] : 'linenums'}) }
+      end
+      super
+    end
+
+    def docinfo? location
+      location == :footer
+    end
+
+    def docinfo location, doc, opts
+      base_url = doc.attr 'prettifydir', %(#{opts[:cdn_base_url]}/prettify/r298)
+      prettify_theme_url = ((prettify_theme = doc.attr 'prettify-theme', 'prettify').start_with? 'http://', 'https://') ? prettify_theme : %(#{base_url}/#{prettify_theme}.min.css)
+      %(<link rel="stylesheet" href="#{prettify_theme_url}"#{opts[:self_closing_tag_slash]}>
+<script src="#{base_url}/run_prettify.min.js"></script>)
+    end
+  end
+end

--- a/lib/asciidoctor/syntax_highlighter/pygments.rb
+++ b/lib/asciidoctor/syntax_highlighter/pygments.rb
@@ -1,0 +1,150 @@
+module Asciidoctor
+  class SyntaxHighlighter::Pygments < SyntaxHighlighter::Base
+    register_for 'pygments'
+
+    def initialize *args
+      super
+      @requires_stylesheet = nil
+      @style = nil
+    end
+
+    def highlight?
+      library_available?
+    end
+
+    def highlight node, source, lang, opts
+      lexer = (::Pygments::Lexer.find_by_alias lang) || (::Pygments::Lexer.find_by_mimetype 'text/plain')
+      @requires_stylesheet = true unless (noclasses = opts[:css_mode] != :class)
+      highlight_opts = {
+        classprefix: TOKEN_CLASS_PREFIX,
+        cssclass: WRAPPER_CLASS,
+        nobackground: true,
+        noclasses: noclasses,
+        startinline: lexer.name == 'PHP' && !(node.option? 'mixed'),
+        stripnl: false,
+        style: (@style ||= (style = opts[:style]) && (style_available? style) || DEFAULT_STYLE),
+      }
+      if (highlight_lines = opts[:highlight_lines])
+        highlight_opts[:hl_lines] = highlight_lines.join ' '
+      end
+      if (linenos = opts[:line_numbers]) && (highlight_opts[:linenostart] = opts[:start_line_number]) && (highlight_opts[:linenos] = linenos) == :table
+        if (highlighted = lexer.highlight source, options: highlight_opts)
+          highlighted = highlighted.sub StyledLinenoDivPreStartTagsRx, LinenoDivPreStartTagsCs if noclasses
+          highlighted = highlighted.sub WrapperTagRx, PreTagCs
+          opts[:callouts] ? [highlighted, (idx = highlighted.index CodeCellStartTagCs) ? idx + CodeCellStartTagCs.length : nil] : highlighted
+        else
+          node.sub_specialchars source # handles nil response from ::Pygments::Lexer#highlight
+        end
+      elsif (highlighted = lexer.highlight source, options: highlight_opts)
+        if linenos
+          highlighted = highlighted.gsub StyledLinenoSpanTagRx, LinenoSpanTagCs if noclasses
+          highlighted.sub WrapperTagRx, PreTagCs
+        else
+          highlighted.sub WrapperTagRx, '\1'
+        end
+      else
+        node.sub_specialchars source # handles nil response from ::Pygments::Lexer#highlight
+      end
+    end
+
+    def format node, lang, opts
+      if opts[:css_mode] != :class && (@style = (style = opts[:style]) && (style_available? style) || DEFAULT_STYLE) &&
+          (pre_style_attr_val = base_style @style)
+        opts[:transform] = -> pre, _ { pre['style'] = pre_style_attr_val }
+      end
+      super
+    end
+
+    def docinfo? location
+      @requires_stylesheet && location == :footer
+    end
+
+    def docinfo location, doc, opts
+      if opts[:linkcss]
+        %(<link rel="stylesheet" href="#{doc.normalize_web_path (stylesheet_basename @style), (doc.attr 'stylesdir', ''), false}"#{opts[:self_closing_tag_slash]}>)
+      else
+        %(<style>
+#{read_stylesheet @style}
+</style>)
+      end
+    end
+
+    def write_stylesheet? doc
+      @requires_stylesheet
+    end
+
+    def write_stylesheet doc, to_dir
+      ::File.write (::File.join to_dir, (stylesheet_basename @style)), (read_stylesheet @style)
+    end
+
+    module Loader
+      private
+
+      def library_available?
+        (@@library_status ||= load_library) == :loaded ? true : nil
+      end
+
+      def load_library
+        (defined? ::Pygments::Lexer) ? :loaded : (Helpers.require_library 'pygments', 'pygments.rb', :warn).nil? ? :unavailable : :loaded
+      end
+    end
+
+    module Styles
+      include Loader
+
+      def read_stylesheet style
+        library_available? ? @@stylesheet_cache[style || DEFAULT_STYLE] || '/* Failed to load Pygments CSS. */' : '/* Pygments CSS disabled because Pygments is not available. */'
+      end
+
+      def stylesheet_basename style
+        %(pygments-#{style || DEFAULT_STYLE}.css)
+      end
+
+      private
+
+      def style_available? style
+        (((@@available_styles ||= ::Pygments.styles.to_set).include? style) rescue nil) && style
+      end
+
+      def base_style style
+        @@base_style_cache[style || DEFAULT_STYLE]
+      end
+
+      (@@base_style_cache = {}).default_proc = proc do |cache, key|
+        if BaseStyleRx =~ @@stylesheet_cache[key]
+          @@base_style_cache = cache.merge key => (style = $1.strip)
+          style
+        end
+      end
+      (@@stylesheet_cache = {}).default_proc = proc do |cache, key|
+        if (stylesheet = ::Pygments.css BASE_SELECTOR, classprefix: TOKEN_CLASS_PREFIX, style: key)
+          @@stylesheet_cache = cache.merge key => stylesheet
+          stylesheet
+        end
+      end
+
+      DEFAULT_STYLE = 'default'
+      BASE_SELECTOR = 'pre.pygments'
+      TOKEN_CLASS_PREFIX = 'tok-'
+
+      BaseStyleRx = /^#{BASE_SELECTOR.gsub '.', '\\.'} +\{([^}]+?)\}/
+
+      private_constant :BASE_SELECTOR, :TOKEN_CLASS_PREFIX, :BaseStyleRx
+    end
+
+    extend Styles # exports static methods
+    include Loader, Styles # adds methods to instance
+
+    CodeCellStartTagCs = '<td class="code">'
+    LinenoDivPreStartTagsCs = '<div class="linenodiv"><pre>'
+    LinenoSpanTagCs = '<span class="lineno">\1</span>'
+    PreTagCs = '<pre>\1</pre>'
+    StyledLinenoDivPreStartTagsRx = /<div class="linenodiv" style="[^"]+?"><pre style="[^"]+?">/
+    StyledLinenoSpanTagRx = %r(<span style="background-color: #f0f0f0; padding: 0 5px 0 5px">( *\d+ )</span>)
+    WRAPPER_CLASS = 'pygments-'
+    # NOTE <pre> has style attribute when pygments-css=style; <div> has trailing newline when pygments-linenums-mode=table; initial <span></span> preserves leading blank lines
+    WrapperTagRx = %r(<div class="#{WRAPPER_CLASS}"><pre\b[^>]*?>(.*)</pre></div>\n*)m
+
+    private_constant :CodeCellStartTagCs, :LinenoDivPreStartTagsCs, :LinenoSpanTagCs, :PreTagCs, :StyledLinenoDivPreStartTagsRx, :StyledLinenoSpanTagRx, :WrapperTagRx, :WRAPPER_CLASS
+  end
+end

--- a/test/blocks_test.rb
+++ b/test/blocks_test.rb
@@ -908,7 +908,34 @@ paragraph 2
       assert_xpath '(/*[@class="paragraph"]/following-sibling::*)[1][@class="listingblock"]', output, 1
     end
 
-    test "should preserve endlines in literal block" do
+    test 'should warn if listing block is not terminated' do
+      input = <<-EOS
+outside
+
+----
+inside
+
+still inside
+
+eof
+      EOS
+
+      output = convert_string_to_embedded input
+      assert_xpath '/*[@class="listingblock"]', output, 1
+      assert_message @logger, :WARN, '<stdin>: line 3: unterminated listing block', Hash
+    end
+
+    test 'should not crash if listing block has no lines' do
+      input = <<-EOS
+----
+----
+      EOS
+      output = convert_string_to_embedded input
+      assert_css 'pre', output, 1
+      assert_css 'pre:empty', output, 1
+    end
+
+    test 'should preserve endlines in literal block' do
       input = <<-EOS
 ....
 line one
@@ -932,9 +959,8 @@ EOS
       }
     end
 
-    test "should preserve endlines in listing block" do
+    test 'should preserve endlines in listing block' do
       input = <<-EOS
-[source]
 ----
 line one
 
@@ -945,9 +971,9 @@ line three
 EOS
       [true, false].each {|header_footer|
         output = convert_string input, header_footer: header_footer
-        assert_xpath '//pre/code', output, 1
-        assert_xpath '//pre/code/text()', output, 1
-        text = xmlnodes_at_xpath('//pre/code/text()', output, 1).text
+        assert_xpath '//pre', output, 1
+        assert_xpath '//pre/text()', output, 1
+        text = xmlnodes_at_xpath('//pre/text()', output, 1).text
         lines = text.lines
         assert_equal 5, lines.size
         expected = "line one\n\nline two\n\nline three".lines
@@ -957,7 +983,7 @@ EOS
       }
     end
 
-    test "should preserve endlines in verse block" do
+    test 'should preserve endlines in verse block' do
       input = <<-EOS
 --
 [verse]
@@ -1008,7 +1034,6 @@ last line
 
     test 'should process block with CRLF endlines' do
       input = <<-EOS
-[source]\r
 ----\r
 source line 1\r
 source line 2\r
@@ -1016,10 +1041,8 @@ source line 2\r
       EOS
 
       output = convert_string_to_embedded input
-      refute_match(/\[source\]/, output)
       assert_xpath '/*[@class="listingblock"]//pre', output, 1
-      assert_xpath '/*[@class="listingblock"]//pre/code', output, 1
-      assert_xpath %(/*[@class="listingblock"]//pre/code[text()="source line 1\nsource line 2"]), output, 1
+      assert_xpath %(/*[@class="listingblock"]//pre[text()="source line 1\nsource line 2"]), output, 1
     end
 
     test 'should remove block indent if indent attribute is 0' do
@@ -1292,27 +1315,27 @@ listing block
       input = <<-EOS
 [source]
 ----
-listing block
+source block
 ----
       EOS
 
       output = convert_string_to_embedded input, backend: 'docbook'
-      assert_xpath '/screen[text()="listing block"]', output, 1
+      assert_xpath '/screen[@linenumbering="unnumbered"][text()="source block"]', output, 1
     end
 
-    test 'source block with title and no language should generate screen element inside formalpara element in docbook' do
+    test 'source block with title and no language should generate screen element inside formalpara element for docbook' do
       input = <<-EOS
 [source]
 .title
 ----
-listing block
+source block
 ----
       EOS
 
       output = convert_string_to_embedded input, backend: 'docbook'
       assert_xpath '/formalpara', output, 1
       assert_xpath '/formalpara/title[text()="title"]', output, 1
-      assert_xpath '/formalpara/para/screen[text()="listing block"]', output, 1
+      assert_xpath '/formalpara/para/screen[@linenumbering="unnumbered"][text()="source block"]', output, 1
     end
   end
 
@@ -3009,413 +3032,6 @@ alert("Hello, World!")
       assert_css '.listingblock', output, 2
       assert_css '.listingblock pre code.language-ruby[data-lang=ruby]', output, 1
       assert_css '.listingblock pre code.language-javascript[data-lang=javascript]', output, 1
-    end
-
-    test 'should highlight source if source-highlighter attribute is coderay' do
-      input = <<-EOS
-:source-highlighter: coderay
-
-[source, ruby]
-----
-require 'coderay'
-
-html = CodeRay.scan("puts 'Hello, world!'", :ruby).div line_numbers: :table
-----
-      EOS
-      output = convert_string input, safe: Asciidoctor::SafeMode::SAFE, linkcss_default: true
-      assert_xpath '//pre[@class="CodeRay highlight"]/code[@data-lang="ruby"]//span[@class = "constant"][text() = "CodeRay"]', output, 1
-      assert_match(/\.CodeRay *\{/, output)
-    end
-
-    test 'should number lines if third positional attribute is set' do
-      input = <<-EOS
-:source-highlighter: coderay
-
-[source,ruby,linenums]
-----
-puts 'Hello, World!'
-----
-      EOS
-      output = convert_string_to_embedded input, safe: Asciidoctor::SafeMode::SAFE
-      assert_xpath '//td[@class="line-numbers"]', output, 1
-    end
-
-    test 'should number lines if linenums option is set on source block' do
-      input = <<-EOS
-:source-highlighter: coderay
-
-[source%linenums,ruby]
-----
-puts 'Hello, World!'
-----
-      EOS
-      output = convert_string_to_embedded input, safe: Asciidoctor::SafeMode::SAFE
-      assert_xpath '//td[@class="line-numbers"]', output, 1
-    end
-
-    test 'should number lines of source block if source-linenums-option document attribute is set' do
-      input = <<-EOS
-:source-highlighter: coderay
-:source-linenums-option:
-
-[source,ruby]
-----
-puts 'Hello, World!'
-----
-      EOS
-      output = convert_string_to_embedded input, safe: Asciidoctor::SafeMode::SAFE
-      assert_xpath '//td[@class="line-numbers"]', output, 1
-    end
-
-    test 'should set starting line number in HTML output if linenums option is enabled and start attribute is set' do
-      input = <<-EOS
-:source-highlighter: coderay
-:coderay-linenums-mode: inline
-
-[source%linenums,ruby,start=10]
-----
-puts 'Hello, World!'
-----
-      EOS
-      output = convert_string_to_embedded input, safe: Asciidoctor::SafeMode::SAFE
-      assert_xpath '//span[@class="line-numbers"]', output, 1
-      assert_xpath '//span[@class="line-numbers"][text()="10"]', output, 1
-    end
-
-    test 'should set starting line number in DocBook output if linenums option is enabled and start attribute is set' do
-      input = <<-EOS
-[source%linenums,java,start=3]
-----
-public class HelloWorld {
-  public static void main(String[] args) {
-    out.println("Hello, World!");
-  }
-}
-----
-      EOS
-
-      output = convert_string_to_embedded input, backend: :docbook, safe: Asciidoctor::SafeMode::SAFE
-      assert_css 'programlisting[startinglinenumber]', output, 1
-      assert_css 'programlisting[startinglinenumber="3"]', output, 1
-    end
-
-    test 'should highlight lines specified in highlight attribute if linenums is set and source-highlighter is coderay' do
-      %w(highlight="1,4-6" highlight=1;4..6 highlight=1;4..;!7).each do |highlight_attr|
-        input = <<-EOS
-:source-highlighter: coderay
-
-[source%linenums,java,#{highlight_attr}]
-----
-import static java.lang.System.out;
-
-public class HelloWorld {
-  public static void main(String[] args) {
-    out.println("Hello, World!");
-  }
-}
-----
-        EOS
-        output = convert_string_to_embedded input, safe: Asciidoctor::SafeMode::SAFE
-        assert_css 'strong.highlighted', output, 4
-        assert_xpath '//strong[@class="highlighted"][text()="1"]', output, 1
-        assert_xpath '//strong[@class="highlighted"][text()="2"]', output, 0
-        assert_xpath '//strong[@class="highlighted"][text()="3"]', output, 0
-        assert_xpath '//strong[@class="highlighted"][text()="4"]', output, 1
-        assert_xpath '//strong[@class="highlighted"][text()="5"]', output, 1
-        assert_xpath '//strong[@class="highlighted"][text()="6"]', output, 1
-        assert_xpath '//strong[@class="highlighted"][text()="7"]', output, 0
-      end
-    end
-
-    test 'should read source language from source-language document attribute if not specified on source block' do
-      input = <<-EOS
-:source-highlighter: coderay
-:source-language: ruby
-
-[source]
-----
-require 'coderay'
-
-html = CodeRay.scan("puts 'Hello, world!'", :ruby).div line_numbers: :table
-----
-      EOS
-      output = convert_string_to_embedded input, safe: Asciidoctor::SafeMode::SAFE, linkcss_default: true
-      assert_xpath '//pre[@class="CodeRay highlight"]/code[@data-lang="ruby"]//span[@class = "constant"][text() = "CodeRay"]', output, 1
-    end
-
-    test 'should rename document attribute named language to source-language when compat-mode is enabled' do
-      input = <<-EOS
-:language: ruby
-
-{source-language}
-      EOS
-
-      assert_equal 'ruby', (convert_inline_string input, attributes: { 'compat-mode' => '' })
-
-      input = <<-EOS
-:language: ruby
-
-{source-language}
-      EOS
-
-      assert_equal '{source-language}', (convert_inline_string input)
-    end
-
-    test 'should replace callout marks but not highlight them if source-highlighter attribute is coderay' do
-      input = <<-EOS
-:source-highlighter: coderay
-
-[source, ruby]
-----
-require 'coderay' # <1>
-
-html = CodeRay.scan("puts 'Hello, world!'", :ruby).div line_numbers: :table # <2>
-puts html # <3> <4>
-exit 0 # <5><6>
-----
-<1> Load library
-<2> Highlight source
-<3> Print to stdout
-<4> Redirect to a file to capture output
-<5> Exit program
-<6> Reports success
-      EOS
-      output = convert_string_to_embedded input, safe: Asciidoctor::SafeMode::SAFE
-      assert_match(/<span class="content">coderay<\/span>.* # <b class="conum">\(1\)<\/b>$/, output)
-      assert_match(/<span class="content">puts 'Hello, world!'<\/span>.* # <b class="conum">\(2\)<\/b>$/, output)
-      assert_match(/puts html.* # <b class="conum">\(3\)<\/b> <b class="conum">\(4\)<\/b>$/, output)
-      assert_match(/exit.* # <b class="conum">\(5\)<\/b> <b class="conum">\(6\)<\/b><\/code>/, output)
-    end
-
-    test 'should support autonumbered callout marks if source-highlighter attribute is coderay' do
-      input = <<-EOS
-:source-highlighter: coderay
-
-[source, ruby]
-----
-require 'coderay' # <.><.>
-
-html = CodeRay.scan("puts 'Hello, world!'", :ruby).div line_numbers: :table # <.>
-puts html # <.>
-----
-<.> Load library
-<.> Gem must be installed
-<.> Highlight source
-<.> Print to stdout
-      EOS
-      output = convert_string_to_embedded input, safe: Asciidoctor::SafeMode::SAFE
-      assert_match(/<span class="content">coderay<\/span>.* # <b class="conum">\(1\)<\/b> <b class="conum">\(2\)<\/b>$/, output)
-      assert_match(/<span class="content">puts 'Hello, world!'<\/span>.* # <b class="conum">\(3\)<\/b>$/, output)
-      assert_match(/puts html.* # <b class="conum">\(4\)<\/b><\/code>/, output)
-      assert_css '.colist ol', output, 1
-      assert_css '.colist ol li', output, 4
-    end
-
-    test 'should restore callout marks to correct lines if source highlighter is coderay and table line numbering is enabled' do
-      input = <<-EOS
-:source-highlighter: coderay
-:coderay-linenums-mode: table
-
-[source, ruby, numbered]
-----
-require 'coderay' # <1>
-
-html = CodeRay.scan("puts 'Hello, world!'", :ruby).div line_numbers: :table # <2>
-puts html # <3> <4>
-exit 0 # <5><6>
-----
-<1> Load library
-<2> Highlight source
-<3> Print to stdout
-<4> Redirect to a file to capture output
-<5> Exit program
-<6> Reports success
-      EOS
-      output = convert_string_to_embedded input, safe: Asciidoctor::SafeMode::SAFE
-      assert_match(/<span class="content">coderay<\/span>.* # <b class="conum">\(1\)<\/b>$/, output)
-      assert_match(/<span class="content">puts 'Hello, world!'<\/span>.* # <b class="conum">\(2\)<\/b>$/, output)
-      assert_match(/puts html.* # <b class="conum">\(3\)<\/b> <b class="conum">\(4\)<\/b>$/, output)
-      assert_match(/exit.* # <b class="conum">\(5\)<\/b> <b class="conum">\(6\)<\/b><\/pre>/, output)
-    end
-
-    test 'should preserve space before callout on final line' do
-      inputs = []
-
-      inputs << <<-EOS
-[source,yaml]
-----
-a: 'a'
-key: 'value' #<1>
-----
-<1> key-value pair
-      EOS
-
-      inputs << <<-EOS
-[source,ruby]
-----
-puts 'hi'
-puts 'value' #<1>
-----
-<1> print to stdout
-      EOS
-
-      inputs << <<-EOS
-[source,python]
-----
-print 'hi'
-print 'value' #<1>
-----
-<1> print to stdout
-      EOS
-
-      inputs.each do |input|
-        output = convert_string_to_embedded input, safe: Asciidoctor::SafeMode::SAFE, attributes: { 'source-highlighter' => 'coderay' }
-        output = output.gsub(/<\/?span.*?>/, '')
-        assert_includes output, '\'value\' #<b class="conum">(1)</b>'
-      end
-    end
-
-    test 'should preserve passthrough placeholders when highlighting source using coderay' do
-      input = <<-EOS
-:source-highlighter: coderay
-
-[source,java]
-[subs="specialcharacters,macros,callouts"]
-----
-public class Printer {
-  public static void main(String[] args) {
-    System.pass:quotes[_out_].println("*asterisks* make text pass:quotes[*bold*]");
-  }
-}
-----
-      EOS
-      output = convert_string input, safe: Asciidoctor::SafeMode::SAFE
-      assert_match(/\.<em>out<\/em>\./, output, 1)
-      assert_match(/\*asterisks\*/, output, 1)
-      assert_match(/<strong>bold<\/strong>/, output, 1)
-      refute_includes output, Asciidoctor::Substitutors::PASS_START
-    end
-
-    test 'should link to CodeRay stylesheet if source-highlighter is coderay and linkcss is set' do
-      input = <<-EOS
-:source-highlighter: coderay
-
-[source, ruby]
-----
-require 'coderay'
-
-html = CodeRay.scan("puts 'Hello, world!'", :ruby).div line_numbers: :table
-----
-      EOS
-      output = convert_string input, safe: Asciidoctor::SafeMode::SAFE, attributes: { 'linkcss' => '' }
-      assert_xpath '//pre[@class="CodeRay highlight"]/code[@data-lang="ruby"]//span[@class = "constant"][text() = "CodeRay"]', output, 1
-      assert_css 'link[rel="stylesheet"][href="./coderay-asciidoctor.css"]', output, 1
-    end
-
-    test 'should highlight source inline if source-highlighter attribute is coderay and coderay-css is style' do
-      input = <<-EOS
-:source-highlighter: coderay
-:coderay-css: style
-
-[source, ruby]
-----
-require 'coderay'
-
-html = CodeRay.scan("puts 'Hello, world!'", :ruby).div line_numbers: :table
-----
-      EOS
-      output = convert_string input, safe: Asciidoctor::SafeMode::SAFE, linkcss_default: true
-      assert_xpath '//pre[@class="CodeRay highlight"]/code[@data-lang="ruby"]//span[@style = "color:#036;font-weight:bold"][text() = "CodeRay"]', output, 1
-      refute_match(/\.CodeRay \{/, output)
-    end
-
-    test 'should include remote highlight.js assets if source-highlighter attribute is highlightjs' do
-      input = <<-EOS
-:source-highlighter: highlightjs
-
-[source, javascript]
-----
-<link rel="stylesheet" href="styles/default.css">
-<script src="highlight.pack.js"></script>
-<script>hljs.initHighlightingOnLoad();</script>
-----
-      EOS
-      output = convert_string input, safe: Asciidoctor::SafeMode::SAFE
-      assert_match(/<link .*highlight\.js/, output)
-      assert_match(/<script .*highlight\.js/, output)
-      assert_match(/hljs.initHighlightingOnLoad/, output)
-    end
-
-    test 'should add language classes to child code element when source-highlighter is prettify' do
-      input = <<-EOS
-[source,ruby]
-----
-puts "foo"
-----
-      EOS
-
-      output = convert_string_to_embedded input, attributes: { 'source-highlighter' => 'prettify' }
-      assert_css 'pre[class="prettyprint highlight"]', output, 1
-      assert_css 'pre > code.language-ruby[data-lang="ruby"]', output, 1
-    end
-
-    test 'should set linenums start if linenums are enabled and start attribute is set when source-highlighter is prettify' do
-      input = <<-EOS
-[source%linenums,ruby,start=5]
-----
-puts "foo"
-----
-      EOS
-
-      output = convert_string_to_embedded input, attributes: { 'source-highlighter' => 'prettify' }
-      assert_css 'pre[class="prettyprint highlight linenums:5"]', output, 1
-      assert_css 'pre > code.language-ruby[data-lang="ruby"]', output, 1
-    end
-
-    test 'should set lang attribute on pre when source-highlighter is html-pipeline' do
-      input = <<-EOS
-[source,ruby]
-----
-filters = [
-  HTML::Pipeline::AsciiDocFilter,
-  HTML::Pipeline::SanitizationFilter,
-  HTML::Pipeline::SyntaxHighlightFilter
-]
-
-puts HTML::Pipeline.new(filters, {}).call(input)[:output]
-----
-      EOS
-
-      output = convert_string input, attributes: { 'source-highlighter' => 'html-pipeline' }
-      assert_css 'pre[lang="ruby"]', output, 1
-      assert_css 'pre[lang="ruby"] > code', output, 1
-      assert_css 'pre[class]', output, 0
-      assert_css 'code[class]', output, 0
-    end
-
-    test 'document cannot turn on source highlighting if safe mode is at least SERVER' do
-      input = <<-EOS
-:source-highlighter: coderay
-      EOS
-      doc = document_from_string input, safe: Asciidoctor::SafeMode::SERVER
-      assert_nil doc.attributes['source-highlighter']
-    end
-
-    test 'should warn if listing block is not terminated' do
-      input = <<-EOS
-outside
-
-----
-inside
-
-still inside
-
-eof
-      EOS
-
-      output = convert_string_to_embedded input
-      assert_xpath '/*[@class="listingblock"]', output, 1
-      assert_message @logger, :WARN, '<stdin>: line 3: unterminated listing block', Hash
     end
   end
 

--- a/test/fixtures/source-block.adoc
+++ b/test/fixtures/source-block.adoc
@@ -1,0 +1,4 @@
+[source,ruby]
+----
+puts 'Hello, World!'
+----

--- a/test/invoker_test.rb
+++ b/test/invoker_test.rb
@@ -279,11 +279,26 @@ context 'Invoker' do
     asciidoctor_stylesheet = fixture_path 'asciidoctor.css'
     coderay_stylesheet = fixture_path 'coderay-asciidoctor.css'
     begin
-      invoker = invoke_cli %W(-o #{sample_outpath} -a linkcss -a source-highlighter=coderay)
-      invoker.document
+      invoke_cli %W(-o #{sample_outpath} -a linkcss -a source-highlighter=coderay), 'source-block.adoc'
       assert File.exist?(sample_outpath)
       assert File.exist?(asciidoctor_stylesheet)
       assert File.exist?(coderay_stylesheet)
+    ensure
+      FileUtils.rm_f(sample_outpath)
+      FileUtils.rm_f(asciidoctor_stylesheet)
+      FileUtils.rm_f(coderay_stylesheet)
+    end
+  end
+
+  test 'should not copy coderay stylesheet to target directory when no source blocks where highlighted' do
+    sample_outpath = fixture_path 'sample-output.html'
+    asciidoctor_stylesheet = fixture_path 'asciidoctor.css'
+    coderay_stylesheet = fixture_path 'coderay-asciidoctor.css'
+    begin
+      invoke_cli %W(-o #{sample_outpath} -a linkcss -a source-highlighter=coderay)
+      assert File.exist?(sample_outpath)
+      assert File.exist?(asciidoctor_stylesheet)
+      refute File.exist?(coderay_stylesheet)
     ensure
       FileUtils.rm_f(sample_outpath)
       FileUtils.rm_f(asciidoctor_stylesheet)

--- a/test/lists_test.rb
+++ b/test/lists_test.rb
@@ -4405,9 +4405,9 @@ puts doc.convert # <2>
     assert_xpath '(//programlisting/following-sibling::calloutlist/callout)[2][@arearefs = "CO1-2 CO1-3"]', output, 1
   end
 
-  test 'listing block with non-sequential callouts followed by adjacent callout list' do
+  test 'source block with non-sequential callouts followed by adjacent callout list' do
     input = <<-EOS
-[source, ruby]
+[source,ruby]
 ----
 require 'asciidoctor' # <2>
 doc = Asciidoctor::Document.new('Hello, World!') # <3>

--- a/test/substitutions_test.rb
+++ b/test/substitutions_test.rb
@@ -1959,15 +1959,16 @@ foo&#8201;&#8212;&#8201;'
 
   context 'Resolve subs' do
     test 'should resolve subs for block' do
-      block = Asciidoctor::Block.new(empty_document, :paragraph)
+      doc = empty_document parse: true
+      block = Asciidoctor::Block.new doc, :paragraph
       block.attributes['subs'] = 'quotes,normal'
       block.lock_in_subs
       assert_equal [:quotes, :specialcharacters, :attributes, :replacements, :macros, :post_replacements], block.subs
     end
 
     test 'should resolve specialcharacters sub as highlight for source block when source highlighter is coderay' do
-      doc = empty_document attributes: { 'source-highlighter' => 'coderay' }
-      block = Asciidoctor::Block.new(doc, :listing, content_model: :verbatim)
+      doc = empty_document attributes: { 'source-highlighter' => 'coderay' }, parse: true
+      block = Asciidoctor::Block.new doc, :listing, content_model: :verbatim
       block.style = 'source'
       block.attributes['subs'] = 'specialcharacters'
       block.attributes['language'] = 'ruby'
@@ -1976,18 +1977,18 @@ foo&#8201;&#8212;&#8201;'
     end
 
     test 'should resolve specialcharacters sub as highlight for source block when source highlighter is pygments' do
-      doc = empty_document attributes: { 'source-highlighter' => 'pygments' }
-      block = Asciidoctor::Block.new(doc, :listing, content_model: :verbatim)
+      doc = empty_document attributes: { 'source-highlighter' => 'pygments' }, parse: true
+      block = Asciidoctor::Block.new doc, :listing, content_model: :verbatim
       block.style = 'source'
       block.attributes['subs'] = 'specialcharacters'
       block.attributes['language'] = 'ruby'
       block.lock_in_subs
       assert_equal [:highlight], block.subs
-    end
+    end if ENV['PYGMENTS']
 
-    test 'should not resolve specialcharacters sub as highlight for source block when source highlighter is not set' do
-      doc = empty_document
-      block = Asciidoctor::Block.new(doc, :listing, content_model: :verbatim)
+    test 'should not replace specialcharacters sub with highlight for source block when source highlighter is not set' do
+      doc = empty_document parse: true
+      block = Asciidoctor::Block.new doc, :listing, content_model: :verbatim
       block.style = 'source'
       block.attributes['subs'] = 'specialcharacters'
       block.attributes['language'] = 'ruby'
@@ -1996,7 +1997,7 @@ foo&#8201;&#8212;&#8201;'
     end
 
     test 'should not use subs if subs option passed to block constructor is nil' do
-      doc = empty_document
+      doc = empty_document parse: true
       block = Asciidoctor::Block.new doc, :paragraph, source: '*bold* _italic_', subs: nil, attributes: { 'subs' => 'quotes' }
       assert_empty block.subs
       block.lock_in_subs
@@ -2004,7 +2005,7 @@ foo&#8201;&#8212;&#8201;'
     end
 
     test 'should not use subs if subs option passed to block constructor is empty array' do
-      doc = empty_document
+      doc = empty_document parse: true
       block = Asciidoctor::Block.new doc, :paragraph, source: '*bold* _italic_', subs: [], attributes: { 'subs' => 'quotes' }
       assert_empty block.subs
       block.lock_in_subs
@@ -2012,7 +2013,7 @@ foo&#8201;&#8212;&#8201;'
     end
 
     test 'should use subs from subs option passed to block constructor' do
-      doc = empty_document
+      doc = empty_document parse: true
       block = Asciidoctor::Block.new doc, :paragraph, source: '*bold* _italic_', subs: [:specialcharacters], attributes: { 'subs' => 'quotes' }
       assert_equal [:specialcharacters], block.subs
       block.lock_in_subs
@@ -2020,7 +2021,7 @@ foo&#8201;&#8212;&#8201;'
     end
 
     test 'should use subs from subs attribute if subs option is not passed to block constructor' do
-      doc = empty_document
+      doc = empty_document parse: true
       block = Asciidoctor::Block.new doc, :paragraph, source: '*bold* _italic_', attributes: { 'subs' => 'quotes' }
       assert_empty block.subs
       # in this case, we have to call lock_in_subs to resolve the subs
@@ -2029,7 +2030,7 @@ foo&#8201;&#8212;&#8201;'
     end
 
     test 'should use subs from subs attribute if subs option passed to block constructor is :default' do
-      doc = empty_document
+      doc = empty_document parse: true
       block = Asciidoctor::Block.new doc, :paragraph, source: '*bold* _italic_', subs: :default, attributes: { 'subs' => 'quotes' }
       assert_equal [:quotes], block.subs
       block.lock_in_subs
@@ -2037,7 +2038,7 @@ foo&#8201;&#8212;&#8201;'
     end
 
     test 'should use built-in subs if subs option passed to block constructor is :default and subs attribute is absent' do
-      doc = empty_document
+      doc = empty_document parse: true
       block = Asciidoctor::Block.new doc, :paragraph, source: '*bold* _italic_', subs: :default
       assert_equal [:specialcharacters, :quotes, :attributes, :replacements, :macros, :post_replacements], block.subs
       block.lock_in_subs

--- a/test/syntax_highlighter_test.rb
+++ b/test/syntax_highlighter_test.rb
@@ -1,0 +1,719 @@
+require_relative 'test_helper'
+
+context 'Syntax Highlighter' do
+  test 'should set syntax_highlighter property on document if source highlighter is set and basebackend is html' do
+    input = <<-EOS
+:source-highlighter: coderay
+
+[source, ruby]
+----
+puts 'Hello, World!'
+----
+    EOS
+    doc = document_from_string input, safe: :safe, parse: true
+    assert doc.basebackend? 'html'
+    refute_nil doc.syntax_highlighter
+    assert_kind_of Asciidoctor::SyntaxHighlighter, doc.syntax_highlighter
+  end
+
+  test 'should not set syntax_highlighter property on document if source highlighter is not set' do
+    input = <<-EOS
+[source, ruby]
+----
+puts 'Hello, World!'
+----
+    EOS
+    doc = document_from_string input, safe: :safe, parse: true
+    assert_nil doc.syntax_highlighter
+  end
+
+  test 'should not set syntax_highlighter property on document if syntax highlighter cannot be found' do
+    input = <<-EOS
+:source-highlighter: unknown
+
+[source, ruby]
+----
+puts 'Hello, World!'
+----
+    EOS
+    doc = document_from_string input, safe: :safe, parse: true
+    assert_nil doc.syntax_highlighter
+  end
+
+  test 'should not set syntax_highlighter property on document if basebackend is not html' do
+    input = <<-EOS
+:source-highlighter: coderay
+
+[source, ruby]
+----
+puts 'Hello, World!'
+----
+    EOS
+    doc = document_from_string input, safe: :safe, backend: 'docbook', parse: true
+    refute doc.basebackend? 'html'
+    assert_nil doc.syntax_highlighter
+  end
+
+  test 'should not allow document to enable syntax highlighter if safe mode is at least SERVER' do
+    input = <<-EOS
+:source-highlighter: coderay
+    EOS
+    doc = document_from_string input, safe: Asciidoctor::SafeMode::SERVER, parse: true
+    assert_nil doc.attributes['source-highlighter']
+    assert_nil doc.syntax_highlighter
+  end
+
+  test 'should set language on source block output when source-highlighter attribute is not set' do
+    input = <<-EOS
+[source, ruby]
+----
+puts 'Hello, World!'
+----
+    EOS
+    output = convert_string input, safe: Asciidoctor::SafeMode::SAFE
+    assert_css 'pre.highlight', output, 1
+    assert_css 'pre.highlight > code.language-ruby', output, 1
+    assert_css 'pre.highlight > code.language-ruby[data-lang="ruby"]', output, 1
+  end
+
+  test 'should set language on source block output when source-highlighter attribute is not recognized' do
+    input = <<-EOS
+:source-highlighter: unknown
+
+[source, ruby]
+----
+puts 'Hello, World!'
+----
+    EOS
+    output = convert_string input, safe: Asciidoctor::SafeMode::SAFE
+    assert_css 'pre.highlight', output, 1
+    assert_css 'pre.highlight > code.language-ruby', output, 1
+    assert_css 'pre.highlight > code.language-ruby[data-lang="ruby"]', output, 1
+  end
+
+  test 'should highlight source if source-highlighter attribute is coderay' do
+    input = <<-EOS
+:source-highlighter: coderay
+
+[source, ruby]
+----
+require 'coderay'
+
+html = CodeRay.scan("puts 'Hello, world!'", :ruby).div line_numbers: :table
+----
+    EOS
+    output = convert_string input, safe: Asciidoctor::SafeMode::SAFE, linkcss_default: true
+    assert_xpath '//pre[@class="CodeRay highlight"]/code[@data-lang="ruby"]//span[@class = "constant"][text() = "CodeRay"]', output, 1
+    assert_match(/\.CodeRay *\{/, output)
+  end
+
+  test 'should highlight source if source highlighter is set even if language is not set' do
+    input = <<-EOS
+:source-highlighter: coderay
+
+[source%linenums]
+----
+[numbers]
+one
+two
+three
+----
+    EOS
+    output = convert_string input, safe: :safe
+    assert_css 'pre.CodeRay.highlight', output, 1
+    assert_css 'pre.CodeRay.highlight td.line-numbers', output, 1
+    assert_includes output, '<code>'
+  end
+
+  test 'should not crash if source block has no lines and source highlighter is set' do
+    input = <<-EOS
+:source-highlighter: coderay
+
+[source,text]
+----
+----
+    EOS
+    output = convert_string_to_embedded input, safe: :safe
+    assert_css 'pre.CodeRay', output, 1
+    assert_css 'pre.CodeRay > code', output, 1
+    assert_css 'pre.CodeRay > code:empty', output, 1
+  end
+
+  test 'should highlight source inside AsciiDoc table cell if source-highlighter attribute is coderay' do
+    input = <<-EOS
+:source-highlighter: coderay
+
+|===
+a|
+[source, ruby]
+----
+require 'coderay'
+
+html = CodeRay.scan("puts 'Hello, world!'", :ruby).div line_numbers: :table
+----
+|===
+    EOS
+    output = convert_string_to_embedded input, safe: :safe
+    assert_xpath '/table//pre[@class="CodeRay highlight"]/code[@data-lang="ruby"]//span[@class = "constant"][text() = "CodeRay"]', output, 1
+  end
+
+  test 'should number lines if third positional attribute is set' do
+    input = <<-EOS
+:source-highlighter: coderay
+
+[source,ruby,linenums]
+----
+puts 'Hello, World!'
+----
+    EOS
+    output = convert_string_to_embedded input, safe: Asciidoctor::SafeMode::SAFE
+    assert_xpath '//td[@class="line-numbers"]', output, 1
+  end
+
+  test 'should number lines if linenums option is set on source block' do
+    input = <<-EOS
+:source-highlighter: coderay
+
+[source%linenums,ruby]
+----
+puts 'Hello, World!'
+----
+    EOS
+    output = convert_string_to_embedded input, safe: Asciidoctor::SafeMode::SAFE
+    assert_xpath '//td[@class="line-numbers"]', output, 1
+  end
+
+  test 'should number lines of source block if source-linenums-option document attribute is set' do
+    input = <<-EOS
+:source-highlighter: coderay
+:source-linenums-option:
+
+[source,ruby]
+----
+puts 'Hello, World!'
+----
+    EOS
+    output = convert_string_to_embedded input, safe: Asciidoctor::SafeMode::SAFE
+    assert_xpath '//td[@class="line-numbers"]', output, 1
+  end
+
+  test 'should set starting line number in HTML output if linenums option is enabled and start attribute is set' do
+    input = <<-EOS
+:source-highlighter: coderay
+:coderay-linenums-mode: inline
+
+[source%linenums,ruby,start=10]
+----
+puts 'Hello, World!'
+----
+    EOS
+    output = convert_string_to_embedded input, safe: Asciidoctor::SafeMode::SAFE
+    assert_xpath '//span[@class="line-numbers"]', output, 1
+    assert_xpath '//span[@class="line-numbers"][text()="10"]', output, 1
+  end
+
+  test 'should set starting line number in DocBook output if linenums option is enabled and start attribute is set' do
+    input = <<-EOS
+[source%linenums,java,start=3]
+----
+public class HelloWorld {
+public static void main(String[] args) {
+  out.println("Hello, World!");
+}
+}
+----
+    EOS
+
+    output = convert_string_to_embedded input, backend: :docbook, safe: Asciidoctor::SafeMode::SAFE
+    assert_css 'programlisting[startinglinenumber]', output, 1
+    assert_css 'programlisting[startinglinenumber="3"]', output, 1
+  end
+
+  test 'should highlight lines specified in highlight attribute if linenums is set and source-highlighter is coderay' do
+    %w(highlight="1,4-6" highlight=1;4..6 highlight=1;4..;!7).each do |highlight_attr|
+      input = <<-EOS
+:source-highlighter: coderay
+
+[source%linenums,java,#{highlight_attr}]
+----
+import static java.lang.System.out;
+
+public class HelloWorld {
+public static void main(String[] args) {
+  out.println("Hello, World!");
+}
+}
+----
+      EOS
+      output = convert_string_to_embedded input, safe: Asciidoctor::SafeMode::SAFE
+      assert_css 'strong.highlighted', output, 4
+      assert_xpath '//strong[@class="highlighted"][text()="1"]', output, 1
+      assert_xpath '//strong[@class="highlighted"][text()="2"]', output, 0
+      assert_xpath '//strong[@class="highlighted"][text()="3"]', output, 0
+      assert_xpath '//strong[@class="highlighted"][text()="4"]', output, 1
+      assert_xpath '//strong[@class="highlighted"][text()="5"]', output, 1
+      assert_xpath '//strong[@class="highlighted"][text()="6"]', output, 1
+      assert_xpath '//strong[@class="highlighted"][text()="7"]', output, 0
+    end
+  end
+
+  test 'should read source language from source-language document attribute if not specified on source block' do
+    input = <<-EOS
+:source-highlighter: coderay
+:source-language: ruby
+
+[source]
+----
+require 'coderay'
+
+html = CodeRay.scan("puts 'Hello, world!'", :ruby).div line_numbers: :table
+----
+    EOS
+    output = convert_string_to_embedded input, safe: Asciidoctor::SafeMode::SAFE, linkcss_default: true
+    assert_xpath '//pre[@class="CodeRay highlight"]/code[@data-lang="ruby"]//span[@class = "constant"][text() = "CodeRay"]', output, 1
+  end
+
+  test 'should rename document attribute named language to source-language when compat-mode is enabled' do
+    input = <<-EOS
+:language: ruby
+
+{source-language}
+    EOS
+
+    assert_equal 'ruby', (convert_inline_string input, attributes: { 'compat-mode' => '' })
+
+    input = <<-EOS
+:language: ruby
+
+{source-language}
+    EOS
+
+    assert_equal '{source-language}', (convert_inline_string input)
+  end
+
+  test 'should replace callout marks but not highlight them if source-highlighter attribute is coderay' do
+    input = <<-EOS
+:source-highlighter: coderay
+
+[source, ruby]
+----
+require 'coderay' # <1>
+
+html = CodeRay.scan("puts 'Hello, world!'", :ruby).div line_numbers: :table # <2>
+puts html # <3> <4>
+exit 0 # <5><6>
+----
+<1> Load library
+<2> Highlight source
+<3> Print to stdout
+<4> Redirect to a file to capture output
+<5> Exit program
+<6> Reports success
+    EOS
+    output = convert_string_to_embedded input, safe: Asciidoctor::SafeMode::SAFE
+    assert_match(/<span class="content">coderay<\/span>.* # <b class="conum">\(1\)<\/b>$/, output)
+    assert_match(/<span class="content">puts 'Hello, world!'<\/span>.* # <b class="conum">\(2\)<\/b>$/, output)
+    assert_match(/puts html.* # <b class="conum">\(3\)<\/b> <b class="conum">\(4\)<\/b>$/, output)
+    assert_match(/exit.* # <b class="conum">\(5\)<\/b> <b class="conum">\(6\)<\/b><\/code>/, output)
+  end
+
+  test 'should support autonumbered callout marks if source-highlighter attribute is coderay' do
+    input = <<-EOS
+:source-highlighter: coderay
+
+[source, ruby]
+----
+require 'coderay' # <.><.>
+
+html = CodeRay.scan("puts 'Hello, world!'", :ruby).div line_numbers: :table # <.>
+puts html # <.>
+----
+<.> Load library
+<.> Gem must be installed
+<.> Highlight source
+<.> Print to stdout
+    EOS
+    output = convert_string_to_embedded input, safe: Asciidoctor::SafeMode::SAFE
+    assert_match(/<span class="content">coderay<\/span>.* # <b class="conum">\(1\)<\/b> <b class="conum">\(2\)<\/b>$/, output)
+    assert_match(/<span class="content">puts 'Hello, world!'<\/span>.* # <b class="conum">\(3\)<\/b>$/, output)
+    assert_match(/puts html.* # <b class="conum">\(4\)<\/b><\/code>/, output)
+    assert_css '.colist ol', output, 1
+    assert_css '.colist ol li', output, 4
+  end
+
+  test 'should restore callout marks to correct lines if source highlighter is coderay and table line numbering is enabled' do
+    input = <<-EOS
+:source-highlighter: coderay
+:coderay-linenums-mode: table
+
+[source, ruby, numbered]
+----
+require 'coderay' # <1>
+
+html = CodeRay.scan("puts 'Hello, world!'", :ruby).div line_numbers: :table # <2>
+puts html # <3> <4>
+exit 0 # <5><6>
+----
+<1> Load library
+<2> Highlight source
+<3> Print to stdout
+<4> Redirect to a file to capture output
+<5> Exit program
+<6> Reports success
+    EOS
+    output = convert_string_to_embedded input, safe: Asciidoctor::SafeMode::SAFE
+    assert_match(/<span class="content">coderay<\/span>.* # <b class="conum">\(1\)<\/b>$/, output)
+    assert_match(/<span class="content">puts 'Hello, world!'<\/span>.* # <b class="conum">\(2\)<\/b>$/, output)
+    assert_match(/puts html.* # <b class="conum">\(3\)<\/b> <b class="conum">\(4\)<\/b>$/, output)
+    # NOTE notice there's a newline before the closing </pre> tag
+    assert_match(/exit.* # <b class="conum">\(5\)<\/b> <b class="conum">\(6\)<\/b>\n<\/pre>/, output)
+  end
+
+  test 'should restore isolated callout mark on last line of source when source highlighter is coderay' do
+    input = <<-EOS
+:source-highlighter: coderay
+
+[source,ruby,linenums]
+----
+require 'app'
+
+launch_app
+# <1>
+----
+<1> Profit.
+    EOS
+
+    output = convert_string_to_embedded input, safe: Asciidoctor::SafeMode::SAFE
+    # NOTE notice there's a newline before the closing </pre> tag
+    assert_match(/\n# <b class="conum">\(1\)<\/b>\n<\/pre>/, output)
+  end
+
+  test 'should preserve space before callout on final line' do
+    inputs = []
+
+    inputs << <<-EOS
+[source,yaml]
+----
+a: 'a'
+key: 'value' #<1>
+----
+<1> key-value pair
+    EOS
+
+    inputs << <<-EOS
+[source,ruby]
+----
+puts 'hi'
+puts 'value' #<1>
+----
+<1> print to stdout
+    EOS
+
+    inputs << <<-EOS
+[source,python]
+----
+print 'hi'
+print 'value' #<1>
+----
+<1> print to stdout
+    EOS
+
+    inputs.each do |input|
+      output = convert_string_to_embedded input, safe: Asciidoctor::SafeMode::SAFE, attributes: { 'source-highlighter' => 'coderay' }
+      output = output.gsub(/<\/?span.*?>/, '')
+      assert_includes output, '\'value\' #<b class="conum">(1)</b>'
+    end
+  end
+
+  test 'should preserve passthrough placeholders when highlighting source using coderay' do
+    input = <<-EOS
+:source-highlighter: coderay
+
+[source,java]
+[subs="specialcharacters,macros,callouts"]
+----
+public class Printer {
+public static void main(String[] args) {
+  System.pass:quotes[_out_].println("*asterisks* make text pass:quotes[*bold*]");
+}
+}
+----
+    EOS
+    output = convert_string input, safe: Asciidoctor::SafeMode::SAFE
+    assert_match(/\.<em>out<\/em>\./, output, 1)
+    assert_match(/\*asterisks\*/, output, 1)
+    assert_match(/<strong>bold<\/strong>/, output, 1)
+    refute_includes output, Asciidoctor::Substitutors::PASS_START
+  end
+
+  test 'should link to CodeRay stylesheet if source-highlighter is coderay and linkcss is set' do
+    input = <<-EOS
+:source-highlighter: coderay
+
+[source, ruby]
+----
+require 'coderay'
+
+html = CodeRay.scan("puts 'Hello, world!'", :ruby).div line_numbers: :table
+----
+    EOS
+    output = convert_string input, safe: Asciidoctor::SafeMode::SAFE, attributes: { 'linkcss' => '' }
+    assert_xpath '//pre[@class="CodeRay highlight"]/code[@data-lang="ruby"]//span[@class = "constant"][text() = "CodeRay"]', output, 1
+    assert_css 'link[rel="stylesheet"][href="./coderay-asciidoctor.css"]', output, 1
+  end
+
+  test 'should highlight source inline if source-highlighter attribute is coderay and coderay-css is style' do
+    input = <<-EOS
+:source-highlighter: coderay
+:coderay-css: style
+
+[source, ruby]
+----
+require 'coderay'
+
+html = CodeRay.scan("puts 'Hello, world!'", :ruby).div line_numbers: :table
+----
+    EOS
+    output = convert_string input, safe: Asciidoctor::SafeMode::SAFE, linkcss_default: true
+    assert_xpath '//pre[@class="CodeRay highlight"]/code[@data-lang="ruby"]//span[@style = "color:#036;font-weight:bold"][text() = "CodeRay"]', output, 1
+    refute_match(/\.CodeRay \{/, output)
+  end
+
+  test 'should include remote highlight.js assets if source-highlighter attribute is highlight.js' do
+    input = <<-EOS
+:source-highlighter: highlight.js
+
+[source, javascript]
+----
+<link rel="stylesheet" href="styles/default.css">
+<script src="highlight.pack.js"></script>
+<script>hljs.initHighlightingOnLoad();</script>
+----
+    EOS
+    output = convert_string input, safe: Asciidoctor::SafeMode::SAFE
+    assert_match(/<link .*highlight\.js/, output)
+    assert_match(/<script .*highlight\.js/, output)
+    assert_match(/hljs.initHighlightingOnLoad/, output)
+  end
+
+  test 'should add language-none class to source block when source-highlighter is highlight.js and language is not set' do
+    input = <<-EOS
+:source-highlighter: highlight.js
+
+[source]
+----
+[numbers]
+one
+two
+three
+----
+    EOS
+    output = convert_string input, safe: :safe
+    assert_css 'code.language-none', output, 1
+  end
+
+  test 'should add language classes to child code element when source-highlighter is prettify' do
+    input = <<-EOS
+[source,ruby]
+----
+puts "foo"
+----
+    EOS
+
+    output = convert_string_to_embedded input, attributes: { 'source-highlighter' => 'prettify' }
+    assert_css 'pre[class="prettyprint highlight"]', output, 1
+    assert_css 'pre > code[data-lang="ruby"]', output, 1
+  end
+
+  test 'should set linenums start if linenums are enabled and start attribute is set when source-highlighter is prettify' do
+    input = <<-EOS
+[source%linenums,ruby,start=5]
+----
+puts "foo"
+----
+    EOS
+
+    output = convert_string_to_embedded input, attributes: { 'source-highlighter' => 'prettify' }
+    assert_css 'pre[class="prettyprint highlight linenums:5"]', output, 1
+    assert_css 'pre > code[data-lang="ruby"]', output, 1
+  end
+
+  test 'should set lang attribute on pre when source-highlighter is html-pipeline' do
+    input = <<-EOS
+[source,ruby]
+----
+filters = [
+HTML::Pipeline::AsciiDocFilter,
+HTML::Pipeline::SanitizationFilter,
+HTML::Pipeline::SyntaxHighlightFilter
+]
+
+puts HTML::Pipeline.new(filters, {}).call(input)[:output]
+----
+    EOS
+
+    output = convert_string input, attributes: { 'source-highlighter' => 'html-pipeline' }
+    assert_css 'pre[lang="ruby"]', output, 1
+    assert_css 'pre[lang="ruby"] > code', output, 1
+    assert_css 'pre[class]', output, 0
+    assert_css 'code[class]', output, 0
+  end
+
+  test 'should not invoke highlight method on syntax highlighter if highlight? is false' do
+    Class.new Asciidoctor::SyntaxHighlighter::Base do
+      register_for 'unavailable'
+
+      def format node, language, opts
+        %(<pre class="highlight"><code class="language-#{language}" data-lang="#{language}">#{node.content}</code></pre>)
+      end
+
+      def highlight?
+        false
+      end
+    end
+
+    input = <<-EOS
+[source,ruby]
+----
+puts 'Hello, World!'
+----
+    EOS
+
+    doc = document_from_string input, attributes: { 'source-highlighter' => 'unavailable' }
+    output = doc.convert
+    assert_css 'pre.highlight > code.language-ruby', output, 1
+    source_block = (doc.find_by {|candidate| candidate.style == 'source' })[0]
+    assert_raises NotImplementedError do
+      doc.syntax_highlighter.highlight source_block, source_block.source, (source_block.attr 'language'), {}
+    end
+  end
+
+  context 'Pygments' do
+    test 'should highlight source if source-highlighter attribute is pygments' do
+      input = <<-EOS
+:source-highlighter: pygments
+:pygments-style: monokai
+
+[source,python]
+----
+from pygments import highlight
+from pygments.lexers import PythonLexer
+from pygments.formatters import HtmlFormatter
+
+source = 'print "Hello World"'
+print(highlight(source, PythonLexer(), HtmlFormatter()))
+----
+      EOS
+      output = convert_string input, safe: :safe, linkcss_default: true
+      assert_xpath '//pre[@class="pygments highlight"]/code[@data-lang="python"]/span[@class="tok-kn"][text()="import"]', output, 3
+      assert_includes output, 'pre.pygments '
+    end
+
+    test 'should gracefully fallback to default style if specified style not recognized' do
+      input = <<-EOS
+:source-highlighter: pygments
+:pygments-style: unknown
+
+[source,python]
+----
+from pygments import highlight
+from pygments.lexers import PythonLexer
+from pygments.formatters import HtmlFormatter
+
+source = 'print "Hello World"'
+print(highlight(source, PythonLexer(), HtmlFormatter()))
+----
+      EOS
+      output = convert_string input, safe: :safe, linkcss_default: true
+      assert_css 'pre.pygments', output, 1
+      assert_includes output, 'pre.pygments '
+      assert_includes output, '.tok-c { color: #408080;'
+    end
+
+    test 'should restore callout marks to correct lines if source highlighter is pygments and table line numbering is enabled' do
+      input = <<-EOS
+:source-highlighter: pygments
+:pygments-linenums-mode: table
+
+[source%linenums,ruby]
+----
+from pygments import highlight # <1>
+from pygments.lexers import PythonLexer
+from pygments.formatters import HtmlFormatter
+
+code = 'print "Hello World"'
+print(highlight(code, PythonLexer(), HtmlFormatter())) # <2><3>
+----
+<1> Load library
+<2> Highlight source
+<3> Print to stdout
+      EOS
+      output = convert_string_to_embedded input, safe: :safe
+      assert_match(/highlight<\/span> # <b class="conum">\(1\)<\/b>$/, output)
+      # NOTE notice there's a newline before the closing </pre> tag
+      assert_match(/\(\)\)\).*<\/span> # <b class="conum">\(2\)<\/b> <b class="conum">\(3\)<\/b>$/, output)
+    end
+
+    test 'should restore isolated callout mark on last line of source when source highlighter is pygments' do
+      input = <<-EOS
+:source-highlighter: pygments
+
+[source,ruby,linenums]
+----
+require 'app'
+
+launch_app
+# <1>
+----
+<1> Profit.
+      EOS
+
+      output = convert_string_to_embedded input, safe: :safe
+      # NOTE notice there's a newline before the closing </pre> tag, but not before the closing </td> tag
+      assert_match(/\n# <b class="conum">\(1\)<\/b>\n<\/pre><\/td>/, output)
+    end
+
+    test 'should not hardcode inline styles on lineno div and pre elements when linenums are enabled in table mode' do
+      input = <<-EOS
+:source-highlighter: pygments
+:pygments-css: inline
+
+[source%linenums,ruby]
+----
+puts 'Hello, World!'
+----
+      EOS
+
+      output = convert_string_to_embedded input, safe: :safe
+      assert_css 'div.linenodiv:not([style])', output, 1
+      assert_includes output, '<div class="linenodiv"><pre>'
+      assert_css 'pre:not([style])', output, 2
+    end
+
+    test 'should not hardcode styles on lineno spans when linenums are enabled and source-highlighter is pygments' do
+      input = <<-EOS
+:source-highlighter: pygments
+:pygments-css: inline
+:pygments-linenums-mode: inline
+
+[source%linenums,ruby]
+----
+puts 'Hello, World!'
+puts 'Hello, World!'
+puts 'Hello, World!'
+puts 'Hello, World!'
+puts 'Hello, World!'
+puts 'Hello, World!'
+puts 'Hello, World!'
+puts 'Hello, World!'
+puts 'Hello, World!'
+exit 0
+----
+      EOS
+
+      output = convert_string_to_embedded input, safe: :safe
+      assert_includes output, '<span class="lineno"> 1 </span>'
+      assert_includes output, '<span class="lineno">10 </span>'
+    end
+  end if ENV['PYGMENTS']
+end


### PR DESCRIPTION
resolves #2106

- define the Asciidoctor::SyntaxHighlighter module to handle all aspects of syntax highlighting
- define built-in SyntaxHighlighter adapters for coderay, pygments, highlight.js, html-pipeline, and prettify
- move all embedded syntax highlighting logic into SyntaxHighlighter adapters
- allow SyntaxHighlighter adapter class to self register with a source highlighter name using register_for
- load SyntaxHighlighter adapters lazily (except for highlight.js and html-pipeline)
- add :syntax_highlighters and :syntax_highlighter_factory options to API to allow syntax highlighter resolution to be customized
- instantiate SyntaxHighlighter adapter once header is finalized if source-highlighter attribute is set on document and basebackend is html
- provide SyntaxHighlighter factory modules for registering syntax highlighter adapters (default, custom, and default proxy)
- allow SyntaxHighlighter adapter to contribute docinfo at :head and :footer slots in HTML output document
- move retrieval and writing of stylesheets for syntax highlighters to SyntaxHighlighter adapters
- wire methods in Stylesheets class that pertain to syntax highlighting to SyntaxHighlighter adapters
- remove hard-coded styles in Pygments output
- update default stylesheets to support Pygments styles and drop CSS workarounds
- don't fail if value of pygments-style attribute is not recognized; instead fallback to default style
- don't remove nested pre tags in HTML produced by Pygments when linenums are enabled
- update default stylesheet to avoid styling nested pre tags
- rename pygments table class to pygments-table
- change pygments base CSS selector from .listingblock .pygments to pre.pygments
- allow color for generic text, line numbers, and line number border to inherit from Pygments style
- align stylesheet for default CodeRay style with other syntax highlighters
- set default background color for prettify using a selector with the lowest precedence
- update and add tests
- add tests for the Pygments integration
- add pygments.rb dependency and enable Pygments integration tests if the environment variable PYGMENTS=true is set
- move syntax highlighter tests to dedicated test file