### PR TITLE
Resolves #3064, compute docyear and docdatetime from docdate and doctime

### DIFF
--- a/lib/asciidoctor/document.rb
+++ b/lib/asciidoctor/document.rb
@@ -1222,26 +1222,17 @@ class Document < AbstractBlock
     # %Z is OS dependent and may contain characters that aren't UTF-8 encoded (see asciidoctor#2770 and asciidoctor.js#23)
     localtime = (attrs['localtime'] ||= now.strftime %(%T #{now.utc_offset == 0 ? 'UTC' : '%z'}))
     attrs['localdatetime'] ||= %(#{localdate} #{localtime})
+    # docdate, doctime and docdatetime should default to localdate, localtime and localdatetime if not otherwise set
+    input_mtime = source_date_epoch || input_mtime || now
     if (docdate = attrs['docdate'])
       attrs['docyear'] ||= ((docdate.index '-') == 4 ? (docdate.slice 0, 4) : nil)
-    end
-    if input_mtime
-      input_mtime = source_date_epoch if source_date_epoch
-      docdate = (attrs['docdate'] ||= input_mtime.strftime '%F')
-      attrs['docyear'] ||= input_mtime.year.to_s
-      # %Z is OS dependent and may contain characters that aren't UTF-8 encoded (see asciidoctor#2770 and asciidoctor.js#23)
-      doctime = (attrs['doctime'] ||= input_mtime.strftime %(%T #{input_mtime.utc_offset == 0 ? 'UTC' : '%z'}))
-      attrs['docdatetime'] ||= %(#{docdate} #{doctime})
     else
-      # docdate, doctime and docdatetime should default to
-      # localdate, localtime and localdatetime if not otherwise set
-      doctime = (attrs['doctime'] ||= localtime)
-      docdate ||= localdate
-      attrs['docdate'] ||= docdate
-      attrs['docyear'] ||= localyear
-      attrs['doctime'] ||= doctime
-      attrs['docdatetime'] ||= %(#{docdate} #{doctime})
+      docdate = attrs['docdate'] = input_mtime.strftime '%F'
+      attrs['docyear'] ||= input_mtime.year.to_s
     end
+    # %Z is OS dependent and may contain characters that aren't UTF-8 encoded (see asciidoctor#2770 and asciidoctor.js#23)
+    doctime = (attrs['doctime'] ||= input_mtime.strftime %(%T #{input_mtime.utc_offset == 0 ? 'UTC' : '%z'}))
+    attrs['docdatetime'] ||= %(#{docdate} #{doctime})
     nil
   end
 

--- a/lib/asciidoctor/document.rb
+++ b/lib/asciidoctor/document.rb
@@ -1222,24 +1222,25 @@ class Document < AbstractBlock
     # %Z is OS dependent and may contain characters that aren't UTF-8 encoded (see asciidoctor#2770 and asciidoctor.js#23)
     localtime = (attrs['localtime'] ||= now.strftime %(%T #{now.utc_offset == 0 ? 'UTC' : '%z'}))
     attrs['localdatetime'] ||= %(#{localdate} #{localtime})
+    if (docdate = attrs['docdate'])
+      attrs['docyear'] ||= ((docdate.index '-') == 4 ? (docdate.slice 0, 4) : nil)
+    end
     if input_mtime
       input_mtime = source_date_epoch if source_date_epoch
-      if (docdate = attrs['docdate'])
-        attrs['docyear'] ||= ((docdate.index '-') == 4 ? (docdate.slice 0, 4) : nil)
-      else
-        docdate = attrs['docdate'] = input_mtime.strftime '%F'
-        attrs['docyear'] ||= input_mtime.year.to_s
-      end
+      docdate = (attrs['docdate'] ||= input_mtime.strftime '%F')
+      attrs['docyear'] ||= input_mtime.year.to_s
       # %Z is OS dependent and may contain characters that aren't UTF-8 encoded (see asciidoctor#2770 and asciidoctor.js#23)
       doctime = (attrs['doctime'] ||= input_mtime.strftime %(%T #{input_mtime.utc_offset == 0 ? 'UTC' : '%z'}))
       attrs['docdatetime'] ||= %(#{docdate} #{doctime})
     else
       # docdate, doctime and docdatetime should default to
       # localdate, localtime and localdatetime if not otherwise set
-      attrs['docdate'] ||= localdate
+      doctime = (attrs['doctime'] ||= localtime)
+      docdate ||= localdate
+      attrs['docdate'] ||= docdate
       attrs['docyear'] ||= localyear
-      attrs['doctime'] ||= localtime
-      attrs['docdatetime'] ||= %(#{localdate} #{localtime})
+      attrs['doctime'] ||= doctime
+      attrs['docdatetime'] ||= %(#{docdate} #{doctime})
     end
     nil
   end

--- a/test/document_test.rb
+++ b/test/document_test.rb
@@ -1718,4 +1718,44 @@ context 'Document' do
       assert_equal expect, result
     end
   end
+
+  context 'Date time attributes' do
+    test 'should compute docyear and docdatetime from docdate and doctime' do
+      doc = Asciidoctor::Document.new [], attributes: {'docdate' => '2015-01-01', 'doctime' => '10:00:00-0700'}
+      assert_equal '2015-01-01', (doc.attr 'docdate')
+      assert_equal '2015', (doc.attr 'docyear')
+      assert_equal '10:00:00-0700', (doc.attr 'doctime')
+      assert_equal '2015-01-01 10:00:00-0700', (doc.attr 'docdatetime')
+    end
+    test 'should allow docdate and doctime to be overridden' do
+      doc = Asciidoctor::Document.new [], input_mtime: ::Time.now, attributes: {'docdate' => '2015-01-01', 'doctime' => '10:00:00-0700'}
+      assert_equal '2015-01-01', (doc.attr 'docdate')
+      assert_equal '2015', (doc.attr 'docyear')
+      assert_equal '10:00:00-0700', (doc.attr 'doctime')
+      assert_equal '2015-01-01 10:00:00-0700', (doc.attr 'docdatetime')
+    end
+    test 'should compute docdatetime from doctime' do
+      doc = Asciidoctor::Document.new [], attributes: {'doctime' => '10:00:00-0700'}
+      assert_equal '10:00:00-0700', (doc.attr 'doctime')
+      assert (doc.attr 'docdatetime').end_with?(' 10:00:00-0700')
+    end
+    test 'should compute docyear from docdate' do
+      doc = Asciidoctor::Document.new [], attributes: {'docdate' => '2015-01-01'}
+      assert_equal '2015', (doc.attr 'docyear')
+      assert (doc.attr 'docdatetime').start_with?('2015-01-01 ')
+    end
+    test 'should allow doctime to be overridden' do
+      doc = Asciidoctor::Document.new [], input_mtime: ::Time.new(2019, 01, 02, 3, 4, 5, "+06:00"), attributes: {'doctime' => '10:00:00-0700'}
+      assert_equal '2019-01-02', (doc.attr 'docdate')
+      assert_equal '2019', (doc.attr 'docyear')
+      assert_equal '10:00:00-0700', (doc.attr 'doctime')
+      assert_equal '2019-01-02 10:00:00-0700', (doc.attr 'docdatetime')
+    end
+    test 'should allow docdate to be overridden' do
+      doc = Asciidoctor::Document.new [], input_mtime: ::Time.new(2019, 01, 02, 3, 4, 5, "+06:00"), attributes: {'docdate' => '2015-01-01'}
+      assert_equal '2015-01-01', (doc.attr 'docdate')
+      assert_equal '2015', (doc.attr 'docyear')
+      assert_equal '2015-01-01 03:04:05 +0600', (doc.attr 'docdatetime')
+    end
+  end
 end


### PR DESCRIPTION
Resolves #3064

The behavior is now consistent with either `convert_file` or `convert`.
It's also possible to override just  `docdate` or just `doctime`.

For instance we can use the document date but override the document time:

```rb
doc = Asciidoctor::Document.new [], input_mtime: ::Time.new(2019, 01, 02, 3, 4, 5, "+06:00"), attributes: {'doctime' => '10:00:00-0700'}
p doc.attr 'docdate' # '2019-01-02'
p doc.attr 'docyear' # '2019'
p doc.attr 'doctime' # '10:00:00-0700'
p doc.attr 'docdatetime' # '2019-01-02 10:00:00-0700'
```

In the example above, we override `doctime`.
As we can see, `docdatetime` is updated accordingly. The attributes `docdate` and `docyear` are using the document date (ie. `mtime`).

We can also just override `docdate`:

```rb
doc = Asciidoctor::Document.new [], input_mtime: ::Time.new(2019, 01, 02, 3, 4, 5, "+06:00"), attributes: {'docdate' => '2015-01-01'}
p doc.attr 'docdate' # '2015-01-01'
p doc.attr 'docyear' # '2015'
p doc.attr 'doctime' # '03:04:05 +0600'
p doc.attr 'docdatetime' # '2015-01-01 03:04:05 +0600'
```

