### PR TITLE
clean up newline handling in test suite

### DIFF
--- a/test/api_test.rb
+++ b/test/api_test.rb
@@ -231,14 +231,14 @@ context 'API' do
 
     test 'converts block to output format when convert is called' do
       doc = Asciidoctor.load 'paragraph text'
-      expected = <<~'EOS'
+      expected = <<~'EOS'.chop
       <div class="paragraph">
       <p>paragraph text</p>
       </div>
       EOS
       assert_equal 1, doc.blocks.length
       assert_equal :paragraph, doc.blocks[0].context
-      assert_equal expected.chomp, doc.blocks[0].convert
+      assert_equal expected, doc.blocks[0].convert
     end
 
     test 'render method on node is aliased to convert method' do

--- a/test/blocks_test.rb
+++ b/test/blocks_test.rb
@@ -1008,6 +1008,7 @@ context 'Blocks' do
     end
 
     test 'should strip leading and trailing blank lines when converting verbatim block' do
+      # NOTE cannot use single-quoted heredoc because of https://github.com/jruby/jruby/issues/4260
       input = <<~EOS
       [subs="attributes"]
       ....
@@ -1043,6 +1044,7 @@ context 'Blocks' do
     end
 
     test 'should remove block indent if indent attribute is 0' do
+      # NOTE cannot use single-quoted heredoc because of https://github.com/jruby/jruby/issues/4260
       input = <<~EOS
       [indent="0"]
       ----
@@ -1054,7 +1056,8 @@ context 'Blocks' do
       ----
       EOS
 
-      expected = <<~EOS
+      # NOTE cannot use single-quoted heredoc because of https://github.com/jruby/jruby/issues/4260
+      expected = <<~EOS.chop
       def names
 
         @names.split
@@ -1066,10 +1069,11 @@ context 'Blocks' do
       assert_css 'pre', output, 1
       assert_css '.listingblock pre', output, 1
       result = xmlnodes_at_xpath('//pre', output, 1).text
-      assert_equal expected.chomp, result
+      assert_equal expected, result
     end
 
     test 'should not remove block indent if indent attribute is -1' do
+      # NOTE cannot use single-quoted heredoc because of https://github.com/jruby/jruby/issues/4260
       input = <<~EOS
       [indent="-1"]
       ----
@@ -1081,16 +1085,17 @@ context 'Blocks' do
       ----
       EOS
 
-      expected = (input.lines.slice 2, 5).join
+      expected = (input.lines.slice 2, 5).join.chop
 
       output = convert_string_to_embedded input
       assert_css 'pre', output, 1
       assert_css '.listingblock pre', output, 1
       result = xmlnodes_at_xpath('//pre', output, 1).text
-      assert_equal expected.chomp, result
+      assert_equal expected, result
     end
 
     test 'should set block indent to value specified by indent attribute' do
+      # NOTE cannot use single-quoted heredoc because of https://github.com/jruby/jruby/issues/4260
       input = <<~EOS
       [indent="1"]
       ----
@@ -1102,16 +1107,17 @@ context 'Blocks' do
       ----
       EOS
 
-      expected = (input.lines.slice 2, 5).map {|l| l.sub '    ', ' ' }.join
+      expected = (input.lines.slice 2, 5).map {|l| l.sub '    ', ' ' }.join.chop
 
       output = convert_string_to_embedded input
       assert_css 'pre', output, 1
       assert_css '.listingblock pre', output, 1
       result = xmlnodes_at_xpath('//pre', output, 1).text
-      assert_equal expected.chomp, result
+      assert_equal expected, result
     end
 
     test 'should set block indent to value specified by indent document attribute' do
+      # NOTE cannot use single-quoted heredoc because of https://github.com/jruby/jruby/issues/4260
       input = <<~EOS
       :source-indent: 1
 
@@ -1125,13 +1131,13 @@ context 'Blocks' do
       ----
       EOS
 
-      expected = (input.lines.slice 4, 5).map {|l| l.sub '    ', ' '}.join
+      expected = (input.lines.slice 4, 5).map {|l| l.sub '    ', ' '}.join.chop
 
       output = convert_string_to_embedded input
       assert_css 'pre', output, 1
       assert_css '.listingblock pre', output, 1
       result = xmlnodes_at_xpath('//pre', output, 1).text
-      assert_equal expected.chomp, result
+      assert_equal expected, result
     end
 
     test 'should expand tabs if tabsize attribute is positive' do
@@ -1148,7 +1154,8 @@ context 'Blocks' do
       ----
       EOS
 
-      expected = <<~EOS
+      # NOTE cannot use single-quoted heredoc because of https://github.com/jruby/jruby/issues/4260
+      expected = <<~EOS.chop
       def names
 
           @names.split
@@ -1160,7 +1167,7 @@ context 'Blocks' do
       assert_css 'pre', output, 1
       assert_css '.listingblock pre', output, 1
       result = xmlnodes_at_xpath('//pre', output, 1).text
-      assert_equal expected.chomp, result
+      assert_equal expected, result
     end
 
     test 'literal block should honor nowrap option' do
@@ -1507,6 +1514,7 @@ context 'Blocks' do
     end
 
     test 'should strip leading and trailing blank lines when converting raw block' do
+      # NOTE cannot use single-quoted heredoc because of https://github.com/jruby/jruby/issues/4260
       input = <<~EOS
       ++++
       line above
@@ -1591,7 +1599,7 @@ context 'Blocks' do
       f: x |-> x + 1
       ++++
       EOS
-      expected = <<~'EOS'.chomp
+      expected = <<~'EOS'.chop
       \$f: bbb"N" -&gt; bbb"N"
       f: x |-&gt; x + 1\$
       EOS
@@ -1610,7 +1618,7 @@ context 'Blocks' do
       f: x |-> x + 1
       ++++
       EOS
-      expected = <<~'EOS'.chomp
+      expected = <<~'EOS'.chop
       \$f: bbb"N" -&gt; bbb"N"\$<br>
       \$f: x |-&gt; x + 1\$
       EOS
@@ -1630,7 +1638,7 @@ context 'Blocks' do
       f: x |-> x + 1
       ++++
       EOS
-      expected = <<~'EOS'.chomp
+      expected = <<~'EOS'.chop
       \$f: bbb"N" -&gt; bbb"N"\$<br>
       <br>
       \$f: x |-&gt; x + 1\$
@@ -1652,7 +1660,7 @@ context 'Blocks' do
       f: x |-> x + 1
       ++++
       EOS
-      expected = <<~'EOS'.chomp
+      expected = <<~'EOS'.chop
       \$f: bbb"N" -&gt; bbb"N"\$<br>
       <br>
       <br>
@@ -1702,7 +1710,7 @@ context 'Blocks' do
       ++++
       EOS
 
