### PR TITLE
refactor implicit link processing

### DIFF
--- a/lib/asciidoctor.rb
+++ b/lib/asciidoctor.rb
@@ -886,7 +886,7 @@ module Asciidoctor
     #   link:https://github.com[]
     #
     # FIXME revisit! the main issue is we need different rules for implicit vs explicit
-    InlineLinkRx = %r((^|link:|#{CG_BLANK}|&lt;|[>\(\)\[\];])(\\?(?:https?|file|ftp|irc)://[^\s\[\]<]*[^\s.,\[\]<])(?:\[(|#{CC_ALL}*?[^\\])\])?)m
+    InlineLinkRx = %r((^|link:|#{CG_BLANK}|&lt;|[>\(\)\[\];])(\\?(?:https?|file|ftp|irc)://[^\s\[\]<]*([^\s.,\[\]<]))(?:\[(|#{CC_ALL}*?[^\\])\])?)m
 
     # Match a link or e-mail inline macro.
     #
@@ -1084,16 +1084,6 @@ module Asciidoctor
     #   not c:/sample.adoc or c:\sample.adoc
     #
     UriSniffRx = %r(^#{CG_ALPHA}[#{CC_ALNUM}.+-]+:/{0,2})
-
-    # Detects the end of an implicit URI in the text
-    #
-    # Examples
-    #
-    #   (http://google.com)
-    #   &gt;http://google.com&lt;
-    #   (See http://google.com):
-    #
-    UriTerminatorRx = /[);:]$/
 
     # Detects XML tags
     XmlSanitizeRx = /<[^>]+>/

--- a/test/links_test.rb
+++ b/test/links_test.rb
@@ -86,37 +86,45 @@ context 'Links' do
   end
 
   test 'qualified url with trailing round bracket' do
-    assert_xpath '//a[@href="https://asciidoctor.org"][text()="https://asciidoctor.org"]', convert_string('Asciidoctor is a Ruby-based AsciiDoc processor (see https://asciidoctor.org)'), 1
+    result = convert_string_to_embedded 'Asciidoctor is a Ruby-based AsciiDoc processor (see https://asciidoctor.org)'
+    assert_xpath '//a[@href="https://asciidoctor.org"][text()="https://asciidoctor.org"]', result, 1
+    assert_xpath '//a[@href="https://asciidoctor.org"][text()="https://asciidoctor.org"]/following-sibling::text()[starts-with(.,")")]', result, 1
   end
 
   test 'qualified url with trailing semi-colon' do
-    assert_xpath '//a[@href="https://asciidoctor.org"][text()="https://asciidoctor.org"]', convert_string('https://asciidoctor.org; where text gets parsed'), 1
+    result = convert_string_to_embedded 'https://asciidoctor.org; where text gets parsed'
+    assert_xpath '//a[@href="https://asciidoctor.org"][text()="https://asciidoctor.org"]', result, 1
+    assert_xpath '//a[@href="https://asciidoctor.org"][text()="https://asciidoctor.org"]/following-sibling::text()[starts-with(.,";")]', result, 1
   end
 
   test 'qualified url with trailing colon' do
-    assert_xpath '//a[@href="https://asciidoctor.org"][text()="https://asciidoctor.org"]', convert_string('https://asciidoctor.org: where text gets parsed'), 1
+    result = convert_string_to_embedded 'https://asciidoctor.org: where text gets parsed'
+    assert_xpath '//a[@href="https://asciidoctor.org"][text()="https://asciidoctor.org"]', result, 1
+    assert_xpath '//a[@href="https://asciidoctor.org"][text()="https://asciidoctor.org"]/following-sibling::text()[starts-with(.,":")]', result, 1
   end
 
   test 'qualified url in round brackets with trailing colon' do
-    assert_xpath '//a[@href="https://asciidoctor.org"][text()="https://asciidoctor.org"]', convert_string('(https://asciidoctor.org): where text gets parsed'), 1
+    result = convert_string_to_embedded '(https://asciidoctor.org): where text gets parsed'
+    assert_xpath '//a[@href="https://asciidoctor.org"][text()="https://asciidoctor.org"]', result, 1
+    assert_xpath '//a[@href="https://asciidoctor.org"][text()="https://asciidoctor.org"]/following-sibling::text()[starts-with(.,"):")]', result, 1
   end
 
   test 'qualified url with trailing round bracket followed by colon' do
     result = convert_string_to_embedded '(from https://asciidoctor.org): where text gets parsed'
     assert_xpath '//a[@href="https://asciidoctor.org"][text()="https://asciidoctor.org"]', result, 1
-    assert_xpath '//a[@href="https://asciidoctor.org"][text()="https://asciidoctor.org"]/preceding-sibling::text()[.="(from "]', result, 1
-    assert_xpath '//a[@href="https://asciidoctor.org"][text()="https://asciidoctor.org"]/following-sibling::text()[.="): where text gets parsed"]', result, 1
+    assert_xpath '//a[@href="https://asciidoctor.org"][text()="https://asciidoctor.org"]/following-sibling::text()[starts-with(., "):")]', result, 1
   end
 
   test 'qualified url in round brackets with trailing semi-colon' do
-    assert_xpath '//a[@href="https://asciidoctor.org"][text()="https://asciidoctor.org"]', convert_string('(https://asciidoctor.org); where text gets parsed'), 1
+    result = convert_string_to_embedded '(https://asciidoctor.org); where text gets parsed'
+    assert_xpath '//a[@href="https://asciidoctor.org"][text()="https://asciidoctor.org"]', result, 1
+    assert_xpath '//a[@href="https://asciidoctor.org"][text()="https://asciidoctor.org"]/following-sibling::text()[starts-with(., ");")]', result, 1
   end
 
   test 'qualified url with trailing round bracket followed by semi-colon' do
     result = convert_string_to_embedded '(from https://asciidoctor.org); where text gets parsed'
     assert_xpath '//a[@href="https://asciidoctor.org"][text()="https://asciidoctor.org"]', result, 1
-    assert_xpath '//a[@href="https://asciidoctor.org"][text()="https://asciidoctor.org"]/preceding-sibling::text()[.="(from "]', result, 1
-    assert_xpath '//a[@href="https://asciidoctor.org"][text()="https://asciidoctor.org"]/following-sibling::text()[.="); where text gets parsed"]', result, 1
+    assert_xpath '//a[@href="https://asciidoctor.org"][text()="https://asciidoctor.org"]/following-sibling::text()[starts-with(., ");")]', result, 1
   end
 
   test 'URI scheme with trailing characters should not be converted to a link' do


### PR DESCRIPTION
- use capture to avoid running subsequent regular expression (UriTerminatorRx)
- only check if target ends with :// if target was modified
- update assertions to check that terminating character(s) got moved outside URL