### PR TITLE
enforce and report relative max include depth properly

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -73,6 +73,7 @@ Improvements::
   * pass :input_mtime option to Document constructor; let Document constructor assign docdate/time/year attributes (#3029)
   * never mutate strings; add a `frozen_string_literal: true` magic comment to top of all Ruby source files (#3054)
   * always use docdate and doctime to compute docyear and docdatetime (#3064)
+  * rename PreprocessorReader#exceeded_max_depth? to PreprocessorReader#exceeds_max_depth? and return nil if includes are disabled
 
 Bug Fixes::
 
@@ -95,6 +96,7 @@ Bug Fixes::
   * fix deprecated ERB trim mode that was causing warning (#3006)
   * move time anchor after query string on vimeo video to avoid dropping options
   * allow color for generic text, line numbers, and line number border to inherit from Pygments style (#2106)
+  * enforce and report relative include depth properly (depth=0 rather than depth=1 disables nested includes)
 
 Build / Infrastructure::
 

--- a/test/fixtures/parent-include-restricted.adoc
+++ b/test/fixtures/parent-include-restricted.adoc
@@ -1,5 +1,5 @@
 first line of parent
 
-include::child-include.adoc[depth=1]
+include::child-include.adoc[depth=0]
 
 last line of parent

--- a/test/reader_test.rb
+++ b/test/reader_test.rb
@@ -1473,8 +1473,8 @@ class ReaderTest < Minitest::Test
           doc = empty_safe_document base_dir: DIRNAME
           reader = Asciidoctor::PreprocessorReader.new doc, input, Asciidoctor::Reader::Cursor.new(pseudo_docfile), normalize: true
           lines = reader.readlines
-          assert_includes lines, 'include::child-include.adoc[]'
-          assert_message logger, :ERROR, 'fixtures/parent-include.adoc: line 3: maximum include depth of 1 exceeded', Hash
+          assert_includes lines, 'include::grandchild-include.adoc[]'
+          assert_message logger, :ERROR, 'fixtures/child-include.adoc: line 3: maximum include depth of 1 exceeded', Hash
         end
       end
 
@@ -1487,7 +1487,7 @@ class ReaderTest < Minitest::Test
           lines = reader.readlines
           assert_includes lines, 'first line of child'
           assert_includes lines, 'include::grandchild-include.adoc[]'
-          assert_message logger, :ERROR, 'fixtures/child-include.adoc: line 3: maximum include depth of 1 exceeded', Hash
+          assert_message logger, :ERROR, 'fixtures/child-include.adoc: line 3: maximum include depth of 0 exceeded', Hash
         end
       end
 


### PR DESCRIPTION
- enforce and report relative max include depth properly
- depth=0 on include directive disables nested includes (instead of depth=1)
- rename PreprocessorReader#exceeded_max_depth? to PreprocessorReader#exceeds_max_depth?
- change PreprocessorReader#exceeds_max_depth? to return nil if includes are disabled
- add api doc to PreprocessorReader#exceeds_max_depth?