### PR TITLE
resolves #3030 separate the -v and -w CLI flags

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -43,6 +43,7 @@ Enhancements::
   * when using a server-side syntax highlighter, highlight content of source block even if source language is not set (#3027)
   * remove the 2-character (i.e., `""`) quote block syntax
   * don't allow block role to inherit from document attribute; only look for role in block attributes (#1944)
+  * split out functionality of -w CLI flag (script warnings) from -v CLI flag (verbose logging) (#3030)
 
 Improvements::
 
@@ -57,8 +58,12 @@ Improvements::
   * ensure linenos class is added to linenos column when source highlighter is pygments and pygments-css=style
   * rename CSS class of Pygments line numbering table to linenotable (to align with Rouge) (#1040)
   * remove unused Converter#convert_with_options method (#2891)
+<<<<<<< HEAD
   * don't store the options attribute on the block once the options are parsed (#3051)
   * add an options method on AbstractNode to retrieve the set of option names (#3051)
+=======
+  * log possible invalid references at debug level (#3030)
+>>>>>>> d2a3e87d... resolves #3030 separate the -v and -w CLI flags
 
 Bug Fixes::
 

--- a/lib/asciidoctor/cli/invoker.rb
+++ b/lib/asciidoctor/cli/invoker.rb
@@ -33,7 +33,7 @@ module Asciidoctor
         return unless @options
 
         old_logger = old_logger_level = nil
-        old_verbose, $VERBOSE = $VERBOSE, false
+        old_verbose, $VERBOSE = $VERBOSE, @options[:warnings]
         opts = {}
         infiles = []
         outfile = nil
@@ -61,14 +61,13 @@ module Asciidoctor
           when :timings
             show_timings = val
           when :trace
-            # currently does nothing
+            # no assignment
           when :verbose
             case val
             when 0
               $VERBOSE = nil
               old_logger, LoggerManager.logger = logger, NullLogger.new
             when 2
-              $VERBOSE = true
               old_logger_level, logger.level = logger.level, ::Logger::Severity::DEBUG
             end
           else

--- a/lib/asciidoctor/substitutors.rb
+++ b/lib/asciidoctor/substitutors.rb
@@ -992,14 +992,14 @@ module Substitutors
         # handles: #id
         if target
           refid = fragment
-          logger.warn %(invalid reference: #{refid}) if $VERBOSE && !(doc.catalog[:ids].key? refid)
+          logger.debug %(possible invalid reference: #{refid}) if logger.debug? && !(doc.catalog[:ids].key? refid)
         elsif path
           # handles: path#, path#id, path.adoc#, path.adoc#id, or path.adoc (xref macro only)
           # the referenced path is the current document, or its contents have been included in the current document
           if src2src && (doc.attributes['docname'] == path || doc.catalog[:includes][path])
             if fragment
               refid, path, target = fragment, nil, %(##{fragment})
-              logger.warn %(invalid reference: #{refid}) if $VERBOSE && !(doc.catalog[:ids].key? refid)
+              logger.debug %(possible invalid reference: #{refid}) if logger.debug? && !(doc.catalog[:ids].key? refid)
             else
               refid, path, target = nil, nil, '#'
             end
@@ -1014,7 +1014,7 @@ module Substitutors
         # handles: id (in compat mode or when natural xrefs are disabled)
         elsif doc.compat_mode || !Compliance.natural_xrefs
           refid, target = fragment, %(##{fragment})
-          logger.warn %(invalid reference: #{refid}) if $VERBOSE && !(doc.catalog[:ids].key? refid)
+          logger.debug %(possible invalid reference: #{refid}) if logger.debug? && !(doc.catalog[:ids].key? refid)
         # handles: id
         elsif doc.catalog[:ids].key? fragment
           refid, target = fragment, %(##{fragment})
@@ -1024,7 +1024,7 @@ module Substitutors
           fragment, target = refid, %(##{refid})
         else
           refid, target = fragment, %(##{fragment})
-          logger.warn %(invalid reference: #{refid}) if $VERBOSE
+          logger.debug %(possible invalid reference: #{refid}) if logger.debug?
         end
         attrs['path'], attrs['fragment'], attrs['refid'] = path, fragment, refid
         Inline.new(self, :anchor, text, type: :xref, target: target, attributes: attrs).convert

--- a/man/asciidoctor.1
+++ b/man/asciidoctor.1
@@ -2,12 +2,12 @@
 .\"     Title: asciidoctor
 .\"    Author: Dan Allen, Sarah White, Ryan Waldron
 .\" Generator: Asciidoctor 2.0.0.dev
-.\"      Date: 2019-02-04
+.\"      Date: 2019-02-09
 .\"    Manual: Asciidoctor Manual
 .\"    Source: Asciidoctor 2.0.0.dev
 .\"  Language: English
 .\"
-.TH "ASCIIDOCTOR" "1" "2019-02-04" "Asciidoctor 2.0.0.dev" "Asciidoctor Manual"
+.TH "ASCIIDOCTOR" "1" "2019-02-09" "Asciidoctor 2.0.0.dev" "Asciidoctor Manual"
 .ie \n(.g .ds Aq \(aq
 .el       .ds Aq '
 .ss \n[.ss] 0
@@ -173,35 +173,39 @@ Matching templates found in subsequent directories override ones previously disc
 \fB\-\-failure\-level\fP=\fILEVEL\fP
 .RS 4
 The minimum logging level that triggers a non\-zero exit code (failure).
-If this option is not set (default: FATAL), the program exits with a status code zero even if warnings or errors have been logged.
+If this option is not set (default: FATAL), the program exits with exit code zero even if warnings or errors have been logged.
 .RE
 .sp
 \fB\-q, \-\-quiet\fP
 .RS 4
-Silence warnings.
+Silence application log messages and script warnings.
 .RE
 .sp
 \fB\-\-trace\fP
 .RS 4
-Include backtrace information on errors.
-Not enabled by default.
+Include backtrace information when reporting errors.
 .RE
 .sp
 \fB\-v, \-\-verbose\fP
 .RS 4
-Verbosely print processing information and configuration file checks to stderr.
+Verbosely print processing information to stderr, including debug\-level log messages.
+.RE
+.sp
+\fB\-w, \-\-warnings\fP
+.RS 4
+Turn on script warnings (applies to executed code).
 .RE
 .sp
 \fB\-t, \-\-timings\fP
 .RS 4
-Display timings information (time to read, parse and convert).
+Print timings report to stderr (time to read, parse and convert).
 .RE
 .SS "Program Information"
 .sp
 \fB\-h, \-\-help\fP [\fITOPIC\fP]
 .RS 4
-Print the help message.
-Show the command usage if \fITOPIC\fP is not specified (or not recognized).
+Print a help message.
+Show the command usage if \fITOPIC\fP is not specified or recognized.
 Dump the Asciidoctor man page (in troff/groff format) if \fITOPIC\fP is \fImanpage\fP.
 .RE
 .sp
@@ -209,7 +213,7 @@ Dump the Asciidoctor man page (in troff/groff format) if \fITOPIC\fP is \fImanpa
 .RS 4
 Print program version number.
 .sp
-\f(CR\-v\fP can also be used if no other flags or arguments are present.
+\fB\-v\fP can also be used if no source files are specified.
 .RE
 .SH "ENVIRONMENT"
 .sp

--- a/man/asciidoctor.adoc
+++ b/man/asciidoctor.adoc
@@ -126,32 +126,34 @@ Matching templates found in subsequent directories override ones previously disc
 
 *--failure-level*=_LEVEL_::
   The minimum logging level that triggers a non-zero exit code (failure).
-  If this option is not set (default: FATAL), the program exits with a status code zero even if warnings or errors have been logged.
+  If this option is not set (default: FATAL), the program exits with exit code zero even if warnings or errors have been logged.
 
 *-q, --quiet*::
-  Silence warnings.
+  Silence application log messages and script warnings.
 
 *--trace*::
-  Include backtrace information on errors.
-  Not enabled by default.
+  Include backtrace information when reporting errors.
 
 *-v, --verbose*::
-  Verbosely print processing information and configuration file checks to stderr.
+  Verbosely print processing information to stderr, including debug-level log messages.
+
+*-w, --warnings*::
+  Turn on script warnings (applies to executed code).
 
 *-t, --timings*::
-  Display timings information (time to read, parse and convert).
+  Print timings report to stderr (time to read, parse and convert).
 
 === Program Information
 
 *-h, --help* [_TOPIC_]::
-  Print the help message.
-  Show the command usage if _TOPIC_ is not specified (or not recognized).
+  Print a help message.
+  Show the command usage if _TOPIC_ is not specified or recognized.
   Dump the Asciidoctor man page (in troff/groff format) if _TOPIC_ is _manpage_.
 
 *-V, --version*::
   Print program version number.
 +
-`-v` can also be used if no other flags or arguments are present.
+*-v* can also be used if no source files are specified.
 
 == ENVIRONMENT
 

--- a/test/invoker_test.rb
+++ b/test/invoker_test.rb
@@ -161,6 +161,21 @@ context 'Invoker' do
     assert_match(/WARNING/, warnings)
   end
 
+  test 'should enable script warnings if -w flag is specified' do
+    old_verbose, $VERBOSE = $VERBOSE, false
+    begin
+      warnings = nil
+      redirect_streams do |out, err|
+        invoke_cli_to_buffer(%w(-w -o /dev/null), '-') { $NO_SUCH_VARIABLE || 'text' }
+        warnings = err.string
+      end
+      assert_equal false, $VERBOSE
+      refute_empty warnings
+    rescue
+      $VERBOSE = old_verbose
+    end
+  end
+
   test 'should silence warnings if -q flag is specified' do
     input = <<~'EOS'
     2. second

--- a/test/links_test.rb
+++ b/test/links_test.rb
@@ -514,7 +514,7 @@ anchor:foo[b[a\]r]text'
         doc.catalog[:includes]['tigers'] = true
         output = doc.convert
         assert_xpath '//a[@href="#about"][text() = "About Tigers"]', output, 1
-        assert_message logger, :WARN, 'invalid reference: about'
+        assert_message logger, :DEBUG, 'possible invalid reference: about'
       end
     end
   end
@@ -526,7 +526,7 @@ anchor:foo[b[a\]r]text'
         doc.catalog[:includes]['part1/tigers'] = true
         output = doc.convert
         assert_xpath '//a[@href="#about"][text() = "About Tigers"]', output, 1
-        assert_message logger, :WARN, 'invalid reference: about'
+        assert_message logger, :DEBUG, 'possible invalid reference: about'
       end
     end
   end
@@ -688,7 +688,7 @@ See <<foobaz>>.
       in_verbose_mode do
         output = convert_string_to_embedded input
         assert_xpath '//a[@href="#foobaz"][text() = "[foobaz]"]', output, 1
-        assert_message logger, :WARN, 'invalid reference: foobaz'
+        assert_message logger, :DEBUG, 'possible invalid reference: foobaz'
       end
     end
   end
@@ -706,7 +706,7 @@ See <<#foobaz>>.
       in_verbose_mode do
         output = convert_string_to_embedded input
         assert_xpath '//a[@href="#foobaz"][text() = "[foobaz]"]', output, 1
-        assert_message logger, :WARN, 'invalid reference: foobaz'
+        assert_message logger, :DEBUG, 'possible invalid reference: foobaz'
       end
     end
   end
@@ -787,7 +787,7 @@ See <<test.adoc#foobaz>>.
       in_verbose_mode do
         output = convert_string_to_embedded input, attributes: { 'docname' => 'test' }
         assert_xpath '//a[@href="#foobaz"][text() = "[foobaz]"]', output, 1
-        assert_message logger, :WARN, 'invalid reference: foobaz'
+        assert_message logger, :DEBUG, 'possible invalid reference: foobaz'
       end
     end
   end

--- a/test/options_test.rb
+++ b/test/options_test.rb
@@ -78,7 +78,7 @@ context 'Options' do
   end
 
   test 'basic argument assignment' do
-    options = Asciidoctor::Cli::Options.parse!(%w(-v -s -d book test/fixtures/sample.adoc))
+    options = Asciidoctor::Cli::Options.parse!(%w(-w -v -s -d book test/fixtures/sample.adoc))
 
     assert_equal 2, options[:verbose]
     assert_equal false, options[:header_footer]
@@ -255,6 +255,11 @@ context 'Options' do
   test 'should set verbose to 0 when -q flag is specified after -v flag' do
     options = Asciidoctor::Cli::Options.parse!(%w(-v -q test/fixtures/sample.adoc))
     assert_equal 0, options[:verbose]
+  end
+
+  test 'should enable warnings when -w flag is specified' do
+    options = Asciidoctor::Cli::Options.parse!(%w(-w test/fixtures/sample.adoc))
+    assert options[:warnings]
   end
 
   test 'should enable timings when -t flag is specified' do

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -321,10 +321,10 @@ class Minitest::Test
 
   def in_verbose_mode
     begin
-      old_verbose, $VERBOSE = $VERBOSE, true
+      old_logger_level, Asciidoctor::LoggerManager.logger.level = Asciidoctor::LoggerManager.logger.level, Logger::Severity::DEBUG
       yield
     ensure
-      $VERBOSE = old_verbose
+      Asciidoctor::LoggerManager.logger.level = old_logger_level
     end
   end
 


### PR DESCRIPTION
- use -v to set logger level to debug
- use -w to enable pedantic Ruby warnings (aka $VERBOSE = true)
- log possible invalid reference warnings at debug level

Note that -q still sets $VERBOSE = nil and is thus mutually exclusive with -w (in fact it overrides it).