### PR TITLE
resolves #3051 drop the options attribute

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -57,6 +57,8 @@ Improvements::
   * ensure linenos class is added to linenos column when source highlighter is pygments and pygments-css=style
   * rename CSS class of Pygments line numbering table to linenotable (to align with Rouge) (#1040)
   * remove unused Converter#convert_with_options method (#2891)
+  * don't store the options attribute on the block once the options are parsed (#3051)
+  * add an options method on AbstractNode to retrieve the set of option names (#3051)
 
 Bug Fixes::
 

--- a/lib/asciidoctor/abstract_node.rb
+++ b/lib/asciidoctor/abstract_node.rb
@@ -149,34 +149,32 @@ class AbstractNode
   # enabled on the current node.
   #
   # Check if the option is enabled. This method simply checks to see if the
-  # %name%-option attribute is defined on the current node.
+  # <name>-option attribute is defined on the current node.
   #
   # name    - the String or Symbol name of the option
   #
   # return a Boolean indicating whether the option has been specified
-  def option?(name)
+  def option? name
     @attributes.key? %(#{name}-option)
   end
 
   # Public: Set the specified option on this node.
   #
-  # This method sets the specified option on this node if not already set.
-  # It will add the name to the options attribute and set the <name>-option
-  # attribute.
+  # This method sets the specified option on this node by setting the <name>-option attribute.
   #
   # name - the String name of the option
   #
-  # returns truthy if the option was set or falsey if the option was already set
-  def set_option(name)
-    if (attrs = @attributes)['options']
-      unless attrs[key = %(#{name}-option)]
-        attrs['options'] += %(,#{name})
-        attrs[key] = ''
-      end
-    else
-      attrs['options'] = name
-      attrs[%(#{name}-option)] = ''
-    end
+  # Returns Nothing
+  def set_option name
+    @attributes[%(#{name}-option)] = ''
+    nil
+  end
+
+  # Public: Retrieve the Set of option names that are set on this node
+  #
+  # Returns a [Set] of option names
+  def options
+    ::Set.new.tap {|accum| @attributes.keys.each {|k| accum << (k.slice 0, k.length - 7) if k.to_s.end_with? '-option' } }
   end
 
   # Public: Update the attributes of this node with the new values in

--- a/lib/asciidoctor/abstract_node.rb
+++ b/lib/asciidoctor/abstract_node.rb
@@ -155,7 +155,7 @@ class AbstractNode
   #
   # return a Boolean indicating whether the option has been specified
   def option? name
-    @attributes.key? %(#{name}-option)
+    @attributes[%(#{name}-option)] ? true : false
   end
 
   # Public: Set the specified option on this node.

--- a/lib/asciidoctor/attribute_list.rb
+++ b/lib/asciidoctor/attribute_list.rb
@@ -158,9 +158,8 @@ class AttributeList
           value = value.delete ' ' if value.include? ' '
           (value.split ',').each {|opt| @attributes[%(#{opt}-option)] = '' unless opt.empty? }
         else
-          @attributes[%(#{value = value.strip}-option)] = ''
+          @attributes[%(#{value}-option)] = '' unless value.empty?
         end
-        @attributes['options'] = value
       else
         if single_quoted_value && @block
           case name

--- a/lib/asciidoctor/converter/html5.rb
+++ b/lib/asciidoctor/converter/html5.rb
@@ -771,7 +771,7 @@ Your browser does not support the audio tag.
       classes << %(stripes-#{stripes})
     end
     styles = []
-    if (autowidth = node.attributes['autowidth-option']) && !(node.attr? 'width', nil, false)
+    if (autowidth = node.option? 'autowidth') && !(node.attr? 'width', nil, false)
       classes << 'fit-content'
     elsif (tablewidth = node.attr 'tablepcwidth') == 100
       classes << 'stretch'
@@ -794,7 +794,7 @@ Your browser does not support the audio tag.
         result += (Array.new node.columns.size, %(<col#{slash}>))
       else
         node.columns.each do |col|
-          result << (col.attributes['autowidth-option'] ? %(<col#{slash}>) : %(<col style="width: #{col.attr 'colpcwidth'}%;"#{slash}>))
+          result << ((col.option? 'autowidth') ? %(<col#{slash}>) : %(<col style="width: #{col.attr 'colpcwidth'}%;"#{slash}>))
         end
       end
       result << '</colgroup>'

--- a/lib/asciidoctor/list.rb
+++ b/lib/asciidoctor/list.rb
@@ -114,8 +114,7 @@ class ListItem < AbstractBlock
     if (first_block = @blocks[0]) && Block === first_block &&
         ((first_block.context == :paragraph && !continuation_connects_first_block) ||
         ((content_adjacent || !continuation_connects_first_block) && first_block.context == :literal &&
-            first_block.attributes.key?('listparagraph-option')))
-
+            first_block.attributes['listparagraph-option']))
       block = blocks.shift
       block.lines.unshift @text unless @text.nil_or_empty?
       @text = block.source

--- a/lib/asciidoctor/list.rb
+++ b/lib/asciidoctor/list.rb
@@ -114,7 +114,7 @@ class ListItem < AbstractBlock
     if (first_block = @blocks[0]) && Block === first_block &&
         ((first_block.context == :paragraph && !continuation_connects_first_block) ||
         ((content_adjacent || !continuation_connects_first_block) && first_block.context == :literal &&
-            first_block.option?('listparagraph')))
+            first_block.attributes.key?('listparagraph-option')))
 
       block = blocks.shift
       block.lines.unshift @text unless @text.nil_or_empty?

--- a/lib/asciidoctor/parser.rb
+++ b/lib/asciidoctor/parser.rb
@@ -787,7 +787,7 @@ class Parser
         if doc_attrs.key? 'source-language'
           attributes['language'] = doc_attrs['source-language']
         end unless attributes.key? 'language'
-        if (attributes.key? 'linenums-option') || (doc_attrs.key? 'source-linenums-option')
+        if attributes['linenums-option'] || doc_attrs['source-linenums-option']
           attributes['linenums'] = ''
         end unless attributes.key? 'linenums'
         if doc_attrs.key? 'source-indent'
@@ -814,7 +814,7 @@ class Parser
         else
           attributes['language'] = language
         end
-        if (attributes.key? 'linenums-option') || (doc_attrs.key? 'source-linenums-option')
+        if attributes['linenums-option'] || doc_attrs['source-linenums-option']
           attributes['linenums'] = ''
         end unless attributes.key? 'linenums'
         if doc_attrs.key? 'source-indent'
@@ -2297,7 +2297,7 @@ class Parser
     skipped = table_reader.skip_blank_lines || 0
     parser_ctx = Table::ParserContext.new table_reader, table, attributes
     format, loop_idx, implicit_header_boundary = parser_ctx.format, -1, nil
-    implicit_header = true unless skipped > 0 || (attributes.key? 'header-option') || (attributes.key? 'noheader-option')
+    implicit_header = true unless skipped > 0 || attributes['header-option'] || attributes['noheader-option']
 
     while (line = table_reader.read_line)
       if (beyond_first = (loop_idx += 1) > 0) && line.empty?

--- a/lib/asciidoctor/parser.rb
+++ b/lib/asciidoctor/parser.rb
@@ -702,7 +702,7 @@ class Parser
         block = Block.new(parent, :literal, content_model: :verbatim, source: lines, attributes: attributes)
         # a literal gets special meaning inside of a description list
         # TODO this feels hacky, better way to distinguish from explicit literal block?
-        block.set_option('listparagraph') if in_list
+        block.set_option 'listparagraph' if in_list
       # a normal paragraph: contiguous non-blank/non-continuation lines (left-indented or normal style)
       else
         lines = read_paragraph_lines reader, skipped == 0 && ListItem === parent, skip_line_comments: true
@@ -1300,9 +1300,7 @@ class Parser
               catalog_inline_anchor $1, $2, list_item, reader
             end
           elsif item_text.start_with?('[ ] ', '[x] ', '[*] ')
-            # FIXME next_block wipes out update to options attribute
-            #list_block.set_option 'checklist' unless list_block.attributes['checklist-option']
-            list_block.attributes['checklist-option'] = ''
+            list_block.set_option 'checklist'
             list_item.attributes['checkbox'] = ''
             list_item.attributes['checked'] = '' unless item_text.start_with? '[ '
             list_item.text = item_text.slice(4, item_text.length)
@@ -2411,7 +2409,6 @@ class Parser
     if implicit_header
       table.has_header_option = true
       attributes['header-option'] = ''
-      attributes['options'] = (attributes.key? 'options') ? %(#{attributes['options']},header) : 'header'
     end
 
     table.partition_header_footer attributes
@@ -2606,7 +2603,6 @@ class Parser
 
         if parsed_attrs.key? :option
           (opts = parsed_attrs[:option]).each {|opt| attributes[%(#{opt}-option)] = '' }
-          attributes['options'] = (existing_opts = attributes['options']).nil_or_empty? ? (opts.join ',') : %(#{existing_opts},#{opts.join ','})
         end
 
         parsed_style

--- a/lib/asciidoctor/reader.rb
+++ b/lib/asciidoctor/reader.rb
@@ -687,7 +687,7 @@ class PreprocessorReader < Reader
 
     if path
       @path = path
-      @includes[Helpers.rootname path] = attributes['partial-option'] ? nil : true if @process_lines
+      @includes[Helpers.rootname path] = (attributes.key? 'partial-option') ? nil : true if @process_lines
     else
       @path = '<stdin>'
     end
@@ -1089,7 +1089,7 @@ class PreprocessorReader < Reader
         shift
         # FIXME not accounting for skipped lines in reader line numbering
         if inc_offset
-          parsed_attrs['partial-option'] = true
+          parsed_attrs['partial-option'] = ''
           push_include inc_lines, inc_path, relpath, inc_offset, parsed_attrs
         end
       elsif inc_tags
@@ -1154,7 +1154,7 @@ class PreprocessorReader < Reader
         end
         shift
         if inc_offset
-          parsed_attrs['partial-option'] = true unless base_select && wildcard && inc_tags.empty?
+          parsed_attrs['partial-option'] = '' unless base_select && wildcard && inc_tags.empty?
           # FIXME not accounting for skipped lines in reader line numbering
           push_include inc_lines, inc_path, relpath, inc_offset, parsed_attrs
         end

--- a/lib/asciidoctor/reader.rb
+++ b/lib/asciidoctor/reader.rb
@@ -687,7 +687,7 @@ class PreprocessorReader < Reader
 
     if path
       @path = path
-      @includes[Helpers.rootname path] = (attributes.key? 'partial-option') ? nil : true if @process_lines
+      @includes[Helpers.rootname path] = attributes['partial-option'] ? nil : true if @process_lines
     else
       @path = '<stdin>'
     end
@@ -1208,7 +1208,7 @@ class PreprocessorReader < Reader
       # include file is resolved relative to dir of current include, or base_dir if within original docfile
       inc_path = doc.normalize_system_path target, @dir, nil, target_name: 'include file'
       unless ::File.file? inc_path
-        if attributes.key? 'optional-option'
+        if attributes['optional-option']
           shift
           return true
         else

--- a/lib/asciidoctor/substitutors.rb
+++ b/lib/asciidoctor/substitutors.rb
@@ -1059,7 +1059,7 @@ module Substitutors
   #
   # Returns the converted String text
   def sub_post_replacements(text)
-    if (@document.attributes.key? 'hardbreaks') || (@attributes.key? 'hardbreaks-option')
+    if @document.attributes['hardbreaks'] || @attributes['hardbreaks-option']
       lines = text.split LF, -1
       return text if lines.size < 2
       last = lines.pop
@@ -1484,7 +1484,7 @@ module Substitutors
       when :simple
         default_subs = NORMAL_SUBS
       when :verbatim
-        if @context == :listing || (@context == :literal && !(@attributes.key? 'listparagraph-option'))
+        if @context == :listing || (@context == :literal && !@attributes['listparagraph-option'])
           default_subs = VERBATIM_SUBS
         elsif @context == :verse
           default_subs = NORMAL_SUBS

--- a/lib/asciidoctor/substitutors.rb
+++ b/lib/asciidoctor/substitutors.rb
@@ -1484,7 +1484,7 @@ module Substitutors
       when :simple
         default_subs = NORMAL_SUBS
       when :verbatim
-        if @context == :listing || (@context == :literal && !(option? 'listparagraph'))
+        if @context == :listing || (@context == :literal && !(@attributes.key? 'listparagraph-option'))
           default_subs = VERBATIM_SUBS
         elsif @context == :verse
           default_subs = NORMAL_SUBS

--- a/lib/asciidoctor/table.rb
+++ b/lib/asciidoctor/table.rb
@@ -47,7 +47,7 @@ class Table < AbstractBlock
     @rows = Rows.new
     @columns = []
 
-    @has_header_option = attributes.key? 'header-option'
+    @has_header_option = attributes['header-option'] ? true : false
 
     # smells like we need a utility method here
     # to resolve an integer width from potential bogus input
@@ -66,7 +66,7 @@ class Table < AbstractBlock
           ((@attributes['tablepcwidth'].to_f / 100) * @document.attributes['pagewidth']).round
     end
 
-    attributes['orientation'] = 'landscape' if attributes.key? 'rotate-option'
+    attributes['orientation'] = 'landscape' if attributes['rotate-option']
   end
 
   # Internal: Returns whether the current row being processed is
@@ -158,7 +158,7 @@ class Table < AbstractBlock
       @rows.head = [head]
     end
 
-    if num_body_rows > 0 && (attrs.key? 'footer-option')
+    if num_body_rows > 0 && attrs['footer-option']
       @rows.foot = [@rows.body.pop]
     end
 

--- a/lib/asciidoctor/table.rb
+++ b/lib/asciidoctor/table.rb
@@ -158,7 +158,7 @@ class Table < AbstractBlock
       @rows.head = [head]
     end
 
-    if num_body_rows > 0 && attrs.key?('footer-option')
+    if num_body_rows > 0 && (attrs.key? 'footer-option')
       @rows.foot = [@rows.body.pop]
     end
 

--- a/test/api_test.rb
+++ b/test/api_test.rb
@@ -1328,11 +1328,9 @@ context 'API' do
       EOS
 
       block = (document_from_string input).blocks[0]
-      assert block.set_option('reversed')
-      refute block.set_option('reversed')
-      assert block.option?('reversed')
+      block.set_option('reversed')
+      assert block.option? 'reversed'
       assert_equal '', block.attributes['reversed-option']
-      assert_equal 'reversed', block.attributes['options']
     end
 
     test 'should append option to existing options' do
@@ -1344,8 +1342,9 @@ context 'API' do
       EOS
 
       block = (document_from_string input).blocks[0]
-      assert block.set_option('reversed')
-      assert_equal 'fancy,reversed', block.attributes['options']
+      block.set_option('reversed')
+      assert block.option? 'fancy'
+      assert block.option? 'reversed'
     end
 
     test 'should not append option if option is already set' do
@@ -1358,7 +1357,19 @@ context 'API' do
 
       block = (document_from_string input).blocks[0]
       refute block.set_option('reversed')
-      assert_equal 'reversed', block.attributes['options']
+      assert_equal '', block.attributes['reversed-option']
+    end
+
+    test 'should return set of option names' do
+      input = <<~'EOS'
+      [%compact%reversed]
+      . three
+      . two
+      . one
+      EOS
+
+      block = (document_from_string input).blocks[0]
+      assert_equal %w(compact reversed).to_set, block.options
     end
   end
 end

--- a/test/attribute_list_test.rb
+++ b/test/attribute_list_test.rb
@@ -207,16 +207,24 @@ context 'AttributeList' do
 
   test 'collect options attribute' do
     attributes = {}
-    line = %(quote, options='opt1,opt2 , opt3')
-    expected = { 1 => 'quote', 'options' => 'opt1,opt2,opt3', 'opt1-option' => '', 'opt2-option' => '', 'opt3-option' => '' }
+    line = %(quote, options='opt1,,opt2 , opt3')
+    expected = { 1 => 'quote', 'opt1-option' => '', 'opt2-option' => '', 'opt3-option' => '' }
     Asciidoctor::AttributeList.new(line).parse_into(attributes)
     assert_equal expected, attributes
   end
 
   test 'collect opts attribute as options' do
     attributes = {}
-    line = %(quote, opts='opt1,opt2 , opt3')
-    expected = { 1 => 'quote', 'options' => 'opt1,opt2,opt3', 'opt1-option' => '', 'opt2-option' => '', 'opt3-option' => '' }
+    line = %(quote, opts='opt1,,opt2 , opt3')
+    expected = { 1 => 'quote', 'opt1-option' => '', 'opt2-option' => '', 'opt3-option' => '' }
+    Asciidoctor::AttributeList.new(line).parse_into(attributes)
+    assert_equal expected, attributes
+  end
+
+  test 'should ignore options attribute if empty' do
+    attributes = {}
+    line = %(quote, opts=)
+    expected = { 1 => 'quote' }
     Asciidoctor::AttributeList.new(line).parse_into(attributes)
     assert_equal expected, attributes
   end

--- a/test/attributes_test.rb
+++ b/test/attributes_test.rb
@@ -459,9 +459,9 @@ context 'Attributes' do
     test 'backend attributes defined in document options overrides backend attribute in document' do
       doc = document_from_string(':backend: docbook5', safe: Asciidoctor::SafeMode::SAFE, attributes: { 'backend' => 'html5' })
       assert_equal 'html5', doc.attributes['backend']
-      assert doc.attributes.has_key? 'backend-html5'
+      assert doc.attributes.key? 'backend-html5'
       assert_equal 'html', doc.attributes['basebackend']
-      assert doc.attributes.has_key? 'basebackend-html'
+      assert doc.attributes.key? 'basebackend-html'
     end
 
     test 'can only access a positional attribute from the attributes hash' do
@@ -1231,7 +1231,7 @@ context 'Attributes' do
 
       doc = document_from_string input
       para = doc.blocks.first
-      refute para.attributes.has_key?('id')
+      refute para.attributes.key?('id')
     end
 
     test 'role? returns true if role is assigned' do
@@ -1347,8 +1347,8 @@ context 'Attributes' do
       assert_equal :literal, para.context
       assert_equal 'first', para.attributes['id']
       assert_equal 'lead', para.attributes['role']
-      assert_equal 'step', para.attributes['options']
-      assert para.attributes.has_key?('step-option')
+      assert para.attributes.key?('step-option')
+      refute para.attributes.key?('options')
     end
 
     test 'id, role and options attributes can be specified using shorthand syntax on block style using multiple block attribute lines' do
@@ -1364,8 +1364,8 @@ context 'Attributes' do
       assert_equal :literal, para.context
       assert_equal 'first', para.attributes['id']
       assert_equal 'lead', para.attributes['role']
-      assert_equal 'step', para.attributes['options']
-      assert para.attributes.has_key?('step-option')
+      assert para.attributes.key?('step-option')
+      refute para.attributes.key?('options')
     end
 
     test 'multiple roles and options can be specified in block style using shorthand syntax' do
@@ -1377,9 +1377,9 @@ context 'Attributes' do
       doc = document_from_string input
       para = doc.blocks.first
       assert_equal 'role1 role2', para.attributes['role']
-      assert_equal 'option1,option2', para.attributes['options']
-      assert para.attributes.has_key?('option1-option')
-      assert para.attributes.has_key?('option2-option')
+      assert para.attributes.key?('option1-option')
+      assert para.attributes.key?('option2-option')
+      refute para.attributes.key?('options')
     end
 
     test 'options specified using shorthand syntax on block style across multiple lines should be additive' do
@@ -1391,9 +1391,9 @@ context 'Attributes' do
 
       doc = document_from_string input
       para = doc.blocks.first
-      assert_equal 'option1,option2', para.attributes['options']
-      assert para.attributes.has_key?('option1-option')
-      assert para.attributes.has_key?('option2-option')
+      assert para.attributes.key?('option1-option')
+      assert para.attributes.key?('option2-option')
+      refute para.attributes.key?('options')
     end
 
     test 'roles specified using shorthand syntax on block style across multiple lines should be additive' do
@@ -1531,8 +1531,8 @@ context 'Attributes' do
 
       doc = document_from_string input
       list = doc.blocks.first
-      assert_equal 'interactive', list.attributes['options']
-      assert list.attributes.has_key?('interactive-option')
+      assert list.attributes.key? 'interactive-option'
+      refute list.attributes.key? 'options'
     end
 
     test 'id and role attributes can be specified on section style using shorthand syntax' do

--- a/test/lists_test.rb
+++ b/test/lists_test.rb
@@ -4910,7 +4910,6 @@ context 'Checklists' do
     doc = document_from_string input
     checklist = doc.blocks[0]
     assert checklist.option?('checklist')
-    #assert_equal 'checklist', checklist.attributes['options']
     assert checklist.items[0].attr?('checkbox')
     refute checklist.items[0].attr?('checked')
     assert checklist.items[1].attr?('checkbox')

--- a/test/parser_test.rb
+++ b/test/parser_test.rb
@@ -109,8 +109,8 @@ context "Parser" do
     assert_equal 'id', attributes['id']
     assert_equal 'role', attributes['role']
     assert_equal '', attributes['fragment-option']
-    assert_equal 'fragment', attributes['options']
     assert_equal 'style.role#id%fragment', attributes[1]
+    refute attributes.key? 'options'
   end
 
   test 'parse style attribute with style, id and multiple roles' do
@@ -160,10 +160,9 @@ context "Parser" do
   end
 
   test 'parse style attribute with option should preserve existing options' do
-    attributes = { 1 => '%header', 'options' => 'footer', 'footer-option' => '' }
+    attributes = { 1 => '%header', 'footer-option' => '' }
     style = Asciidoctor::Parser.parse_style_attribute(attributes)
     assert_nil style
-    assert_equal 'footer,header', attributes['options']
     assert_equal '', attributes['header-option']
     assert_equal '', attributes['footer-option']
   end


### PR DESCRIPTION
- don't store the options attribute on the block once the options are parsed
- only store options as individual attributes (e.g., header-option)
- add an options method on AbstractNode to retrieve the set of option names
- store partial-option as empty string instead of true
- reference low-level option attribute internally