### PR TITLE
optimize listparagraph processing

### DIFF
--- a/lib/asciidoctor/block.rb
+++ b/lib/asciidoctor/block.rb
@@ -71,6 +71,7 @@ class Block < AbstractBlock
           @attributes['subs'] = %(#{subs})
         end
         # resolve the subs eagerly only if subs option is specified
+        # QUESTION should we skip subsequent calls to lock_in_subs?
         lock_in_subs
       # e.g., subs: nil
       else

--- a/lib/asciidoctor/list.rb
+++ b/lib/asciidoctor/list.rb
@@ -115,13 +115,10 @@ class ListItem < AbstractBlock
   #
   # Returns nothing
   def fold_first(continuation_connects_first_block = false, content_adjacent = false)
-    if (first_block = @blocks[0]) && Block === first_block &&
+    if (first_block = @blocks[0]) &&
         ((first_block.context == :paragraph && !continuation_connects_first_block) ||
-        ((content_adjacent || !continuation_connects_first_block) && first_block.context == :literal &&
-            first_block.attributes['listparagraph-option']))
-      block = blocks.shift
-      block.lines.unshift @text unless @text.nil_or_empty?
-      @text = block.source
+        ((content_adjacent || !continuation_connects_first_block) && first_block.attributes['listparagraph-option']))
+      @text = @text.nil_or_empty? ? blocks.shift.source : %(#{@text}#{LF}#{blocks.shift.source})
     end
     nil
   end

--- a/lib/asciidoctor/parser.rb
+++ b/lib/asciidoctor/parser.rb
@@ -713,7 +713,10 @@ class Parser
         block = Block.new(parent, :literal, content_model: :verbatim, source: lines, attributes: attributes)
         # a literal gets special meaning inside of a description list
         # TODO this feels hacky, better way to distinguish from explicit literal block?
-        block.set_option 'listparagraph' if list_item
+        if list_item
+          block.set_option 'listparagraph'
+          block.instance_variable_set :@default_subs, []
+        end
       # a normal paragraph: contiguous non-blank/non-continuation lines (left-indented or normal style)
       else
         lines = read_paragraph_lines reader, skipped == 0 && options[:list_item], skip_line_comments: true

--- a/lib/asciidoctor/substitutors.rb
+++ b/lib/asciidoctor/substitutors.rb
@@ -1464,13 +1464,8 @@ module Substitutors
       when :simple
         default_subs = NORMAL_SUBS
       when :verbatim
-        if @context == :listing || (@context == :literal && !@attributes['listparagraph-option'])
-          default_subs = VERBATIM_SUBS
-        elsif @context == :verse
-          default_subs = NORMAL_SUBS
-        else
-          default_subs = BASIC_SUBS
-        end
+        # NOTE :literal with listparagraph-option gets folded into text of list item later
+        default_subs = @context == :verse ? NORMAL_SUBS : VERBATIM_SUBS
       when :raw
         # TODO make pass subs a compliance setting; AsciiDoc Python performs :attributes and :macros on a pass block
         default_subs = @context == :stem ? BASIC_SUBS : NONE_SUBS


### PR DESCRIPTION
- don't attempt to detect listparagraph when locking in subs
- eagerly set default_subs to empty array
- consolidate fold first block logic
- remove unnecessary type checks when folding first block