### PR TITLE
resolves #2963 modify Cell class to extend from AbstractBlock

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -58,6 +58,8 @@ Enhancements / Compliance::
   * allow the ID and role properties to be set on a list item of ordered and unordered lists via the API (#2840)
   * yield processor instance to registration block for document processor if block has non-zero arity (i.e., has parameters)
   * add Document#parsed? method to check whether document has been parsed
+  * modify Cell class to extend from AbstractBlock instead of AbstractNode (#2963)
+  * implement block? and inline? methods on Column, both which return false (#2963)
 
 Improvements::
 
@@ -111,6 +113,7 @@ Bug Fixes::
   * allow color for generic text, line numbers, and line number border to inherit from Pygments style (#2106)
   * enforce and report relative include depth properly (depth=0 rather than depth=1 disables nested includes)
   * allow outfilesuffix to be soft set from API (#2640)
+  * don't split paragraphs in table cell at line that resolves to blank if adjacent to other non-blank lines (#2963)
 
 Build / Infrastructure::
 

--- a/test/api_test.rb
+++ b/test/api_test.rb
@@ -1407,5 +1407,30 @@ context 'API' do
       block = (document_from_string input).blocks[0]
       assert_equal %w(compact reversed).to_set, block.options
     end
+
+    test 'table column should not be a block or inline' do
+      input = <<~'EOS'
+      |===
+      |a
+      |===
+      EOS
+
+      col = (document_from_string input).blocks[0].columns[0]
+      refute col.block?
+      refute col.inline?
+    end
+
+    test 'table cell should be a block' do
+      input = <<~'EOS'
+      |===
+      |a
+      |===
+      EOS
+
+      cell = (document_from_string input).blocks[0].rows.body[0][0]
+      assert_kind_of ::Asciidoctor::AbstractBlock, cell
+      assert cell.block?
+      refute cell.inline?
+    end
   end
 end

--- a/test/tables_test.rb
+++ b/test/tables_test.rb
@@ -1105,6 +1105,21 @@ context 'Tables' do
       assert_equal 26, literal.text.lines.size
     end
 
+    test 'should not split paragraph at line containing only {blank} that is directly adjacent to non-blank lines' do
+      input = <<~'EOS'
+      |===
+      |paragraph
+      {blank}
+      still one paragraph
+      {blank}
+      still one paragraph
+      |===
+      EOS
+
+      result = convert_string_to_embedded input
+      assert_css 'p.tableblock', result, 1
+    end
+
     test 'should strip trailing newlines when splitting paragraphs' do
       input = <<~'EOS'
       |===


### PR DESCRIPTION
resolves #2963

- modify Cell class to extend AbstractBlock
- don't split paragraphs in table cell at line that resolves to blank and adjacent to other non-blank lines
- set level property on Cell and Column
- set content_model property on Cell
- define block? and inline? methods on Column that both return false