### PR TITLE
fix(asciidoc-vs-markdown): use `ul` consistent with user manual

### DIFF
--- a/docs/asciidoctor/modules/ROOT/pages/project/asciidoc-vs-markdown.adoc
+++ b/docs/asciidoctor/modules/ROOT/pages/project/asciidoc-vs-markdown.adoc
@@ -245,8 +245,8 @@ a|
 ----
 * apples
 * oranges
- ** temple
- ** navel
+** temple
+** navel
 * bananas
 ----
 |Ordered list


### PR DESCRIPTION
* https://asciidoctor.org/docs/user-manual/#nested
  - No leading space before the asterisks