-      expect = <<~'EOS'.chomp
+      expect = <<~'EOS'.chop
       <informalequation>
       <mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML"><mml:mi>x</mml:mi><mml:mo>+</mml:mo><mml:mfrac><mml:mi>b</mml:mi><mml:mrow><mml:mn>2</mml:mn><mml:mi>a</mml:mi></mml:mrow></mml:mfrac><mml:mo>&lt;</mml:mo><mml:mo>&#xB1;</mml:mo><mml:msqrt><mml:mrow><mml:mfrac><mml:msup><mml:mi>b</mml:mi><mml:mn>2</mml:mn></mml:msup><mml:mrow><mml:mn>4</mml:mn><mml:msup><mml:mi>a</mml:mi><mml:mn>2</mml:mn></mml:msup></mml:mrow></mml:mfrac><mml:mo>&#x2212;</mml:mo><mml:mfrac><mml:mi>c</mml:mi><mml:mi>a</mml:mi></mml:mfrac></mml:mrow></mml:msqrt></mml:math>
       </informalequation>

--- a/test/converter_test.rb
+++ b/test/converter_test.rb
@@ -236,7 +236,7 @@ context 'Converter' do
         assert_equal %(block_#{node_name}.html.erb), File.basename(selected.templates[node_name].file)
       end
       # NOTE verify behavior of trim mode
-      expected_output = <<~'EOS'.chomp
+      expected_output = <<~'EOS'.chop
       <div class="openblock wrapper">
       <div class="content">
       <div class="paragraph">

--- a/test/extensions_test.rb
+++ b/test/extensions_test.rb
@@ -888,7 +888,7 @@ context 'Extensions' do
     end
 
     test 'should drop block macro line if target references missing attribute and attribute-missing is drop-line' do
-      input = <<~EOS
+      input = <<~'EOS'
       [.rolename]
       snippet::{gist-ns}12345[mode=edit]
 
@@ -1113,7 +1113,7 @@ context 'Extensions' do
         @target
         ++++
         EOS
-        expected = <<~'EOS'.chomp
+        expected = <<~'EOS'.chop
         target="", attributes=[]
         target="value,key=val", attributes=[[1, "value"], ["key", "val"], ["name", "value"]]
         target="", attributes=[["text", ""]]

--- a/test/lists_test.rb
+++ b/test/lists_test.rb
@@ -19,9 +19,9 @@ context "Bulleted lists (:ulist)" do
 
     test 'indented dash elements using spaces' do
       input = <<~EOS
-       - Foo
-       - Boo
-       - Blech
+      \x20- Foo
+      \x20- Boo
+      \x20- Blech
       EOS
       output = convert_string input
       assert_xpath '//ul', output, 1
@@ -224,6 +224,7 @@ context "Bulleted lists (:ulist)" do
     end
 
     test 'wrapped list item with hanging indent followed by non-indented line' do
+      # NOTE cannot use single-quoted heredoc because of https://github.com/jruby/jruby/issues/4260
       input = <<~EOS
       == Lists
 
@@ -236,7 +237,7 @@ context "Bulleted lists (:ulist)" do
       assert_css 'ul', output, 1
       assert_css 'ul li', output, 2
       # NOTE for some reason, we're getting an extra line after the indented line
-      lines = xmlnodes_at_xpath('(//ul/li)[1]/p', output, 1).text.gsub(/\n[[:space:]]*\n/, "\n").lines
+      lines = xmlnodes_at_xpath('(//ul/li)[1]/p', output, 1).text.gsub(/\n[[:space:]]*\n/, ?\n).lines
       assert_equal 3, lines.size
       assert_equal 'list item 1', lines[0].chomp
       assert_equal '  // not line comment', lines[1].chomp
@@ -244,6 +245,7 @@ context "Bulleted lists (:ulist)" do
     end
 
     test 'a list item with a nested marker terminates indented paragraph for text of list item' do
+      # NOTE cannot use single-quoted heredoc because of https://github.com/jruby/jruby/issues/4260
       input = <<~EOS
       - Foo
         Bar
@@ -257,8 +259,8 @@ context "Bulleted lists (:ulist)" do
 
     test 'a list item that starts with a sequence of list markers characters should not match a nested list' do
       input = <<~EOS
-       * first item
-       *. normal text
+      \x20* first item
+      \x20*. normal text
       EOS
 
       output = convert_string_to_embedded input
@@ -268,6 +270,7 @@ context "Bulleted lists (:ulist)" do
     end
 
     test 'a list item for a different list terminates indented paragraph for text of list item' do
+      # NOTE cannot use single-quoted heredoc because of https://github.com/jruby/jruby/issues/4260
       input = <<~EOS
       == Example 1
 
@@ -290,6 +293,7 @@ context "Bulleted lists (:ulist)" do
     end
 
     test "a literal paragraph offset by blank lines in list content is appended as a literal block" do
+      # NOTE cannot use single-quoted heredoc because of https://github.com/jruby/jruby/issues/4260
       input = <<~EOS
       List
       ====
@@ -311,6 +315,7 @@ context "Bulleted lists (:ulist)" do
     end
 
     test "a literal paragraph offset by a blank line in list content followed by line with continuation is appended as two blocks" do
+      # NOTE cannot use single-quoted heredoc because of https://github.com/jruby/jruby/issues/4260
       input = <<~EOS
       List
       ====
@@ -336,6 +341,7 @@ context "Bulleted lists (:ulist)" do
     end
 
     test 'an admonition paragraph attached by a line continuation to a list item with wrapped text should produce admonition' do
+      # NOTE cannot use single-quoted heredoc because of https://github.com/jruby/jruby/issues/4260
       input = <<~EOS
       - first-line text
         wrapped text
@@ -353,6 +359,7 @@ context "Bulleted lists (:ulist)" do
     end
 
     test 'paragraph-like blocks attached to an ancestory list item by a list continuation should produce blocks' do
+      # NOTE cannot use single-quoted heredoc because of https://github.com/jruby/jruby/issues/4260
       input = <<~EOS
       * parent
        ** child
@@ -436,6 +443,7 @@ context "Bulleted lists (:ulist)" do
     end
 
     test "a literal paragraph with a line that appears as a list item that is followed by a continuation should create two blocks" do
+      # NOTE cannot use single-quoted heredoc because of https://github.com/jruby/jruby/issues/4260
       input = <<~EOS
       * Foo
       +
@@ -458,6 +466,7 @@ context "Bulleted lists (:ulist)" do
     end
 
     test "consecutive literal paragraph offset by blank lines in list content are appended as a literal blocks" do
+      # NOTE cannot use single-quoted heredoc because of https://github.com/jruby/jruby/issues/4260
       input = <<~EOS
       List
       ====
@@ -483,6 +492,7 @@ context "Bulleted lists (:ulist)" do
     end
 
     test "a literal paragraph without a trailing blank line consumes following list items" do
+      # NOTE cannot use single-quoted heredoc because of https://github.com/jruby/jruby/issues/4260
       input = <<~EOS
       List
       ====
@@ -518,9 +528,9 @@ context "Bulleted lists (:ulist)" do
 
     test 'indented asterisk elements using spaces' do
       input = <<~EOS
-       * Foo
-       * Boo
-       * Blech
+      \x20* Foo
+      \x20* Boo
+      \x20* Blech
       EOS
       output = convert_string input
       assert_xpath '//ul', output, 1
@@ -529,9 +539,9 @@ context "Bulleted lists (:ulist)" do
 
     test 'indented unicode bullet elements using spaces' do
       input = <<~EOS
-       • Foo
-       • Boo
-       • Blech
+      \x20• Foo
+      \x20• Boo
+      \x20• Blech
       EOS
       output = convert_string input
       assert_xpath '//ul', output, 1
@@ -704,7 +714,7 @@ context "Bulleted lists (:ulist)" do
     end
 
     test 'should match trailing line separator in text of list item' do
-      input = <<~EOS.chomp
+      input = <<~EOS.chop
       * a
       * b#{decode_char 8232}
       * c
@@ -716,7 +726,7 @@ context "Bulleted lists (:ulist)" do
     end
 
     test 'should match line separator in text of list item' do
-      input = <<~EOS.chomp
+      input = <<~EOS.chop
       * a
       * b#{decode_char 8232}b
       * c
@@ -777,6 +787,7 @@ context "Bulleted lists (:ulist)" do
     end
 
     test "word ending sentence on continuing line not treated as a list item" do
+      # NOTE cannot use single-quoted heredoc because of https://github.com/jruby/jruby/issues/4260
       input = <<~EOS
       A. This is the story about
          AsciiDoc. It begins here.
@@ -964,6 +975,7 @@ context "Bulleted lists (:ulist)" do
     end
 
     test 'level of unordered list should match section level' do
+      # NOTE cannot use single-quoted heredoc because of https://github.com/jruby/jruby/issues/4260
       input = <<~EOS
       == Parent Section
 
@@ -1037,6 +1049,7 @@ context "Bulleted lists (:ulist)" do
     end
 
     test 'level of ordered list should match section level' do
+      # NOTE cannot use single-quoted heredoc because of https://github.com/jruby/jruby/issues/4260
       input = <<~EOS
       == Parent Section
 
@@ -1132,6 +1145,7 @@ context "Bulleted lists (:ulist)" do
     end
 
     test 'list item with literal content should not consume nested list of different type' do
+      # NOTE cannot use single-quoted heredoc because of https://github.com/jruby/jruby/issues/4260
       input = <<~EOS
       List
       ====
@@ -1157,6 +1171,7 @@ context "Bulleted lists (:ulist)" do
     end
 
     test 'nested list item does not eat the title of the following detached block' do
+      # NOTE cannot use single-quoted heredoc because of https://github.com/jruby/jruby/issues/4260
       input = <<~EOS
       List
       ====
@@ -1342,6 +1357,7 @@ context "Bulleted lists (:ulist)" do
     end
 
     test 'list item with hanging indent followed by block attached by list continuation' do
+      # NOTE cannot use single-quoted heredoc because of https://github.com/jruby/jruby/issues/4260
       input = <<~EOS
       == Lists
 
@@ -1627,6 +1643,7 @@ context "Bulleted lists (:ulist)" do
     end
 
     test 'indented outline list item with different marker offset by a blank line should be recognized as a nested list' do
+      # NOTE cannot use single-quoted heredoc because of https://github.com/jruby/jruby/issues/4260
       input = <<~EOS
       * item 1
 
@@ -1659,6 +1676,7 @@ context "Bulleted lists (:ulist)" do
     end
 
     test 'indented description list item inside outline list item offset by a blank line should be recognized as a nested list' do
+      # NOTE cannot use single-quoted heredoc because of https://github.com/jruby/jruby/issues/4260
       input = <<~EOS
       * item 1
 
@@ -1756,9 +1774,9 @@ context "Ordered lists (:olist)" do
 
     test 'indented dot elements using spaces' do
       input = <<~EOS
-       . Foo
-       . Boo
-       . Blech
+      \x20. Foo
+      \x20. Boo
+      \x20. Blech
       EOS
       output = convert_string input
       assert_xpath '//ol', output, 1
@@ -1971,7 +1989,7 @@ context "Ordered lists (:olist)" do
     end
 
     test 'should match trailing line separator in text of list item' do
-      input = <<~EOS.chomp
+      input = <<~EOS.chop
       . a
       . b#{decode_char 8232}
       . c
@@ -1983,7 +2001,7 @@ context "Ordered lists (:olist)" do
     end
 
     test 'should match line separator in text of list item' do
-      input = <<~EOS.chomp
+      input = <<~EOS.chop
       . a
       . b#{decode_char 8232}b
       . c
@@ -2086,6 +2104,7 @@ context "Description lists (:dlist)" do
     end
 
     test "single-line indented adjacent elements" do
+      # NOTE cannot use single-quoted heredoc because of https://github.com/jruby/jruby/issues/4260
       input = <<~EOS
       term1:: def1
        term2:: def2
@@ -2191,6 +2210,7 @@ context "Description lists (:dlist)" do
     end
 
     test "multi-line elements with indented paragraph content" do
+      # NOTE cannot use single-quoted heredoc because of https://github.com/jruby/jruby/issues/4260
       input = <<~EOS
       term1::
        def1
@@ -2208,6 +2228,7 @@ context "Description lists (:dlist)" do
     end
 
     test "multi-line elements with indented paragraph content that includes comment lines" do
+      # NOTE cannot use single-quoted heredoc because of https://github.com/jruby/jruby/issues/4260
       input = <<~EOS
       term1::
        def1
@@ -2228,6 +2249,7 @@ context "Description lists (:dlist)" do
     end
 
     test "should not strip comment line in literal paragraph block attached to list item" do
+      # NOTE cannot use single-quoted heredoc because of https://github.com/jruby/jruby/issues/4260
       input = <<~EOS
       term1::
       +
@@ -2241,6 +2263,7 @@ context "Description lists (:dlist)" do
     end
 
     test 'multi-line element with paragraph starting with multiple dashes should not be seen as list' do
+      # NOTE cannot use single-quoted heredoc because of https://github.com/jruby/jruby/issues/4260
       input = <<~EOS
       term1::
         def1
@@ -2312,6 +2335,7 @@ context "Description lists (:dlist)" do
 
     test "multi-line elements with paragraph and literal content" do
       # blank line following literal paragraph is required or else it will gobble up the second term
+      # NOTE cannot use single-quoted heredoc because of https://github.com/jruby/jruby/issues/4260
       input = <<~EOS
       term1::
       def1
@@ -2561,6 +2585,7 @@ context "Description lists (:dlist)" do
     end
 
     test "should only grab one literal line following last item if item has no inline description" do
+      # NOTE cannot use single-quoted heredoc because of https://github.com/jruby/jruby/issues/4260
       input = <<~EOS
       term1::
 
@@ -2585,6 +2610,7 @@ context "Description lists (:dlist)" do
     end
 
     test "should append subsequent paragraph literals to list item as block content" do
+      # NOTE cannot use single-quoted heredoc because of https://github.com/jruby/jruby/issues/4260
       input = <<~EOS
       term1::
 
@@ -2723,7 +2749,7 @@ context "Description lists (:dlist)" do
     end
 
     test 'should match trailing line separator in text of list item' do
-      input = <<~EOS.chomp
+      input = <<~EOS.chop
       A:: a
       B:: b#{decode_char 8232}
       C:: c
@@ -2735,7 +2761,7 @@ context "Description lists (:dlist)" do
     end
 
     test 'should match line separator in text of list item' do
-      input = <<~EOS.chomp
+      input = <<~EOS.chop
       A:: a
       B:: b#{decode_char 8232}b
       C:: c
@@ -2759,6 +2785,7 @@ context "Description lists (:dlist)" do
     end
 
     test 'should not parse a nested indented dlist delimiter without a term as a dlist' do
+      # NOTE cannot use single-quoted heredoc because of https://github.com/jruby/jruby/issues/4260
       input = <<~EOS
       t::
       desc
@@ -2898,6 +2925,7 @@ context "Description lists (:dlist)" do
     end
 
     test "multi-line element with indented nested element" do
+      # NOTE cannot use single-quoted heredoc because of https://github.com/jruby/jruby/issues/4260
       input = <<~EOS
       term1::
         def1
@@ -2921,6 +2949,7 @@ context "Description lists (:dlist)" do
     end
 
     test "mixed single and multi-line elements with indented nested elements" do
+      # NOTE cannot use single-quoted heredoc because of https://github.com/jruby/jruby/issues/4260
       input = <<~EOS
       term1:: def1
         label1:::
@@ -3112,6 +3141,7 @@ context "Description lists (:dlist)" do
     end
 
     test 'should convert qanda list in HTML with proper semantics' do
+      # NOTE cannot use single-quoted heredoc because of https://github.com/jruby/jruby/issues/4260
       input = <<~EOS
       [qanda]
       Question 1::
@@ -3136,6 +3166,7 @@ context "Description lists (:dlist)" do
     end
 
     test 'should convert qanda list in DocBook with proper semantics' do
+      # NOTE cannot use single-quoted heredoc because of https://github.com/jruby/jruby/issues/4260
       input = <<~EOS
       [qanda]
       Question 1::
@@ -3178,6 +3209,7 @@ context "Description lists (:dlist)" do
     end
 
     test 'should convert bibliography list with proper semantics' do
+      # NOTE cannot use single-quoted heredoc because of https://github.com/jruby/jruby/issues/4260
       input = <<~EOS
       [bibliography]
       - [[[taoup]]] Eric Steven Raymond. 'The Art of Unix
@@ -3198,6 +3230,7 @@ context "Description lists (:dlist)" do
     end
 
     test 'should convert bibliography list with proper semantics to DocBook' do
+      # NOTE cannot use single-quoted heredoc because of https://github.com/jruby/jruby/issues/4260
       input = <<~EOS
       [bibliography]
       - [[[taoup]]] Eric Steven Raymond. 'The Art of Unix
@@ -3234,6 +3267,7 @@ context "Description lists (:dlist)" do
     end
 
     test 'should automatically add bibliography style to top-level lists in bibliography section' do
+      # NOTE cannot use single-quoted heredoc because of https://github.com/jruby/jruby/issues/4260
       input = <<~EOS
       [bibliography]
       == Bibliography
@@ -3432,6 +3466,7 @@ context 'Description lists redux' do
     end
 
     test 'folds text from subsequent indented line' do
+      # NOTE cannot use single-quoted heredoc because of https://github.com/jruby/jruby/issues/4260
       input = <<~EOS
       == Lists
 
@@ -3446,6 +3481,7 @@ context 'Description lists redux' do
     end
 
     test 'folds text from indented line after blank line' do
+      # NOTE cannot use single-quoted heredoc because of https://github.com/jruby/jruby/issues/4260
       input = <<~EOS
       == Lists
 
@@ -3570,6 +3606,7 @@ context 'Description lists redux' do
     end
 
     test 'folds text of first literal line offset by blank line appends subsequent literals offset by blank line as blocks' do
+      # NOTE cannot use single-quoted heredoc because of https://github.com/jruby/jruby/issues/4260
       input = <<~EOS
       == Lists
 
@@ -3592,6 +3629,7 @@ context 'Description lists redux' do
     end
 
     test 'folds text of subsequent line and appends following literal line offset by blank line as block if term has no inline description' do
+      # NOTE cannot use single-quoted heredoc because of https://github.com/jruby/jruby/issues/4260
       input = <<~EOS
       == Lists
 
@@ -3612,6 +3650,7 @@ context 'Description lists redux' do
     end
 
     test 'appends literal line attached by continuation as block if item has no inline description' do
+      # NOTE cannot use single-quoted heredoc because of https://github.com/jruby/jruby/issues/4260
       input = <<~EOS
       == Lists
 
@@ -3629,6 +3668,7 @@ context 'Description lists redux' do
     end
 
     test 'appends literal line attached by continuation as block if item has no inline description followed by ruler' do
+      # NOTE cannot use single-quoted heredoc because of https://github.com/jruby/jruby/issues/4260
       input = <<~EOS
       == Lists
 
@@ -3754,6 +3794,7 @@ context 'Description lists redux' do
     end
 
     test 'appends indented list to first term that is adjacent to second term' do
+      # NOTE cannot use single-quoted heredoc because of https://github.com/jruby/jruby/issues/4260
       input = <<~EOS
       == Lists
 
@@ -3782,6 +3823,7 @@ context 'Description lists redux' do
     end
 
     test 'appends indented list to first term that is attached by a continuation and adjacent to second term' do
+      # NOTE cannot use single-quoted heredoc because of https://github.com/jruby/jruby/issues/4260
       input = <<~EOS
       == Lists
 
@@ -3858,6 +3900,7 @@ context 'Description lists redux' do
     end
 
     test 'literal line attached by continuation swallows adjacent line that looks like term' do
+      # NOTE cannot use single-quoted heredoc because of https://github.com/jruby/jruby/issues/4260
       input = <<~EOS
       == Lists
 
@@ -4078,6 +4121,7 @@ context 'Description lists redux' do
     end
 
     test 'folds text from inline description and subsequent indented line' do
+      # NOTE cannot use single-quoted heredoc because of https://github.com/jruby/jruby/issues/4260
       input = <<~EOS
       == List
 
@@ -4092,6 +4136,7 @@ context 'Description lists redux' do
     end
 
     test 'appends literal line offset by blank line as block if item has inline description' do
+      # NOTE cannot use single-quoted heredoc because of https://github.com/jruby/jruby/issues/4260
       input = <<~EOS
       == Lists
 
@@ -4109,6 +4154,7 @@ context 'Description lists redux' do
     end
 
     test 'appends literal line offset by blank line as block and appends line after continuation as block if item has inline description' do
+      # NOTE cannot use single-quoted heredoc because of https://github.com/jruby/jruby/issues/4260
       input = <<~EOS
       == Lists
 
@@ -4130,6 +4176,7 @@ context 'Description lists redux' do
     end
 
     test 'appends line after continuation as block and literal line offset by blank line as block if item has inline description' do
+      # NOTE cannot use single-quoted heredoc because of https://github.com/jruby/jruby/issues/4260
       input = <<~EOS
       == Lists
 
@@ -4169,6 +4216,7 @@ context 'Description lists redux' do
     end
 
     test 'appends literal line attached by continuation as block if item has inline description followed by ruler' do
+      # NOTE cannot use single-quoted heredoc because of https://github.com/jruby/jruby/issues/4260
       input = <<~EOS
       == Lists
 
@@ -4206,6 +4254,7 @@ context 'Description lists redux' do
     end
 
     test 'nested term with description does not consume following heading' do
+      # NOTE cannot use single-quoted heredoc because of https://github.com/jruby/jruby/issues/4260
       input = <<~EOS
       == Lists
 
@@ -4686,6 +4735,7 @@ context 'Callout lists' do
   end
 
   test 'should not recognize callouts in an indented description list paragraph' do
+    # NOTE cannot use single-quoted heredoc because of https://github.com/jruby/jruby/issues/4260
     input = <<~EOS
     foo::
       bar <1>
@@ -4702,6 +4752,7 @@ context 'Callout lists' do
   end
 
   test 'should not recognize callouts in an indented outline list paragraph' do
+    # NOTE cannot use single-quoted heredoc because of https://github.com/jruby/jruby/issues/4260
     input = <<~EOS
     * foo
       bar <1>
@@ -4816,6 +4867,7 @@ context 'Callout lists' do
   end
 
   test 'should allow line comment chars that precede callout number to be specified' do
+    # NOTE cannot use single-quoted heredoc because of https://github.com/jruby/jruby/issues/4260
     input = <<~EOS
     [source,erlang,line-comment=%]
     ----
@@ -4918,7 +4970,7 @@ context 'Callout lists' do
   end
 
   test 'should match trailing line separator in text of list item' do
-    input = <<~EOS.chomp
+    input = <<~EOS.chop
     ----
     A <1>
     B <2>
@@ -4935,7 +4987,7 @@ context 'Callout lists' do
   end
 
   test 'should match line separator in text of list item' do
-    input = <<~EOS.chomp
+    input = <<~EOS.chop
     ----
     A <1>
     B <2>
@@ -5094,6 +5146,7 @@ context 'Lists model' do
   end
 
   test 'simple? should return true for list item with nested outline list' do
+    # NOTE cannot use single-quoted heredoc because of https://github.com/jruby/jruby/issues/4260
     input = <<~EOS
     * one
       ** more about one

--- a/test/logger_test.rb
+++ b/test/logger_test.rb
@@ -200,9 +200,9 @@ context 'Logger' do
       EOS
       messages = redirect_streams do |_, err|
         convert_string_to_embedded input
-        err.string
+        err.string.chomp
       end
-      assert_equal 'asciidoctor: WARNING: <stdin>: line 5: id assigned to block already in use: first', messages.chomp
+      assert_equal 'asciidoctor: WARNING: <stdin>: line 5: id assigned to block already in use: first', messages
     end
   end
 end

--- a/test/manpage_test.rb
+++ b/test/manpage_test.rb
@@ -2,7 +2,7 @@
 require_relative 'test_helper'
 
 context 'Manpage' do
-  SAMPLE_MANPAGE_HEADER = <<~'EOS'.chomp
+  SAMPLE_MANPAGE_HEADER = <<~'EOS'.chop
   = command (1)
   Author Name
   :doctype: manpage
@@ -153,14 +153,14 @@ context 'Manpage' do
     end
 
     test 'should require specialchars in value of man-linkstyle attribute defined in document to be escaped' do
-      input = <<~EOS.chomp
+      input = <<~EOS.chop
       :man-linkstyle: cyan R < >
       #{SAMPLE_MANPAGE_HEADER}
       EOS
       output = Asciidoctor.convert input, backend: :manpage, header_footer: true
       assert_includes output.lines, %(.  LINKSTYLE cyan R &lt; &gt;\n)
 
-      input = <<~EOS.chomp
+      input = <<~EOS.chop
       :man-linkstyle: pass:[cyan R < >]
       #{SAMPLE_MANPAGE_HEADER}
       EOS
@@ -171,7 +171,7 @@ context 'Manpage' do
 
   context 'Manify' do
     test 'should unescape literal ampersand' do
-      input = <<~EOS.chomp
+      input = <<~EOS.chop
       #{SAMPLE_MANPAGE_HEADER}
 
       (C) & (R) are translated to character references, but not the &.
@@ -181,7 +181,7 @@ context 'Manpage' do
     end
 
     test 'should replace em dashes' do
-      input = <<~EOS.chomp
+      input = <<~EOS.chop
       #{SAMPLE_MANPAGE_HEADER}
 
       go -- to
@@ -194,7 +194,7 @@ context 'Manpage' do
     end
 
     test 'should escape lone period' do
-      input = <<~EOS.chomp
+      input = <<~EOS.chop
       #{SAMPLE_MANPAGE_HEADER}
 
       .
@@ -204,7 +204,7 @@ context 'Manpage' do
     end
 
     test 'should escape raw macro' do
-      input = <<~EOS.chomp
+      input = <<~EOS.chop
       #{SAMPLE_MANPAGE_HEADER}
 
       AAA this line of text should be show
@@ -217,7 +217,7 @@ context 'Manpage' do
     end
 
     test 'should normalize whitespace in a paragraph' do
-      input = <<~EOS.chomp
+      input = <<~EOS.chop
       #{SAMPLE_MANPAGE_HEADER}
 
       Oh, here it goes again
@@ -231,7 +231,7 @@ context 'Manpage' do
     end
 
     test 'should normalize whitespace in a list item' do
-      input = <<~EOS.chomp
+      input = <<~EOS.chop
       #{SAMPLE_MANPAGE_HEADER}
 
       * Oh, here it goes again
@@ -245,7 +245,7 @@ context 'Manpage' do
     end
 
     test 'should collapse whitespace in the man manual and man source' do
-      input = <<~EOS.chomp
+      input = <<~EOS.chop
       #{SAMPLE_MANPAGE_HEADER}
 
       Describe this thing.
@@ -271,7 +271,7 @@ context 'Manpage' do
     end
 
     test 'should preserve backslashes in escape sequences' do
-      input = <<~EOS.chomp
+      input = <<~EOS.chop
       #{SAMPLE_MANPAGE_HEADER}
 
       "`hello`" '`goodbye`' *strong* _weak_ `even`
@@ -281,7 +281,7 @@ context 'Manpage' do
     end
 
     test 'should escape backslashes in content' do
-      input = <<~EOS.chomp
+      input = <<~EOS.chop
       #{SAMPLE_MANPAGE_HEADER}
 
       \\.foo \\ bar\\
@@ -292,7 +292,7 @@ context 'Manpage' do
     end
 
     test 'should escape literal escape sequence' do
-      input = <<~EOS.chomp
+      input = <<~EOS.chop
       #{SAMPLE_MANPAGE_HEADER}
 
        \\fB makes text bold
@@ -302,13 +302,13 @@ context 'Manpage' do
     end
 
     test 'should preserve inline breaks' do
-      input = <<~EOS.chomp
+      input = <<~EOS.chop
       #{SAMPLE_MANPAGE_HEADER}
 
       Before break. +
       After break.
       EOS
-      expected = <<~EOS.chomp
+      expected = <<~'EOS'.chop
       Before break.
       .br
       After break.
@@ -320,13 +320,13 @@ context 'Manpage' do
 
   context 'URL macro' do
     test 'should not leave blank line before URL macro' do
-      input = <<~EOS.chomp
+      input = <<~EOS.chop
       #{SAMPLE_MANPAGE_HEADER}
       First paragraph.
 
       http://asciidoc.org[AsciiDoc]
       EOS
-      expected = <<~'EOS'.chomp
+      expected = <<~'EOS'.chop
       .sp
       First paragraph.
       .sp
@@ -337,12 +337,12 @@ context 'Manpage' do
     end
 
     test 'should not swallow content following URL' do
-      input = <<~EOS.chomp
+      input = <<~EOS.chop
       #{SAMPLE_MANPAGE_HEADER}
 
       http://asciidoc.org[AsciiDoc] can be used to create man pages.
       EOS
-      expected = <<~'EOS'.chomp
+      expected = <<~'EOS'.chop
       .URL "http://asciidoc.org" "AsciiDoc" " "
       can be used to create man pages.
       EOS
@@ -351,12 +351,12 @@ context 'Manpage' do
     end
 
     test 'should pass adjacent character as final argument of URL macro' do
-      input = <<~EOS.chomp
+      input = <<~EOS.chop
       #{SAMPLE_MANPAGE_HEADER}
 
       This is http://asciidoc.org[AsciiDoc].
       EOS
-      expected = <<~'EOS'.chomp
+      expected = <<~'EOS'.chop
       This is \c
       .URL "http://asciidoc.org" "AsciiDoc" "."
       EOS
@@ -365,12 +365,12 @@ context 'Manpage' do
     end
 
     test 'should pass adjacent character as final argument of URL macro and move trailing content to next line' do
-      input = <<~EOS.chomp
+      input = <<~EOS.chop
       #{SAMPLE_MANPAGE_HEADER}
 
       This is http://asciidoc.org[AsciiDoc], which can be used to write content.
       EOS
-      expected = <<~'EOS'.chomp
+      expected = <<~'EOS'.chop
       This is \c
       .URL "http://asciidoc.org" "AsciiDoc" ","
       which can be used to write content.
@@ -380,7 +380,7 @@ context 'Manpage' do
     end
 
     test 'should not leave blank lines between URLs on contiguous lines of input' do
-      input = <<~EOS.chomp
+      input = <<~EOS.chop
       #{SAMPLE_MANPAGE_HEADER}
 
       The corresponding implementations are
@@ -390,7 +390,7 @@ context 'Manpage' do
       http://ecls.sf.net[ECL],
       and http://sbcl.sf.net[SBCL].
       EOS
-      expected = <<~'EOS'.chomp
+      expected = <<~'EOS'.chop
       .sp
       The corresponding implementations are
       .URL "http://clisp.sf.net" "CLISP" ","
@@ -405,12 +405,12 @@ context 'Manpage' do
     end
 
     test 'should not leave blank lines between URLs on same line of input' do
-      input = <<~EOS.chomp
+      input = <<~EOS.chop
       #{SAMPLE_MANPAGE_HEADER}
 
       The corresponding implementations are http://clisp.sf.net[CLISP], http://ccl.clozure.com[Clozure CL], http://cmucl.org[CMUCL], http://ecls.sf.net[ECL], and http://sbcl.sf.net[SBCL].
       EOS
-      expected = <<~'EOS'.chomp
+      expected = <<~'EOS'.chop
       .sp
       The corresponding implementations are \c
       .URL "http://clisp.sf.net" "CLISP" ","
@@ -425,12 +425,12 @@ context 'Manpage' do
     end
 
     test 'should not insert space between link and non-whitespace characters surrounding it' do
-      input = <<~EOS.chomp
+      input = <<~EOS.chop
       #{SAMPLE_MANPAGE_HEADER}
 
       Please search |link:http://discuss.asciidoctor.org[the forums]| before asking.
       EOS
-      expected = <<~'EOS'.chomp
+      expected = <<~'EOS'.chop
       .sp
       Please search |\c
       .URL "http://discuss.asciidoctor.org" "the forums" "|"
@@ -441,12 +441,12 @@ context 'Manpage' do
     end
 
     test 'should be able to use monospaced text inside a link' do
-      input = <<~EOS.chomp
+      input = <<~EOS.chop
       #{SAMPLE_MANPAGE_HEADER}
 
       Enter the link:cat[`cat`] command.
       EOS
-      expected = <<~'EOS'.chomp
+      expected = <<~'EOS'.chop
       .sp
       Enter the \c
       .URL "cat" "\f(CRcat\fP" " "
@@ -459,13 +459,13 @@ context 'Manpage' do
 
   context 'MTO macro' do
     test 'should convert inline email macro into MTO macro' do
-      input = <<~EOS.chomp
+      input = <<~EOS.chop
       #{SAMPLE_MANPAGE_HEADER}
       First paragraph.
 
       mailto:doc@example.org[Contact the doc]
       EOS
-      expected = <<~'EOS'.chomp
+      expected = <<~'EOS'.chop
       .sp
       First paragraph.
       .sp
@@ -476,11 +476,11 @@ context 'Manpage' do
     end
 
     test 'should set text of MTO macro to blank for implicit email' do
-      input = <<~EOS.chomp
+      input = <<~EOS.chop
       #{SAMPLE_MANPAGE_HEADER}
       Bugs fixed daily by doc@example.org.
       EOS
-      expected_coda = <<~'EOS'.chomp
+      expected_coda = <<~'EOS'.chop
       Bugs fixed daily by \c
       .MTO "doc\(atexample.org" "" "."
       EOS
@@ -491,7 +491,7 @@ context 'Manpage' do
 
   context 'Table' do
     test 'should create header, body, and footer rows in correct order' do
-      input = <<~EOS.chomp
+      input = <<~EOS.chop
       #{SAMPLE_MANPAGE_HEADER}
 
       [%header%footer]
@@ -502,7 +502,7 @@ context 'Manpage' do
       |Footer
       |===
       EOS
-      expected_coda = <<~'EOS'.chomp
+      expected_coda = <<~'EOS'.chop
       allbox tab(:);
       lt.
       T{
@@ -529,7 +529,7 @@ context 'Manpage' do
     end
 
     test 'should manify normal table cell content' do
-      input = <<~EOS.chomp
+      input = <<~EOS.chop
       #{SAMPLE_MANPAGE_HEADER}
 
       |===
@@ -544,7 +544,7 @@ context 'Manpage' do
     end
 
     test 'should manify table title' do
-      input = <<~EOS.chomp
+      input = <<~EOS.chop
       #{SAMPLE_MANPAGE_HEADER}
 
       .Table of options
@@ -556,7 +556,7 @@ context 'Manpage' do
       | 3
       |===
       EOS
-      expected_coda = <<~'EOS'.chomp
+      expected_coda = <<~'EOS'.chop
       .it 1 an-trap
       .nr an-no-space-flag 1
       .nr an-break-flag 1
@@ -593,7 +593,7 @@ context 'Manpage' do
     end
 
     test 'should manify and preserve whitespace in literal table cell' do
-      input = <<~EOS.chomp
+      input = <<~EOS.chop
       #{SAMPLE_MANPAGE_HEADER}
 
       |===
@@ -602,7 +602,7 @@ context 'Manpage' do
       .
       |===
       EOS
-      expected_coda = <<~'EOS'.chomp
+      expected_coda = <<~'EOS'.chop
       .TS
       allbox tab(:);
       lt lt.
@@ -625,7 +625,7 @@ context 'Manpage' do
     end
 
     test 'should manify and preserve whitespace in verse table cell' do
-      input = <<~EOS.chomp
+      input = <<~EOS.chop
       #{SAMPLE_MANPAGE_HEADER}
 
       |===
@@ -634,7 +634,7 @@ context 'Manpage' do
       .
       |===
       EOS
-      expected_coda = <<~'EOS'.chomp
+      expected_coda = <<~'EOS'.chop
       .TS
       allbox tab(:);
       lt lt.
@@ -659,7 +659,7 @@ context 'Manpage' do
 
   context 'Images' do
     test 'should replace block image with alt text enclosed in square brackets' do
-      input = <<~EOS.chomp
+      input = <<~EOS.chop
       #{SAMPLE_MANPAGE_HEADER}
 
       Behold the wisdom of the Magic 8 Ball!
@@ -672,7 +672,7 @@ context 'Manpage' do
     end
 
     test 'should replace inline image with alt text enclosed in square brackets' do
-      input = <<~EOS.chomp
+      input = <<~EOS.chop
       #{SAMPLE_MANPAGE_HEADER}
 
       The Magic 8 Ball says image:signs-point-to-yes.jpg[].
@@ -682,7 +682,7 @@ context 'Manpage' do
     end
 
     test 'should place link after alt text for inline image if link is defined' do
-      input = <<~EOS.chomp
+      input = <<~EOS.chop
       #{SAMPLE_MANPAGE_HEADER}
 
       The Magic 8 Ball says image:signs-point-to-yes.jpg[link=https://en.wikipedia.org/wiki/Magic_8-Ball].
@@ -694,7 +694,7 @@ context 'Manpage' do
 
   context 'Quote Block' do
     test 'should indent quote block' do
-      input = <<~EOS.chomp
+      input = <<~EOS.chop
       #{SAMPLE_MANPAGE_HEADER}
 
       [,James Baldwin]
@@ -703,7 +703,7 @@ context 'Manpage' do
       But nothing can be changed until it is faced.
       ____
       EOS
-      expected_coda = <<~'EOS'.chomp
+      expected_coda = <<~'EOS'.chop
       .RS 3
       .ll -.6i
       .sp
@@ -725,7 +725,7 @@ context 'Manpage' do
 
   context 'Callout List' do
     test 'should generate callout list using proper formatting commands' do
-      input = <<~EOS.chomp
+      input = <<~EOS.chop
       #{SAMPLE_MANPAGE_HEADER}
 
       ----
@@ -733,7 +733,7 @@ context 'Manpage' do
       ----
       <1> Installs the asciidoctor gem from RubyGems.org
       EOS
-      expected_coda = <<~'EOS'.chomp
+      expected_coda = <<~'EOS'.chop
       .TS
       tab(:);
       r lw(\n(.lu*75u/100u).

--- a/test/paragraphs_test.rb
+++ b/test/paragraphs_test.rb
@@ -85,7 +85,7 @@ context 'Paragraphs' do
     end
 
     test 'removes indentation from literal paragraph marked as normal' do
-      # NOTE JRuby does not preserve indentation in single-quoted heredoc string; see https://github.com/jruby/jruby/issues/4260
+      # NOTE cannot use single-quoted heredoc because of https://github.com/jruby/jruby/issues/4260
       input = <<~EOS
       [normal]
         Normal paragraph.
@@ -222,7 +222,7 @@ context 'Paragraphs' do
 
   context 'Literal' do
     test 'single-line literal paragraphs' do
-      # NOTE JRuby does not preserve indentation in single-quoted heredoc string; see https://github.com/jruby/jruby/issues/4260
+      # NOTE cannot use single-quoted heredoc because of https://github.com/jruby/jruby/issues/4260
       input = <<~EOS
       you know what?
 
@@ -237,7 +237,7 @@ context 'Paragraphs' do
     end
 
     test 'multi-line literal paragraph' do
-      # NOTE JRuby does not preserve indentation in single-quoted heredoc string; see https://github.com/jruby/jruby/issues/4260
+      # NOTE cannot use single-quoted heredoc because of https://github.com/jruby/jruby/issues/4260
       input = <<~EOS
       Install instructions:
 
@@ -299,7 +299,7 @@ context 'Paragraphs' do
     end
 
     test 'literal paragraph terminates at block attribute list' do
-      # NOTE JRuby does not preserve indentation in single-quoted heredoc string; see https://github.com/jruby/jruby/issues/4260
+      # NOTE cannot use single-quoted heredoc because of https://github.com/jruby/jruby/issues/4260
       input = <<~EOS
        literal text
       [normal]
@@ -311,7 +311,7 @@ context 'Paragraphs' do
     end
 
     test 'literal paragraph terminates at block delimiter' do
-      # NOTE JRuby does not preserve indentation in single-quoted heredoc string; see https://github.com/jruby/jruby/issues/4260
+      # NOTE cannot use single-quoted heredoc because of https://github.com/jruby/jruby/issues/4260
       input = <<~EOS
        literal text
       --
@@ -324,7 +324,7 @@ context 'Paragraphs' do
     end
 
     test 'literal paragraph terminates at list continuation' do
-      # NOTE JRuby does not preserve indentation in single-quoted heredoc string; see https://github.com/jruby/jruby/issues/4260
+      # NOTE cannot use single-quoted heredoc because of https://github.com/jruby/jruby/issues/4260
       input = <<~EOS
        literal text
       +
@@ -420,7 +420,7 @@ context 'Paragraphs' do
       endif::[]
       EOS
 
-      expected = <<~'EOS'.chomp
+      expected = <<~'EOS'.chop
       <div class="sidebarblock">
       <div class="content">
       First line of sidebar.

--- a/test/parser_test.rb
+++ b/test/parser_test.rb
@@ -355,7 +355,7 @@ context "Parser" do
   end
 
   test 'use explicit authorinitials if set after implicit author line' do
-    input = <<~'EOS'.chomp
+    input = <<~'EOS'
     Jean-Claude Van Damme
     :authorinitials: JCVD
     EOS
@@ -365,7 +365,7 @@ context "Parser" do
   end
 
   test 'use explicit authorinitials if set after author attribute' do
-    input = <<~'EOS'.chomp
+    input = <<~'EOS'
     :author: Jean-Claude Van Damme
     :authorinitials: JCVD
     EOS
@@ -525,7 +525,7 @@ context "Parser" do
   end
 
   test "parse rev remark only" do
-    # NOTE JRuby does not preserve indentation in single-quoted heredoc string; see https://github.com/jruby/jruby/issues/4260
+    # NOTE cannot use single-quoted heredoc because of https://github.com/jruby/jruby/issues/4260
     input = <<~EOS
     Joe Cool
      :Must start revremark-only line with space
@@ -606,16 +606,16 @@ context "Parser" do
   end
 
   test 'adjust indentation to 0' do
-    input = <<-'EOS'.chomp
-    def names
+    input = <<~EOS
+    \x20   def names
 
-      @name.split
+    \x20     @name.split
 
-    end
+    \x20   end
     EOS
 
-    # NOTE JRuby does not preserve indentation in single-quoted heredoc string; see https://github.com/jruby/jruby/issues/4260
-    expected = <<~EOS.chomp
+    # NOTE cannot use single-quoted heredoc because of https://github.com/jruby/jruby/issues/4260
+    expected = <<~EOS.chop
     def names
 
       @name.split
@@ -629,7 +629,7 @@ context "Parser" do
   end
 
   test 'adjust indentation mixed with tabs and spaces to 0' do
-    input = <<~EOS.chomp
+    input = <<~EOS
         def names
 
     \t  @name.split
@@ -637,7 +637,7 @@ context "Parser" do
         end
     EOS
 
-    expected = <<~EOS.chomp
+    expected = <<~EOS.chop
     def names
 
       @name.split
@@ -651,14 +651,14 @@ context "Parser" do
   end
 
   test 'expands tabs to spaces' do
-    input = <<~'EOS'.chomp
+    input = <<~'EOS'
     Filesystem				Size	Used	Avail	Use%	Mounted on
     Filesystem              Size    Used    Avail   Use%    Mounted on
     devtmpfs				3.9G	   0	 3.9G	  0%	/dev
     /dev/mapper/fedora-root	 48G	 18G	  29G	 39%	/
     EOS
 
-    expected = <<~'EOS'.chomp
+    expected = <<~'EOS'.chop
     Filesystem              Size    Used    Avail   Use%    Mounted on
     Filesystem              Size    Used    Avail   Use%    Mounted on
     devtmpfs                3.9G       0     3.9G     0%    /dev
@@ -671,20 +671,20 @@ context "Parser" do
   end
 
   test 'adjust indentation to non-zero' do
-    input = <<-'EOS'.chomp
-    def names
+    input = <<~EOS
+    \x20   def names
 
-      @name.split
+    \x20     @name.split
 
-    end
+    \x20   end
     EOS
 
-    expected = <<-'EOS'.chomp
-  def names
+    expected = <<~EOS.chop
+    \x20 def names
 
-    @name.split
+    \x20   @name.split
 
-  end
+    \x20 end
     EOS
 
     lines = input.split ?\n
@@ -693,12 +693,12 @@ context "Parser" do
   end
 
   test 'preserve block indent if indent is -1' do
-    input = <<-'EOS'
-    def names
+    input = <<~EOS
+    \x20   def names
 
-      @name.split
+    \x20     @name.split
 
-    end
+    \x20   end
     EOS
 
     expected = input

--- a/test/substitutions_test.rb
+++ b/test/substitutions_test.rb
@@ -1857,7 +1857,7 @@ context 'Substitutions' do
       stuff in between
       foo --
       EOS
-      expected = <<~'EOS'.chomp
+      expected = <<~'EOS'.chop
       &#8201;&#8212;&#8201;foo foo&#8212;&#8203;bar foo--bar foo&#8201;&#8212;&#8201;bar foo -- bar
       stuff in between&#8201;&#8212;&#8201;foo
       stuff in between

--- a/test/syntax_highlighter_test.rb
+++ b/test/syntax_highlighter_test.rb
@@ -723,7 +723,7 @@ context 'Syntax Highlighter' do
         ----
         EOS
         # NOTE notice the newline in inside the closing </span> of the highlight span
-        expected = <<~EOS.chomp
+        expected = <<~EOS.chop
         <span class="hll"><span class="nb">puts</span> <span class="s1">'Hello, world!'</span>
         </span><span class="nb">puts</span> <span class="s1">'Goodbye, world!'</span>#{opts == '%linenums' ? ?\n : '</code>'}</pre>
         EOS
@@ -745,7 +745,7 @@ context 'Syntax Highlighter' do
         ----
         EOS
         # NOTE notice the newline in inside the closing </span> of the highlight span
-        expected = <<~EOS.chomp
+        expected = <<~EOS.chop
         <span class="nb">puts</span> <span class="s1">'Hello, world!'</span>
         <span class="hll"><span class="nb">puts</span> <span class="s1">'Goodbye, world!'</span>
         </span>#{opts == '%linenums' ? '' : '</code>'}</pre>
@@ -1001,7 +1001,7 @@ context 'Syntax Highlighter' do
       ----
       EOS
       # NOTE notice the newline is inside the closing </span> of the highlight span
-      expected = <<~'EOS'.chomp
+      expected = <<~'EOS'.chop
       <pre class="pygments highlight"><code data-lang="ruby"><span></span><span class="hll"><span class="tok-nb">puts</span> <span class="tok-s1">&#39;Hello, world!&#39;</span>
       </span><span class="hll"><span class="tok-nb">puts</span> <span class="tok-s1">&#39;Goodbye, world!&#39;</span>
       </span></code></pre>

--- a/test/tables_test.rb
+++ b/test/tables_test.rb
@@ -266,7 +266,7 @@ context 'Tables' do
     end
 
     test 'should preserving leading spaces but not leading newlines or trailing spaces in literal table cells' do
-      # NOTE JRuby does not preserve indentation in single-quoted heredoc string; see https://github.com/jruby/jruby/issues/4260
+      # NOTE cannot use single-quoted heredoc because of https://github.com/jruby/jruby/issues/4260
       input = <<~EOS
       [cols=2*]
       |===
@@ -284,7 +284,7 @@ context 'Tables' do
     end
 
     test 'should preserving leading spaces but not leading newlines or trailing spaces in verse table cells' do
-      # NOTE JRuby does not preserve indentation in single-quoted heredoc string; see https://github.com/jruby/jruby/issues/4260
+      # NOTE cannot use single-quoted heredoc because of https://github.com/jruby/jruby/issues/4260
       input = <<~EOS
       [cols=2*]
       |===
@@ -1269,7 +1269,7 @@ context 'Tables' do
     end
 
     test 'should preserve leading indentation in contents of AsciiDoc table cell if contents starts with newline' do
-      # NOTE JRuby does not preserve indentation in single-quoted heredoc string; see https://github.com/jruby/jruby/issues/4260
+      # NOTE cannot use single-quoted heredoc because of https://github.com/jruby/jruby/issues/4260
       input = <<~EOS
       |===
       a|


### PR DESCRIPTION
- use chop instead of chomp to remove trailing newline from heredoc string
- document all uses of non-quoted squiggly heredoc to preserve indentation
- fix incorrect preparation of uniform indentation in list tests
- remove unnecessary uses of chomp