### PR TITLE
use .merge to duplicate Hash instead of .dup

### DIFF
--- a/lib/asciidoctor.rb
+++ b/lib/asciidoctor.rb
@@ -1221,7 +1221,7 @@ module Asciidoctor
   #
   # Returns the Document
   def load input, options = {}
-    options = options.dup
+    options = options.merge
 
     if (timings = options[:timings])
       timings.start :read
@@ -1233,7 +1233,9 @@ module Asciidoctor
 
     if !(attrs = options[:attributes])
       attrs = {}
-    elsif ::Hash === attrs || ((defined? ::Java::JavaUtil::Map) && ::Java::JavaUtil::Map === attrs)
+    elsif ::Hash === attrs
+      attrs = attrs.merge
+    elsif (defined? ::Java::JavaUtil::Map) && ::Java::JavaUtil::Map === attrs
       attrs = attrs.dup
     elsif ::Array === attrs
       attrs = {}.tap do |accum|
@@ -1351,7 +1353,7 @@ module Asciidoctor
   # Returns the Document object if the converted String is written to a
   # file, otherwise the converted String
   def convert input, options = {}
-    options = options.dup
+    options = options.merge
     options.delete(:parse)
     to_file = options.delete(:to_file)
     to_dir = options.delete(:to_dir)

--- a/lib/asciidoctor/abstract_node.rb
+++ b/lib/asciidoctor/abstract_node.rb
@@ -25,19 +25,15 @@ class AbstractNode
   attr_reader :parent
 
   def initialize parent, context, opts = {}
+    # document is a special case, should refer to itself
     if context == :document
-      # document is a special case, should refer to itself
-      @document, @parent = self, nil
-    else
-      if parent
-        @document, @parent = parent.document, parent
-      else
-        @document = @parent = nil
-      end
+      @document = self
+    elsif parent
+      @document = (@parent = parent).document
     end
     @node_name = (@context = context).to_s
-    # QUESTION are we correct in duplicating the attributes (seems to be just as fast)
-    @attributes = (opts.key? :attributes) ? opts[:attributes].dup : {}
+    # NOTE the value of the :attributes option may be nil on an Inline node
+    @attributes = (attrs = opts[:attributes]) ? attrs.merge : {}
     @passthroughs = []
   end
 

--- a/lib/asciidoctor/converter.rb
+++ b/lib/asciidoctor/converter.rb
@@ -238,7 +238,7 @@ module Converter
 
     # Public: Get the Hash of Converter classes keyed by backend name. Intended for testing only.
     def converters
-      registry.dup
+      registry.merge
     end
 
     private def registry

--- a/lib/asciidoctor/converter/template.rb
+++ b/lib/asciidoctor/converter/template.rb
@@ -58,7 +58,7 @@ class Converter::TemplateConverter < Converter::Base
     @safe = opts[:safe]
     @active_engines = {}
     @engine = opts[:template_engine]
-    @engine_options = {}.tap {|accum| DEFAULT_ENGINE_OPTIONS.each {|engine, engine_opts| accum[engine] = engine_opts.dup } }
+    @engine_options = {}.tap {|accum| DEFAULT_ENGINE_OPTIONS.each {|engine, engine_opts| accum[engine] = engine_opts.merge } }
     if opts[:htmlsyntax] == 'html' # if not set, assume xml since this converter is also used for DocBook (which doesn't specify htmlsyntax)
       @engine_options[:haml][:format] = :html5
       @engine_options[:slim][:format] = :html
@@ -124,7 +124,7 @@ class Converter::TemplateConverter < Converter::Base
   #
   # Returns a [Hash] of Tilt template objects keyed by template name.
   def templates
-    @templates.dup
+    @templates.merge
   end
 
   # Public: Registers a Tilt template with this converter.

--- a/lib/asciidoctor/core_ext.rb
+++ b/lib/asciidoctor/core_ext.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 require_relative 'core_ext/float/truncate'
+require_relative 'core_ext/hash/merge'
 require_relative 'core_ext/match_data/names' if RUBY_ENGINE == 'opal'
 require_relative 'core_ext/nil_or_empty'
 require_relative 'core_ext/regexp/is_match'

--- a/lib/asciidoctor/core_ext/hash/merge.rb
+++ b/lib/asciidoctor/core_ext/hash/merge.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+# NOTE remove once minimum required Ruby version is at least 2.6
+Hash.prepend(Module.new do
+  def merge *args
+    (len = args.length) < 1 ? super({}) : (len > 1 ? args.inject(self) {|acc, arg| acc.merge arg } : (super args[0]))
+  end
+end) if (Hash.instance_method :merge).arity == 1

