### PR TITLE
resolves #3060 require setext section title to have at least one alphanumeric character

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -66,6 +66,7 @@ Improvements::
 Bug Fixes::
 
   * don't fail to parse Markdown-style quote block that only contains attribution line (#2989)
+  * enforce rule that Setext section title must have at least one alphanumeric character; fixes problem w/ block nested inside quote block (#3060)
   * don't fail if value of pygments-style attribute is not recognized; gracefully fallback to default style (#2106)
   * do not alter the $LOAD_PATH (#2764)
   * remove conditional comment for IE in output of built-in HTML converter; fixes sidebar table of contents (#2983)

--- a/lib/asciidoctor.rb
+++ b/lib/asciidoctor.rb
@@ -603,7 +603,7 @@ module Asciidoctor
 
     # Matches the title only (first line) of an Setext (two-line) section title.
     # The title cannot begin with a dot and must have at least one alphanumeric character.
-    SetextSectionTitleRx = /^((?!\.)#{CC_ANY}*?#{CG_WORD}#{CC_ANY}*)$/
+    SetextSectionTitleRx = /^((?!\.)#{CC_ANY}*?#{CG_ALNUM}#{CC_ANY}*)$/
 
     # Matches an anchor (i.e., id + optional reference text) inside a section title.
     #

--- a/test/sections_test.rb
+++ b/test/sections_test.rb
@@ -528,6 +528,30 @@ context 'Sections' do
       assert_includes result, '----^^----'
     end
 
+    test 'should not recognize section title that does not contain alphanumeric character' do
+      input = <<~'EOS'
+      !@#$
+      ----
+      EOS
+
+      using_memory_logger do |logger|
+        result = convert_string_to_embedded input
+        assert_css 'h2', result, 0
+      end
+    end
+
+    test 'should not recognize section title that consists of only underscores' do
+      input = <<~'EOS'
+      ____
+      ----
+      EOS
+
+      using_memory_logger do |logger|
+        result = convert_string_to_embedded input
+        assert_css 'h2', result, 0
+      end
+    end
+
     test 'should preprocess second line of setext section title' do
       input = <<~'EOS'
       Section Title


### PR DESCRIPTION
resolves #3060

- although documented this way, the parser was checking for at least one word character, which is different