### PR TITLE
resolves #3161 log warning if conditional expression in ifeval directive is invalid

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -75,6 +75,8 @@ Enhancements / Compliance::
   * replace anchors and xrefs before footnotes (replace footnotes last in macros substitution group)
   * apply substitution for custom inline macro before all other macros
   * load additional languages for highlight.js as defined in the comma-separated highlightjs-languages attribute (#3036)
+  * log warning if conditional expression in ifeval directive is invalid (#3161)
+  * drop lines that contain an invalid preprocessor directive (#3161)
 
 Improvements::
 


### PR DESCRIPTION
resolves #3161

- log warning if conditional expression in ifeval directive is invalid (#3161)
- drop lines that contain an invalid preprocessor directive (#3161)