### PR TITLE
resolves #3165 use proper terminology in warning message about mismatched preprocessor directive

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -109,6 +109,7 @@ Improvements::
   * rename hardbreaks document attribute to hardbreaks-option; retain hardbreaks as a deprecated alias (#3123)
   * truncate with precision (instead of rounding) when computing absolute width for columns in DocBook output (#3131)
   * drop legacy LaTeX math delimiters (e.g, `$..$`) if present (#1339)
+  * use proper terminology in warning message about mismatched preprocessor directive (#3165)
   * upgrade MathJax to 2.7.5
 
 Bug Fixes::

--- a/lib/asciidoctor/reader.rb
+++ b/lib/asciidoctor/reader.rb
@@ -910,12 +910,12 @@ class PreprocessorReader < Reader
 
     if keyword == 'endif'
       if @conditional_stack.empty?
-        logger.error message_with_context %(unmatched macro: endif::#{target}[]), source_location: cursor
+        logger.error message_with_context %(unmatched preprocessor directive: endif::#{target}[]), source_location: cursor
       elsif no_target || target == (pair = @conditional_stack[-1])[:target]
         @conditional_stack.pop
         @skipping = @conditional_stack.empty? ? false : @conditional_stack[-1][:skipping]
       else
-        logger.error message_with_context %(mismatched macro: endif::#{target}[], expected endif::#{pair[:target]}[]), source_location: cursor
+        logger.error message_with_context %(mismatched preprocessor directive: endif::#{target}[], expected endif::#{pair[:target]}[]), source_location: cursor
       end
       return true
     end


### PR DESCRIPTION
- use proper terminology in warning message for preprocessor directive
- add tests for unmatched and mismatched preprocessor directive