### PR TITLE
resolves #3106 apply header subs when assigning doctitle back to doctitle attribute

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -95,6 +95,7 @@ Bug Fixes::
   * fix crash caused by inline passthrough macro with the macros sub clearing the remaining passthrough placeholders (#3089)
   * don't fail to parse Markdown-style quote block that only contains attribution line (#2989)
   * enforce rule that Setext section title must have at least one alphanumeric character; fixes problem w/ block nested inside quote block (#3060)
+  * apply header subs to doctitle value when assigning it back to the doctitle document attribute (#3106)
   * don't fail if value of pygments-style attribute is not recognized; gracefully fallback to default style (#2106)
   * do not alter the $LOAD_PATH (#2764)
   * remove conditional comment for IE in output of built-in HTML converter; fixes sidebar table of contents (#2983)

--- a/test/document_test.rb
+++ b/test/document_test.rb
@@ -639,7 +639,7 @@ context 'Document' do
       assert_xpath '//*[@id="preamble"]//p[text()="Document Title, doctitle"]', doc.convert, 1
     end
 
-    test 'document with doctitle attribute entry overrides header title and doctitle' do
+    test 'document with doctitle attribute entry overrides implicit doctitle' do
       input = <<~'EOS'
       = Document Title
       :snapshot: {doctitle}
@@ -658,7 +658,7 @@ context 'Document' do
       assert_xpath '//*[@id="preamble"]//p[text()="Document Title, Override"]', doc.convert, 1
     end
 
-    test 'doctitle attribute entry above header overrides header title and doctitle' do
+    test 'doctitle attribute entry above header overrides implicit doctitle' do
       input = <<~'EOS'
       :doctitle: Override
       = Document Title
@@ -674,6 +674,18 @@ context 'Document' do
       assert_equal 'Override', doc.header.title
       assert_equal 'Override', doc.first_section.title
       assert_xpath '//*[@id="preamble"]//p[text()="Override"]', doc.convert, 1
+    end
+
+    test 'header substitutions should be applied to the value of the doctitle attribute' do
+      input = <<~'EOS'
+      = <Foo> & <Bar>
+
+      The name of the game is {doctitle}.
+      EOS
+
+      doc = document_from_string input
+      assert_equal '&lt;Foo&gt; &amp; &lt;Bar&gt;', (doc.attr 'doctitle')
+      assert_includes doc.blocks[0].content, '&lt;Foo&gt; &amp; &lt;Bar&gt;'
     end
 
     test 'should recognize document title when preceded by blank lines' do


### PR DESCRIPTION
resolves #3106 

- apply header subs to doctitle attribute so it can safely be referenced in page
- simplify logic that checks for doctitle override