### PR TITLE
refactor Parser.is_delimited_block?

### DIFF
--- a/lib/asciidoctor.rb
+++ b/lib/asciidoctor.rb
@@ -285,7 +285,7 @@ module Asciidoctor
     '```'  => [:fenced_code, ::Set.new]
   }
 
-  DELIMITED_BLOCK_HEADS = {}.tap {|accum| DELIMITED_BLOCKS.each_key {|k| accum[k.slice 0, 2] = k } }
+  DELIMITED_BLOCK_HEADS = {}.tap {|accum| DELIMITED_BLOCKS.each_key {|k| accum[k.slice 0, 2] = true } }
   DELIMITED_BLOCK_TAILS = {}.tap {|accum| DELIMITED_BLOCKS.each_key {|k| accum[k] = k[k.length - 1] if k.length == 4 } }
 
   LAYOUT_BREAK_CHARS = {


### PR DESCRIPTION
- only store true values in DELIMITED_BLOCK_HEADS
- short-circuit check for fenced code block
- compare line with tip before checking for uniform line
- rename tl to tip_len for clarity
- consolidate conditions for checking for matching line and returning match data