### PR TITLE
Always store section numeral as string

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -76,6 +76,7 @@ Enhancements / Compliance::
 Improvements::
 
   * propagate document ID to DocBook output (#3011)
+  * always store section numeral as string; compute roman numeral for part at assignment time (@vmj)
   * refactor code to use modern Hash syntax
   * define LIB_DIR constant; rename *_PATH constants to *_DIR constants to be consistent with RubyGems terminology (#2764)
   * only define ROOT_DIR if not already defined (for compatibility with Asciidoctor.js)

--- a/lib/asciidoctor/section.rb
+++ b/lib/asciidoctor/section.rb
@@ -111,14 +111,7 @@ class Section < AbstractBlock
   # Returns the section number as a String
   def sectnum(delimiter = '.', append = nil)
     append ||= (append == false ? '' : delimiter)
-    if @level == 1
-      %(#{@numeral}#{append})
-    elsif @level > 1
-      Section === @parent ? %(#{@parent.sectnum(delimiter, delimiter)}#{@numeral}#{append}) : %(#{@numeral}#{append})
-    else # @level == 0
-      # NOTE coerce @numeral to int just in case not set; can happen if section nesting is out of sequence
-      %(#{Helpers.int_to_roman @numeral.to_i}#{append})
-    end
+    @level > 1 && Section === @parent ? %(#{@parent.sectnum(delimiter, delimiter)}#{@numeral}#{append}) : %(#{@numeral}#{append})
   end
 
   # (see AbstractBlock#xreftext)

--- a/test/sections_test.rb
+++ b/test/sections_test.rb
@@ -1489,6 +1489,33 @@ context 'Sections' do
       assert_xpath '//h1[@id="_processor"][text() = "II: Processor"]', output, 1
     end
 
+    test 'should assign sequential roman numerals to book parts' do
+      input = <<~'EOS'
+      = Book Title
+      :doctype: book
+      :sectnums:
+      :partnums:
+
+      = First Part
+
+      part intro
+
+      == First Chapter
+
+      = Second Part
+
+      part intro
+
+      == Second Chapter
+      EOS
+
+      doc = document_from_string input
+      assert_equal 'I', doc.sections[0].numeral
+      assert_equal '1', doc.sections[0].sections[0].numeral
+      assert_equal 'II', doc.sections[1].numeral
+      assert_equal '2', doc.sections[1].sections[0].numeral
+    end
+
     test 'should prepend value of part-signifier attribute to title of numbered part' do
       input = <<~'EOS'
       = Book Title
@@ -1806,12 +1833,12 @@ context 'Sections' do
       sections = doc.sections
       [0, 1, 2].each do |index|
         assert_equal index, sections[index].index
-        assert_equal index + 1, sections[index].numeral
+        assert_equal (index + 1).to_s, sections[index].numeral
         assert_equal index + 1, sections[index].number
       end
     end
 
-    test 'should allow sections to be renumbered using deprecated number property' do
+    test 'should allow sections to be renumbered using numberal property' do
       input = <<~'EOS'
       == Somewhere in the Middle
 
@@ -1820,7 +1847,7 @@ context 'Sections' do
 
       doc = document_from_string input, attributes: { 'sectnums' => '' }
       doc.sections.each do |sect|
-        sect.number += 1
+        sect.numeral = sect.numeral.next
       end
 
       output = doc.convert standalone: false


### PR DESCRIPTION
The first commit tries to make sure `numeral` is always a string, as it states in the RDoc.

The second commit changes the `numeral` of book parts from arabic to roman numerals.  The code used to make the translation only in `sectnum` method, leaving the actual attribute to arabic numeral.  Now the translation is done earlier.

These changes are part of the asciidoctor/asciidoctorj#549