--- a/lib/asciidoctor/document.rb
+++ b/lib/asciidoctor/document.rb
@@ -257,10 +257,10 @@ class Document < AbstractBlock
       @parent_document = parent_doc
       options[:base_dir] ||= parent_doc.base_dir
       options[:catalog_assets] = true if parent_doc.options[:catalog_assets]
-      @catalog = parent_doc.catalog.dup.tap {|catalog| catalog[:footnotes] = [] }
+      @catalog = parent_doc.catalog.merge footnotes: []
       # QUESTION should we support setting attribute in parent document from nested document?
       # NOTE we must dup or else all the assignments to the overrides clobbers the real attributes
-      @attribute_overrides = attr_overrides = parent_doc.attributes.dup
+      @attribute_overrides = attr_overrides = parent_doc.attributes.merge
       parent_doctype = attr_overrides.delete 'doctype'
       attr_overrides.delete 'compat-mode'
       attr_overrides.delete 'toc'
@@ -1249,7 +1249,7 @@ class Document < AbstractBlock
       end
     end
 
-    @header_attributes = attrs.dup
+    @header_attributes = attrs.merge
   end
 
   # Internal: Assign the local and document datetime attributes, which includes localdate, localyear, localtime,

--- a/lib/asciidoctor/extensions.rb
+++ b/lib/asciidoctor/extensions.rb
@@ -211,7 +211,7 @@ module Extensions
     # QUESTION is parse_content the right method name? should we wrap in open block automatically?
     def parse_content parent, content, attributes = nil
       reader = Reader === content ? content : (Reader.new content)
-      while ((block = Parser.next_block reader, parent, (attributes ? attributes.dup : {})) && parent << block) ||
+      while ((block = Parser.next_block reader, parent, (attributes ? attributes.merge : {})) && parent << block) ||
           reader.has_more_lines?
       end
       parent

--- a/lib/asciidoctor/inline.rb
+++ b/lib/asciidoctor/inline.rb
@@ -12,19 +12,12 @@ class Inline < AbstractNode
   attr_accessor :target
 
   def initialize(parent, context, text = nil, opts = {})
-    super(parent, context)
+    super(parent, context, opts)
     @node_name = %(inline_#{context})
-
     @text = text
-
     @id = opts[:id]
     @type = opts[:type]
     @target = opts[:target]
-
-    # value of attributes option for inline nodes may be nil
-    if (attrs = opts[:attributes])
-      @attributes = attrs.dup
-    end
   end
 
   def block?

--- a/lib/asciidoctor/parser.rb
+++ b/lib/asciidoctor/parser.rb
@@ -448,7 +448,7 @@ class Parser
     # of a section that need to get transfered to the next section
     # see "trailing block attributes transfer to the following section" in
     # test/attributes_test.rb for an example
-    [section != parent ? section : nil, attributes.dup]
+    [section != parent ? section : nil, attributes.merge]
   end
 
   # Public: Parse and return the next Block at the Reader's current location
@@ -1028,7 +1028,7 @@ class Parser
     if (extension = options[:extension])
       # QUESTION do we want to delete the style?
       attributes.delete('style')
-      if (block = extension.process_method[parent, block_reader || (Reader.new lines), attributes.dup])
+      if (block = extension.process_method[parent, block_reader || (Reader.new lines), attributes.merge])
         attributes.replace block.attributes
         # FIXME if the content model is set to compound, but we only have simple in this context, then
         # forcefully set the content_model to simple to prevent parsing blocks from children
@@ -2454,7 +2454,7 @@ class Parser
         end
 
         if m[1]
-          1.upto(m[1].to_i) { specs << spec.dup }
+          1.upto(m[1].to_i) { specs << spec.merge }
         else
           specs << spec
         end

--- a/lib/asciidoctor/substitutors.rb
+++ b/lib/asciidoctor/substitutors.rb
@@ -506,7 +506,7 @@ module Substitutors
           else
             target, content = ($~[:target] rescue nil), ($~[:content] rescue nil)
           end
-          attributes = (attributes = extconf[:default_attrs]) ? attributes.dup : {}
+          attributes = (attributes = extconf[:default_attrs]) ? attributes.merge : {}
           if content.nil_or_empty?
             attributes['text'] = content if content && extconf[:content_model] != :attributes
           else


### PR DESCRIPTION
- use .merge to duplicate Hash instead of .dup because it's much faster
- include patch for .merge to accept variable length argument list