### PR TITLE
resolves #1944 disable role inheritance 

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -42,6 +42,7 @@ Enhancements::
   * allow icontype to be set using icons attribute (#2953)
   * when using a server-side syntax highlighter, highlight content of source block even if source language is not set (#3027)
   * remove the 2-character (i.e., `""`) quote block syntax
+  * don't allow block role to inherit from document attribute; only look for role in block attributes (#1944)
 
 Improvements::
 

--- a/lib/asciidoctor/abstract_node.rb
+++ b/lib/asciidoctor/abstract_node.rb
@@ -193,59 +193,66 @@ class AbstractNode
     nil
   end
 
-  # Public: A convenience method that returns the value of the role attribute
+  # Public: Retrieves the space-separated String role for this node.
+  #
+  # Returns the role as a space-separated [String].
   def role
-    @attributes['role'] || @document.attributes['role']
+    @attributes['role']
   end
 
-  # Public: A convenience method that returns the role names as an Array
+  # Public: Retrieves the String role names for this node as an Array.
   #
-  # Returns the role names as an Array or an empty Array if the role attribute is absent.
+  # Returns the role names as a String [Array], which is empty if the role attribute is absent on this node.
   def roles
-    (val = @attributes['role'] || @document.attributes['role']).nil_or_empty? ? [] : val.split
+    (val = @attributes['role']) ? val.split : []
   end
 
-  # Public: A convenience method that checks if the role attribute is specified
-  def role? expected_value = nil
-    if expected_value
-      expected_value == (@attributes['role'] || @document.attributes['role'])
-    else
-      @attributes.key?('role') || @document.attributes.key?('role')
-    end
-  end
-
-  # Public: A convenience method that checks if the specified role is present
-  # in the list of roles on this node
-  def has_role?(name)
-    # NOTE center + include? is faster than split + include?
-    (val = @attributes['role'] || @document.attributes['role']) ? %( #{val} ).include?(%( #{name} )) : false
-  end
-
-  # Public: A convenience method that adds the given role directly to this node
+  # Public: Checks if the role attribute is set on this node and, if an expected value is given, whether the
+  # space-separated role matches that value.
   #
-  # Returns a Boolean indicating whether the role was added.
-  def add_role(name)
-    if (val = @attributes['role']).nil_or_empty?
+  # expected_value - The expected String value of the role (optional, default: nil)
+  #
+  # Returns a [Boolean] indicating whether the role attribute is set on this node and, if an expected value is given,
+  # whether the space-separated role matches that value.
+  def role? expected_value = nil
+    expected_value ? expected_value == @attributes['role'] : (@attributes.key? 'role')
+  end
+
+  # Public: Checks if the specified role is present in the list of roles for this node.
+  #
+  # name - The String name of the role to find.
+  #
+  # Returns a [Boolean] indicating whether this node has the specified role.
+  def has_role? name
+    # NOTE center + include? is faster than split + include?
+    (val = @attributes['role']) ? (%( #{val} ).include? %( #{name} )) : false
+  end
+
+  # Public: Adds the given role directly to this node.
+  #
+  # Returns a [Boolean] indicating whether the role was added.
+  def add_role name
+    if (val = @attributes['role'])
+      # NOTE center + include? is faster than split + include?
+      if %( #{val} ).include? %( #{name} )
+        false
+      else
+        @attributes['role'] = %(#{val} #{name})
+        true
+      end
+    else
       @attributes['role'] = name
       true
-    # NOTE center + include? is faster than split + include?
-    elsif %( #{val} ).include?(%( #{name} ))
-      false
-    else
-      @attributes['role'] = %(#{val} #{name})
-      true
     end
   end
 
-  # Public: A convenience method that removes the given role directly from this node
+  # Public: Removes the given role directly from this node.
   #
-  # Returns a Boolean indicating whether the role was removed.
-  def remove_role(name)
-    if (val = @attributes['role']).nil_or_empty?
-      false
-    elsif (val = val.split).delete name
+  # Returns a [Boolean] indicating whether the role was removed.
+  def remove_role name
+    if (val = @attributes['role']) && ((val = val.split).delete name)
       if val.empty?
-        @attributes.delete('role')
+        @attributes.delete 'role'
       else
         @attributes['role'] = val.join ' '
       end

--- a/lib/asciidoctor/converter/html5.rb
+++ b/lib/asciidoctor/converter/html5.rb
@@ -115,7 +115,7 @@ class Converter::Html5Converter < Converter::Base
     else
       classes = [node.doctype]
     end
-    classes << (node.attr 'docrole') if node.attr? 'docrole'
+    classes << node.role if node.role?
     body_attrs << %(class="#{classes.join ' '}")
     body_attrs << %(style="max-width: #{node.attr 'max-width'};") if node.attr? 'max-width'
     result << %(<body #{body_attrs.join ' '}>)

--- a/lib/asciidoctor/parser.rb
+++ b/lib/asciidoctor/parser.rb
@@ -151,7 +151,7 @@ class Parser
         doc_id = document.id
       end
       if (doc_role = block_attrs['role'])
-        doc_attrs['docrole'] = doc_role
+        doc_attrs['role'] = doc_role
       end
       if (doc_reftext = block_attrs['reftext'])
         doc_attrs['reftext'] = doc_reftext

--- a/test/attributes_test.rb
+++ b/test/attributes_test.rb
@@ -1245,6 +1245,18 @@ context 'Attributes' do
       assert p.role?
     end
 
+    test 'role? does not return true if role attribute is set on document' do
+      input = <<~'EOS'
+      :role: lead
+
+      A paragraph
+      EOS
+
+      doc = document_from_string input
+      p = doc.blocks.first
+      refute p.role?
+    end
+
     test 'role? can check for exact role name match' do
       input = <<~'EOS'
       [role="lead"]
@@ -1270,6 +1282,18 @@ context 'Attributes' do
       assert p.has_role?('lead')
     end
 
+    test 'has_role? does not look for role defined as document attribute' do
+      input = <<~'EOS'
+      :role: lead abstract
+
+      A paragraph
+      EOS
+
+      doc = document_from_string input
+      p = doc.blocks.first
+      refute p.has_role?('lead')
+    end
+
     test 'roles returns array of role names' do
       input = <<~'EOS'
       [role="story lead"]
@@ -1283,6 +1307,18 @@ context 'Attributes' do
 
     test 'roles returns empty array if role attribute is not set' do
       input = 'a paragraph'
+
+      doc = document_from_string input
+      p = doc.blocks.first
+      assert_equal [], p.roles
+    end
+
+    test 'roles does not return value of roles document attribute' do
+      input = <<~'EOS'
+      :role: story lead
+
+      A paragraph
+      EOS
 
       doc = document_from_string input
       p = doc.blocks.first


### PR DESCRIPTION
resolves #1944

- scope the role attribute to the block
- use attr/attr? to look up role with inheritance if necessary
- set role on document using role attribute instead of docrole attribute