### PR TITLE
resolves #3084 only store :refs, not :ids, in document catalog

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -75,6 +75,10 @@ Improvements::
   * never mutate strings; add a `frozen_string_literal: true` magic comment to top of all Ruby source files (#3054)
   * always use docdate and doctime to compute docyear and docdatetime (#3064)
   * rename PreprocessorReader#exceeded_max_depth? to PreprocessorReader#exceeds_max_depth? and return nil if includes are disabled
+  * stop populating :ids table in document catalog (#3084)
+  * always use :refs table in document catalog to look for registered IDs (#3084)
+  * don't compute and store reference text in document catalog (#3084)
+  * populate reference text table lazily for resolving ID by reference text (#3084)
 
 Bug Fixes::
 

--- a/features/xref.feature
+++ b/features/xref.feature
@@ -741,7 +741,7 @@ Feature: Cross References
 
       content
 
-      == Section Two
+      == Section Two, continued from <<Section One>>
 
       refer to <<Section One>>
       """
@@ -752,7 +752,9 @@ Feature: Cross References
         h2#_section_one Section One
         .sectionbody: .paragraph: p content
       .sect1
-        h2#_section_two Section Two
+        h2#_section_two_continued_from_section_one
+          |Section Two, continued from
+          a< href='#_section_one' Section One
         .sectionbody: .paragraph: p
           |refer to
           a< href='#_section_one' Section One

--- a/lib/asciidoctor/parser.rb
+++ b/lib/asciidoctor/parser.rb
@@ -882,7 +882,7 @@ class Parser
     #block.style = attributes.delete 'style'
     block.style = attributes['style']
     if (block_id = block.id || (block.id = attributes['id']))
-      unless document.register :refs, [block_id, block, attributes['reftext'] || (block.title? ? block.title : nil)]
+      unless document.register :refs, [block_id, block]
         logger.warn message_with_context %(id assigned to block already in use: #{block_id}), source_location: reader.cursor_at_mark
       end
     end
@@ -1133,7 +1133,7 @@ class Parser
   def self.catalog_inline_anchor id, reftext, node, location, doc = nil
     doc = node.document unless doc
     reftext = doc.sub_attributes reftext if reftext && (reftext.include? ATTR_REF_HEAD)
-    unless doc.register :refs, [id, (Inline.new node, :anchor, reftext, type: :ref, id: id), reftext]
+    unless doc.register :refs, [id, (Inline.new node, :anchor, reftext, type: :ref, id: id)]
       location = location.cursor if Reader === location
       logger.warn message_with_context %(id assigned to anchor already in use: #{id}), source_location: location
     end
@@ -1160,7 +1160,7 @@ class Parser
           next if (reftext.include? ATTR_REF_HEAD) && (reftext = document.sub_attributes reftext).empty?
         end
       end
-      unless document.register :refs, [id, (Inline.new block, :anchor, reftext, type: :ref, id: id), reftext]
+      unless document.register :refs, [id, (Inline.new block, :anchor, reftext, type: :ref, id: id)]
         location = reader.cursor_at_mark
         if (offset = ($`.count LF) + (($&.start_with? LF) ? 1 : 0)) > 0
           (location = location.dup).advance offset
@@ -1181,7 +1181,7 @@ class Parser
   # Returns nothing
   def self.catalog_inline_biblio_anchor id, reftext, node, reader
     # QUESTION should we sub attributes in reftext (like with regular anchors)?
-    unless node.document.register :refs, [id, (Inline.new node, :anchor, (styled_reftext = %([#{reftext || id}])), type: :bibref, id: id), styled_reftext]
+    unless node.document.register :refs, [id, (Inline.new node, :anchor, %([#{reftext || id}]), type: :bibref, id: id)]
       logger.warn message_with_context %(id assigned to bibliography anchor already in use: #{id}), source_location: reader.cursor
     end
     nil
@@ -1614,7 +1614,7 @@ class Parser
 
     # generate an ID if one was not embedded or specified as anchor above section title
     if (id = section.id || (section.id = (document.attributes.key? 'sectids') ? (Section.generate_id section.title, document) : nil))
-      unless document.register :refs, [id, section, sect_reftext || section.title]
+      unless document.register :refs, [id, section]
         logger.warn message_with_context %(id assigned to section already in use: #{id}), source_location: (reader.cursor_at_line reader.lineno - (sect_atx ? 1 : 2))
       end
     end

--- a/lib/asciidoctor/substitutors.rb
+++ b/lib/asciidoctor/substitutors.rb
@@ -918,8 +918,7 @@ module Substitutors
             reftext = reftext.gsub ESC_R_SB, R_SB
           end
         end
-        # NOTE target property on :ref is deprecated
-        Inline.new(self, :anchor, reftext, type: :ref, id: id, target: id).convert
+        Inline.new(self, :anchor, reftext, type: :ref, id: id).convert
       end
     end
 
@@ -1003,11 +1002,11 @@ module Substitutors
           refid, target = fragment, %(##{fragment})
           logger.debug %(possible invalid reference: #{refid}) if logger.debug? && doc.catalog[:refs][refid]
         # handles: id
-        elsif doc.catalog[:ids].key? fragment
+        elsif doc.catalog[:refs][fragment]
           refid, target = fragment, %(##{fragment})
         # handles: Node Title or Reference Text
         # do reverse lookup on fragment if not a known ID and resembles reftext (contains a space or uppercase char)
-        elsif (refid = doc.catalog[:ids].key fragment) && ((fragment.include? ' ') || fragment.downcase != fragment)
+        elsif (refid = doc.resolve_id fragment) && ((fragment.include? ' ') || fragment.downcase != fragment)
           fragment, target = refid, %(##{refid})
         else
           refid, target = fragment, %(##{fragment})

--- a/test/blocks_test.rb
+++ b/test/blocks_test.rb
@@ -3323,7 +3323,7 @@ context 'Blocks' do
       block = doc.blocks.first
       assert_nil block.id
       assert_nil(block.attr 'reftext')
-      refute doc.catalog[:ids].has_key?('illegal$id')
+      refute doc.catalog[:refs].key? 'illegal$id'
     end
 
     test 'should not recognize block anchor that starts with digit' do
@@ -3361,9 +3361,11 @@ context 'Blocks' do
       EOS
 
       doc = document_from_string input
-      reftext = doc.catalog[:ids]['debian']
-      refute_nil reftext
-      assert_equal 'Debian Install', reftext
+      ref = doc.catalog[:refs]['debian']
+      refute_nil ref
+      assert_equal 'Debian Install', ref.reftext
+      #assert_equal 'debian', doc.catalog[:reftexts]['Debian Install']
+      assert_equal 'debian', (doc.resolve_id 'Debian Install')
     end
 
     test 'should allow square brackets in block reference text' do
@@ -3376,9 +3378,11 @@ context 'Blocks' do
       EOS
 
       doc = document_from_string input
-      reftext = doc.catalog[:ids]['debian']
-      refute_nil reftext
-      assert_equal '[Debian] Install', reftext
+      ref = doc.catalog[:refs]['debian']
+      refute_nil ref
+      assert_equal '[Debian] Install', ref.reftext
+      #assert_equal 'debian', doc.catalog[:reftexts]['[Debian] Install']
+      assert_equal 'debian', (doc.resolve_id '[Debian] Install')
     end
 
     test 'should allow comma in block reference text' do
@@ -3391,9 +3395,11 @@ context 'Blocks' do
       EOS
 
       doc = document_from_string input
-      reftext = doc.catalog[:ids]['debian']
-      refute_nil reftext
-      assert_equal 'Debian, Ubuntu', reftext
+      ref = doc.catalog[:refs]['debian']
+      refute_nil ref
+      assert_equal 'Debian, Ubuntu', ref.reftext
+      #assert_equal 'debian', doc.catalog[:reftexts]['Debian, Ubuntu']
+      assert_equal 'debian', (doc.resolve_id 'Debian, Ubuntu')
     end
 
     test 'should substitute attribute references in reftext when registering block reference' do
@@ -3407,12 +3413,11 @@ context 'Blocks' do
       EOS
 
       doc = document_from_string input
-      reftext = doc.catalog[:ids]['tiger-evolution']
-      refute_nil reftext
-      assert_equal 'Evolution of the Tiger', reftext
       ref = doc.catalog[:refs]['tiger-evolution']
       refute_nil ref
       assert_equal 'Evolution of the Tiger', ref.attributes['reftext']
+      #assert_equal 'tiger-evolution', doc.catalog[:reftexts]['Evolution of the Tiger']
+      assert_equal 'tiger-evolution', (doc.resolve_id 'Evolution of the Tiger')
     end
 
     test 'should use specified reftext when registering block reference' do
@@ -3426,9 +3431,11 @@ context 'Blocks' do
       EOS
 
       doc = document_from_string input
-      reftext = doc.catalog[:ids]['debian']
-      refute_nil reftext
-      assert_equal 'Debian Install', reftext
+      ref = doc.catalog[:refs]['debian']
+      refute_nil ref
+      assert_equal 'Debian Install', ref.reftext
+      #assert_equal 'debian', doc.catalog[:reftexts]['Debian Install']
+      assert_equal 'debian', (doc.resolve_id 'Debian Install')
     end
   end
 end

--- a/test/links_test.rb
+++ b/test/links_test.rb
@@ -274,11 +274,10 @@ context 'Links' do
     variations.each do |anchor|
       doc = document_from_string %(Here you can read about tigers.#{anchor})
       output = doc.convert
-      assert_equal '[tigers]', doc.catalog[:ids]['tigers']
       assert_kind_of Asciidoctor::Inline, doc.catalog[:refs]['tigers']
       assert_nil doc.catalog[:refs]['tigers'].text
-      assert_xpath '//a[@id = "tigers"]', output, 1
-      assert_xpath '//a[@id = "tigers"]/child::text()', output, 0
+      assert_xpath '//a[@id="tigers"]', output, 1
+      assert_xpath '//a[@id="tigers"]/child::text()', output, 0
     end
   end
 
@@ -287,16 +286,15 @@ context 'Links' do
     variations.each do |anchor|
       doc = document_from_string %(Here you can read about tigers.\\#{anchor})
       output = doc.convert
-      refute doc.catalog[:ids].key?('tigers')
       refute doc.catalog[:refs].key?('tigers')
-      assert_xpath '//a[@id = "tigers"]', output, 0
+      assert_xpath '//a[@id="tigers"]', output, 0
     end
   end
 
   test 'inline ref can start with colon' do
     input = '[[:idname]] text'
     output = convert_string_to_embedded input
-    assert_xpath '//a[@id = ":idname"]', output, 1
+    assert_xpath '//a[@id=":idname"]', output, 1
   end
 
   test 'inline ref cannot start with digit' do
@@ -310,11 +308,10 @@ context 'Links' do
     %w([[tigers,Tigers]] anchor:tigers[Tigers]).each do |anchor|
       doc = document_from_string %(Here you can read about tigers.#{anchor})
       output = doc.convert
-      assert_equal 'Tigers', doc.catalog[:ids]['tigers']
       assert_kind_of Asciidoctor::Inline, doc.catalog[:refs]['tigers']
       assert_equal 'Tigers', doc.catalog[:refs]['tigers'].text
-      assert_xpath '//a[@id = "tigers"]', output, 1
-      assert_xpath '//a[@id = "tigers"]/child::text()', output, 0
+      assert_xpath '//a[@id="tigers"]', output, 1
+      assert_xpath '//a[@id="tigers"]/child::text()', output, 0
     end
   end
 
@@ -330,7 +327,6 @@ context 'Links' do
       doc.convert
       assert_kind_of Asciidoctor::Inline, doc.catalog[:refs]['tigers']
       assert_equal 'Tigers', doc.catalog[:refs]['tigers'].text
-      assert_equal 'Tigers', doc.catalog[:ids]['tigers']
     end
   end
 
@@ -340,15 +336,13 @@ context 'Links' do
       output = doc.convert header_footer: false
       assert_kind_of Asciidoctor::Inline, doc.catalog[:refs]['tigers']
       assert_equal '<Tigers>', doc.catalog[:refs]['tigers'].text
-      assert_equal '<Tigers>', doc.references[:ids]['tigers']
       assert_includes output, '<anchor xml:id="tigers" xreflabel="&lt;Tigers&gt;"/>'
     end
   end
 
   test 'does not match bibliography anchor in prose when scanning for inline anchor' do
     doc = document_from_string 'Use [[[label]]] to assign a label to a bibliography entry.'
-    refute doc.catalog[:ids].key?('label')
-    refute doc.catalog[:refs].key?('label')
+    refute doc.catalog[:refs].key? 'label'
   end
 
   test 'repeating inline anchor macro with empty reftext' do
@@ -860,22 +854,30 @@ context 'Links' do
   end
 
   test 'anchor creates reference' do
-    doc = document_from_string "[[tigers]]Tigers roam here."
-    assert_equal({ 'tigers' => '[tigers]' }, doc.catalog[:ids])
+    doc = document_from_string '[[tigers]]Tigers roam here.'
+    ref = doc.catalog[:refs]['tigers']
+    refute_nil ref
+    assert_nil ref.reftext
   end
 
-  test 'anchor with label creates reference' do
-    doc = document_from_string "[[tigers,Tigers]]Tigers roam here."
-    assert_equal({ 'tigers' => 'Tigers' }, doc.catalog[:ids])
+  test 'wip anchor with label creates reference' do
+    doc = document_from_string '[[tigers,Tigers]]Tigers roam here.'
+    ref = doc.catalog[:refs]['tigers']
+    refute_nil ref
+    assert_equal 'Tigers', ref.reftext
   end
 
   test 'anchor with quoted label creates reference with quoted label text' do
     doc = document_from_string %([[tigers,"Tigers roam here"]]Tigers roam here.)
-    assert_equal({ 'tigers' => '"Tigers roam here"' }, doc.catalog[:ids])
+    ref = doc.catalog[:refs]['tigers']
+    refute_nil ref
+    assert_equal '"Tigers roam here"', ref.reftext
   end
 
   test 'anchor with label containing a comma creates reference' do
     doc = document_from_string %([[tigers,Tigers, scary tigers, roam here]]Tigers roam here.)
-    assert_equal({ 'tigers' => 'Tigers, scary tigers, roam here' }, doc.catalog[:ids])
+    ref = doc.catalog[:refs]['tigers']
+    refute_nil ref
+    assert_equal 'Tigers, scary tigers, roam here', ref.reftext
   end
 end

--- a/test/sections_test.rb
+++ b/test/sections_test.rb
@@ -245,9 +245,11 @@ context 'Sections' do
       EOS
 
       doc = document_from_string input
-      reftext = doc.catalog[:ids]['install']
-      refute_nil reftext
-      assert_equal 'Install Procedure', reftext
+      ref = doc.catalog[:refs]['install']
+      refute_nil ref
+      assert_equal 'Install Procedure', ref.reftext
+      #assert_equal 'install', doc.catalog[:reftexts]['Install Procedure']
+      assert_equal 'install', (doc.resolve_id 'Install Procedure')
     end
 
     test 'should use specified reftext when registering section reference' do
@@ -259,9 +261,11 @@ context 'Sections' do
       EOS
 
       doc = document_from_string input
-      reftext = doc.catalog[:ids]['_install']
-      refute_nil reftext
-      assert_equal 'Install Procedure', reftext
+      ref = doc.catalog[:refs]['_install']
+      refute_nil ref
+      assert_equal 'Install Procedure', ref.reftext
+      #assert_equal '_install', doc.catalog[:reftexts]['Install Procedure']
+      assert_equal '_install', (doc.resolve_id 'Install Procedure')
     end
 
     test 'should substitute attributes when registering reftext for section' do
@@ -275,9 +279,11 @@ context 'Sections' do
       EOS
 
       doc = document_from_string input
-      reftext = doc.catalog[:ids]['install']
-      refute_nil reftext
-      assert_equal 'install on Linux', reftext
+      ref = doc.catalog[:refs]['install']
+      refute_nil ref
+      assert_equal 'install on Linux', ref.reftext
+      #assert_equal 'install', doc.catalog[:reftexts]['install on Linux']
+      assert_equal 'install', (doc.resolve_id 'install on Linux')
     end
 
     test 'duplicate section id should not overwrite existing section id entry in references table' do
@@ -295,9 +301,12 @@ context 'Sections' do
 
       using_memory_logger do |logger|
         doc = document_from_string input
-        reftext = doc.catalog[:ids]['install']
-        refute_nil reftext
-        assert_equal 'First Install', reftext
+        ref = doc.catalog[:refs]['install']
+        refute_nil ref
+        assert_nil ref.reftext
+        assert_equal 'First Install', ref.title
+        #assert_equal 'install', doc.catalog[:reftexts]['First Install']
+        assert_equal 'install', (doc.resolve_id 'First Install')
         assert_message logger, :WARN, '<stdin>: line 7: id assigned to section already in use: install', Hash
       end
     end
@@ -316,9 +325,12 @@ context 'Sections' do
 
       using_memory_logger do |logger|
         doc = document_from_string input
-        reftext = doc.catalog[:ids]['_do_not_repeat_yourself']
-        refute_nil reftext
-        assert_equal 'Do Not Repeat Yourself', reftext
+        ref = doc.catalog[:refs]['_do_not_repeat_yourself']
+        refute_nil ref
+        assert_nil ref.reftext
+        assert_equal 'Do Not Repeat Yourself', ref.title
+        #assert_equal '_do_not_repeat_yourself', doc.catalog[:reftexts]['Do Not Repeat Yourself']
+        assert_equal '_do_not_repeat_yourself', (doc.resolve_id 'Do Not Repeat Yourself')
         assert_message logger, :WARN, '<stdin>: line 6: id assigned to section already in use: _do_not_repeat_yourself', Hash
         assert_equal 2, (doc.convert.scan 'id="_do_not_repeat_yourself"').size
       end
@@ -337,9 +349,12 @@ context 'Sections' do
 
       using_memory_logger do |logger|
         doc = document_from_string input
-        reftext = doc.catalog[:ids]['install']
-        refute_nil reftext
-        assert_equal 'First Install', reftext
+        ref = doc.catalog[:refs]['install']
+        refute_nil ref
+        assert_nil ref.reftext
+        assert_equal 'First Install', ref.title
+        #assert_equal 'install', doc.catalog[:reftexts]['First Install']
+        assert_equal 'install', (doc.resolve_id 'First Install')
         assert_message logger, :WARN, '<stdin>: line 7: id assigned to block already in use: install', Hash
       end
     end
@@ -1022,7 +1037,7 @@ context 'Sections' do
       assert_kind_of Asciidoctor::Block, heading
       assert_equal :floating_title, heading.context
       assert_equal '_independent_heading', heading.id
-      assert doc.catalog[:ids].has_key?('_independent_heading')
+      assert doc.catalog[:refs].key? '_independent_heading'
     end
 
     test 'should preprocess second line of setext discrete heading' do
@@ -1049,7 +1064,7 @@ context 'Sections' do
       doc = document_from_string input
       heading = doc.blocks.first
       assert_equal 'unchained', heading.id
-      assert doc.catalog[:ids].has_key?('unchained')
+      assert doc.catalog[:refs].key? 'unchained'
     end
 
     test 'should not include discrete heading in toc' do
@@ -1137,9 +1152,11 @@ context 'Sections' do
       EOS
 
       doc = document_from_string input
-      reftext = doc.catalog[:ids]['install']
-      refute_nil reftext
-      assert_equal 'Install Procedure', reftext
+      ref = doc.catalog[:refs]['install']
+      refute_nil ref
+      assert_equal 'Install Procedure', ref.reftext
+      #assert_equal 'install', doc.catalog[:reftexts]['Install Procedure']
+      assert_equal 'install', (doc.resolve_id 'Install Procedure')
     end
 
     test 'should use specified reftext when registering discrete section reference' do
@@ -1152,9 +1169,11 @@ context 'Sections' do
       EOS
 
       doc = document_from_string input
-      reftext = doc.catalog[:ids]['_install']
-      refute_nil reftext
-      assert_equal 'Install Procedure', reftext
+      ref = doc.catalog[:refs]['_install']
+      refute_nil ref
+      assert_equal 'Install Procedure', ref.reftext
+      #assert_equal '_install', doc.catalog[:reftexts]['Install Procedure']
+      assert_equal '_install', (doc.resolve_id 'Install Procedure')
     end
 
     test 'should not process inline anchor in discrete heading if explicit ID is assigned' do


### PR DESCRIPTION
* remove the logic that registers entries in :ids table of the document catalog
* don't attempt to compute the reftext when registering an xref (as this information is available from the referenced node and can be retrieved on demnd)
* add a Document#resolve_id method to look up ID by reference text (reftext or title); cache the result of lookups once parsing is complete
* always look for existing IDs using :refs table (when checking for a duplicate or whether a target exists)
* leave the :ids table empty to avoid breaking existing programs and extensions
* update tests
* add test to verify :ids table is always empty