### PR TITLE
resolves #3131 truncate with precision (instead of rounding) when computing abswidth for columns in DocBook output

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -98,6 +98,7 @@ Improvements::
   * add clearer exception message when source data is binary or has invalid encoding (#2884)
   * rename context for table cell and table column to :table_cell and :table_column, respectively
   * rename hardbreaks document attribute to hardbreaks-option; retain hardbreaks as a deprecated alias (#3123)
+  * truncate with precision (instead of rounding) when computing absolute width for columns in DocBook output (#3131)
 
 Bug Fixes::
 

--- a/lib/asciidoctor/table.rb
+++ b/lib/asciidoctor/table.rb
@@ -71,10 +71,8 @@ class Table < AbstractBlock
     end
     @attributes['tablepcwidth'] = pcwidth_intval
 
-    if @document.attributes.key? 'pagewidth'
-      # FIXME calculate more accurately (only used in DocBook output)
-      @attributes['tableabswidth'] ||=
-          ((@attributes['tablepcwidth'].to_f / 100) * @document.attributes['pagewidth']).round
+    if @document.attributes['pagewidth']
+      @attributes['tableabswidth'] = (abswidth_val = (((pcwidth_intval / 100.0) * @document.attributes['pagewidth'].to_f).truncate DEFAULT_PRECISION)) == abswidth_val.to_i ? abswidth_val.to_i : abswidth_val
     end
 
     attributes['orientation'] = 'landscape' if attributes['rotate-option']
@@ -206,12 +204,10 @@ class Table::Column < AbstractNode
       col_pcwidth = (@attributes['width'].to_f * 100.0 / width_base).truncate precision
       col_pcwidth = col_pcwidth.to_i if col_pcwidth.to_i == col_pcwidth
     end
-    @attributes['colpcwidth'] = col_pcwidth
-    if parent.attributes.key? 'tableabswidth'
-      # FIXME calculate more accurately (only used in DocBook output)
-      @attributes['colabswidth'] = ((col_pcwidth / 100.0) * parent.attributes['tableabswidth']).round
+    if parent.attributes['tableabswidth']
+      @attributes['colabswidth'] = (col_abswidth = ((col_pcwidth / 100.0) * parent.attributes['tableabswidth']).truncate precision) == col_abswidth.to_i ? col_abswidth.to_i : col_abswidth
     end
-    col_pcwidth
+    @attributes['colpcwidth'] = col_pcwidth
   end
 
   def block?

--- a/test/tables_test.rb
+++ b/test/tables_test.rb
@@ -386,6 +386,25 @@ context 'Tables' do
       assert_css 'tgroup colspec[colwidth="28.3334*"]', output, 1
     end
 
+    test 'should compute column widths based on pagewidth when width is set on table in DocBook output' do
+      input = <<~'EOS'
+      :pagewidth: 500
+
+      [width=50%]
+      |=======
+      |A |B |C |D
+
+      |a |b |c |d
+      |1 |2 |3 |4
+      |=======
+      EOS
+      output = convert_string_to_embedded input, backend: 'docbook5'
+      assert_css 'tgroup[cols="4"]', output, 1
+      assert_css 'tgroup colspec', output, 4
+      assert_css 'tgroup colspec[colwidth]', output, 4
+      assert_css 'tgroup colspec[colwidth="62.5*"]', output, 4
+    end
+
     test 'explicit table width is used even when autowidth option is specified' do
       input = <<~'EOS'
       [%autowidth,width=75%]


### PR DESCRIPTION
resolves #3131