### PR TITLE
resolves #3021 assume any shorthand interdocument xref is a source-to-source reference

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -15,7 +15,7 @@ For a detailed view of what has changed, refer to the {uri-repo}/commits/master[
 
 == Unreleased
 
-Enhancements::
+Enhancements / Compliance::
 
   * drop support for Ruby < 2.3 and JRuby < 9.1 and remove workarounds (#2764)
   * drop support for Slim < 3 (#2998)
@@ -48,6 +48,9 @@ Enhancements::
   * use the third argument of AbstractNode#attr / AbstractNode#attr? to set the name of a fallback attribute to look for on the document (#1934)
   * change default value of third argument to Abstractnode#attr / AbstractNode#attr? to nil so attribute doesn't inherit by default (#3059)
   * look for table-frame, table-grid, and table-stripes attributes on document as fallback for frame, grid, and stripes attributes on table (#3059)
+  * always assume the target of a shorthand interdocument xref is a reference to an AsciiDoc document (source-to-source) (#3021)
+  * if the target of a formal xref macro has a file extension, assume it's a path reference (#3021)
+  * never assume target of a formal xref macro is a path reference unless a file extension or fragment is present (#3021)
 
 Improvements::
 

--- a/lib/asciidoctor/substitutors.rb
+++ b/lib/asciidoctor/substitutors.rb
@@ -945,21 +945,27 @@ module Substitutors
           fragment = refid
         elsif (hash_idx = refid.index '#')
           if hash_idx > 0
-            if (fragment_len = refid.length - hash_idx - 1) > 0
+            if (fragment_len = refid.length - 1 - hash_idx) > 0
               path, fragment = (refid.slice 0, hash_idx), (refid.slice hash_idx + 1, fragment_len)
             else
-              path = refid.slice 0, hash_idx
+              path = refid.chop
             end
-            if (ext = ::File.extname path).empty?
+            if macro
+              src2src = (path = path.slice 0, path.length - 5) if path.end_with? '.adoc'
+            elsif (last_dot_idx = path.rindex '.') && ASCIIDOC_EXTENSIONS[path.slice last_dot_idx, path.length]
+              src2src = (path = path.slice 0, last_dot_idx)
+            else
               src2src = path
-            elsif ASCIIDOC_EXTENSIONS[ext]
-              src2src = (path = path.slice 0, path.length - ext.length)
             end
           else
             target, fragment = refid, (refid.slice 1, refid.length)
           end
-        elsif macro && (refid.end_with? '.adoc')
-          src2src = (path = refid.slice 0, refid.length - 5)
+        elsif macro && (refid.include? '.')
+          if refid.end_with? '.adoc'
+            src2src = (path = refid.slice 0, refid.length - 5)
+          else
+            path = refid
+          end
         else
           fragment = refid
         end


### PR DESCRIPTION
resolves #3021 

- always assume the target of a shorthand interdocument xref is a reference to an AsciiDoc document (source-to-source)
- if the target of a formal xref macro has a file extension, assume it's a path reference
- never assume the target of a formal xref macro is a path reference unless a file extension or fragment is present
- update tests

