### PR TITLE
resolve #2047 add support for see and see also relationships on index terms

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -80,7 +80,8 @@ Enhancements / Compliance::
   * replace anchors and xrefs before footnotes (replace footnotes last in macros substitution group)
   * apply substitution for custom inline macro before all other macros
   * only promote index terms automatically (A, B, C becomes A > B > C + B > C + C) if indexterm-promotion option is set on document (#1487)
-  * drop indexterms table from document catalog (in preparation for solution to #450 in a 2.x release)
+  * add support for see and see-also on index terms; parse attributes on indexterm macros if text contains `=` (#2047)
+  * drop :indexterms table from document catalog (in preparation for solution to #450 in a 2.x release)
   * load additional languages for highlight.js as defined in the comma-separated highlightjs-languages attribute (#3036)
   * log warning if conditional expression in ifeval directive is invalid (#3161)
   * drop lines that contain an invalid preprocessor directive (#3161)

--- a/lib/asciidoctor/converter/docbook5.rb
+++ b/lib/asciidoctor/converter/docbook5.rb
@@ -538,11 +538,21 @@ class Converter::DocBook5Converter < Converter::Base
   end
 
   def convert_inline_indexterm node
+    if (see = node.attr 'see')
+      rel = %(\n<see>#{see}</see>)
+    elsif (see_also_list = node.attr 'see-also')
+      rel = see_also_list.map {|see_also| %(\n<seealso>#{see_also}</seealso>) }.join
+    else
+      rel = ''
+    end
     if node.type == :visible
-      %(<indexterm><primary>#{node.text}</primary></indexterm>#{node.text})
-    elsif (numterms = (terms = node.attr 'terms').size) > 2
       %(<indexterm>
-<primary>#{terms[0]}</primary><secondary>#{terms[1]}</secondary><tertiary>#{terms[2]}</tertiary>
+<primary>#{node.text}</primary>#{rel}
+</indexterm>#{node.text})
+    else
+      if (numterms = (terms = node.attr 'terms').size) > 2
+        %(<indexterm>
+<primary>#{terms[0]}</primary><secondary>#{terms[1]}</secondary><tertiary>#{terms[2]}</tertiary>#{rel}
 </indexterm>#{(node.document.option? 'indexterm-promotion') ? %[
 <indexterm>
 <primary>#{terms[1]}</primary><secondary>#{terms[2]}</secondary>
@@ -550,17 +560,18 @@ class Converter::DocBook5Converter < Converter::Base
 <indexterm>
 <primary>#{terms[2]}</primary>
 </indexterm>] : ''})
-    elsif numterms > 1
-      %(<indexterm>
-<primary>#{terms[0]}</primary><secondary>#{terms[1]}</secondary>
+      elsif numterms > 1
+        %(<indexterm>
+<primary>#{terms[0]}</primary><secondary>#{terms[1]}</secondary>#{rel}
 </indexterm>#{(node.document.option?  'indexterm-promotion') ? %[
 <indexterm>
 <primary>#{terms[1]}</primary>
 </indexterm>] : ''})
-    else
-      %(<indexterm>
-<primary>#{terms[0]}</primary>
+      else
+        %(<indexterm>
+<primary>#{terms[0]}</primary>#{rel}
 </indexterm>)
+      end
     end
   end
 

--- a/lib/asciidoctor/substitutors.rb
+++ b/lib/asciidoctor/substitutors.rb
@@ -634,17 +634,39 @@ module Substitutors
           next $&.slice 1, $&.length if $&.start_with? RS
 
           # indexterm:[Tigers,Big cats]
-          terms = split_simple_csv normalize_string $2, true
+          if (attrlist = normalize_string $2, true).include? '='
+            if (primary = (attrs = (AttributeList.new attrlist, self).parse)[1])
+              attrs['terms'] = terms = [primary]
+              if (secondary = attrs[2])
+                terms << secondary
+                if (tertiary = attrs[3])
+                  terms << tertiary
+                end
+              end
+              if (see_also = attrs['see-also'])
+                attrs['see-also'] = (see_also.include? ',') ? (see_also.split ',').map {|it| it.lstrip } : [see_also]
+              end
+            else
+              attrs = { 'terms' => (terms = attrlist) }
+            end
+          else
+            attrs = { 'terms' => (terms = split_simple_csv attrlist) }
+          end
           #doc.register :indexterms, terms
-          (Inline.new self, :indexterm, nil, attributes: { 'terms' => terms }).convert
+          (Inline.new self, :indexterm, nil, attributes: attrs).convert
         when 'indexterm2'
           # honor the escape
           next $&.slice 1, $&.length if $&.start_with? RS
 
           # indexterm2:[Tigers]
-          term = normalize_string $2, true
+          if (term = normalize_string $2, true).include? '='
+            term = (attrs = (AttributeList.new term, self).parse)[1] || (attrs = nil) || term
+            if attrs && (see_also = attrs['see-also'])
+              attrs['see-also'] = (see_also.include? ',') ? (see_also.split ',').map {|it| it.lstrip } : [see_also]
+            end
+          end
           #doc.register :indexterms, [term]
-          (Inline.new self, :indexterm, term, type: :visible).convert
+          (Inline.new self, :indexterm, term, attributes: attrs, type: :visible).convert
         else
           text = $3
           # honor the escape
@@ -670,14 +692,32 @@ module Substitutors
           end
           if visible
             # ((Tigers))
-            term = normalize_string text
+            if (term = normalize_string text).include? ';&'
+              if term.include? ' &gt;&gt; '
+                term, _, see = term.partition ' &gt;&gt; '
+                attrs = { 'see' => see }
+              elsif term.include? ' &amp;&gt; '
+                term, *see_also = term.split ' &amp;&gt; '
+                attrs = { 'see-also' => see_also }
+              end
+            end
             #doc.register :indexterms, [term]
-            subbed_term = (Inline.new self, :indexterm, term, type: :visible).convert
+            subbed_term = (Inline.new self, :indexterm, term, attributes: attrs, type: :visible).convert
           else
             # (((Tigers,Big cats)))
-            terms = split_simple_csv(normalize_string text)
+            attrs = {}
+            if (terms = normalize_string text).include? ';&'
+              if terms.include? ' &gt;&gt; '
+                terms, _, see = terms.partition ' &gt;&gt; '
+                attrs['see'] = see
+              elsif terms.include? ' &amp;&gt; '
+                terms, *see_also = terms.split ' &amp;&gt; '
+                attrs['see-also'] = see_also
+              end
+            end
+            attrs['terms'] = terms = split_simple_csv terms
             #doc.register :indexterms, terms
-            subbed_term = (Inline.new self, :indexterm, nil, attributes: { 'terms' => terms }).convert
+            subbed_term = (Inline.new self, :indexterm, nil, attributes: attrs).convert
           end
           before ? %(#{before}#{subbed_term}#{after}) : subbed_term
         end
@@ -1165,7 +1205,7 @@ module Substitutors
   #
   # Returns an empty Hash if attrlist is nil or empty, otherwise a Hash of parsed attributes.
   def parse_attributes attrlist, posattrs = [], opts = {}
-    return {} unless attrlist && !attrlist.empty?
+    return {} if attrlist ? attrlist.empty? : true
     attrlist = unescape_bracketed_text attrlist if opts[:unescape_input]
     attrlist = @document.sub_attributes attrlist if opts[:sub_input] && (attrlist.include? ATTR_REF_HEAD)
     # substitutions are only performed on attribute values if block is not nil
@@ -1213,10 +1253,10 @@ module Substitutors
   end
 
   # Internal: Strip bounding whitespace and fold newlines
-  def normalize_string str, unescape_brackets = false
+  def normalize_string str, unescape_right_square_brackets = nil
     unless str.empty?
       str = str.strip.tr LF, ' '
-      str = str.gsub ESC_R_SB, R_SB if unescape_brackets && (str.include? R_SB)
+      str = str.gsub ESC_R_SB, R_SB if unescape_right_square_brackets && (str.include? R_SB)
     end
     str
   end

--- a/test/paragraphs_test.rb
+++ b/test/paragraphs_test.rb
@@ -155,7 +155,7 @@ context 'Paragraphs' do
       output = convert_string_to_embedded input, backend: 'docbook', attributes: { 'indexterm-promotion-option' => '' }
       assert_xpath '/simpara', output, 1
       term1 = xmlnodes_at_xpath '(//indexterm)[1]', output, 1
-      assert_equal '<indexterm><primary>tigers</primary></indexterm>', term1.to_s
+      assert_equal %(<indexterm>\n<primary>tigers</primary>\n</indexterm>), term1.to_s
       assert term1.next.content.start_with?('tigers')
 
       term2 = xmlnodes_at_xpath '(//indexterm)[2]', output, 1
@@ -177,7 +177,7 @@ context 'Paragraphs' do
       assert_equal '<primary>Siberian Tiger</primary>', term4_elements[0].to_s
 
       term5 = xmlnodes_at_xpath '(//indexterm)[5]', output, 1
-      assert_equal '<indexterm><primary>Linux</primary></indexterm>', term5.to_s
+      assert_equal %(<indexterm>\n<primary>Linux</primary>\n</indexterm>), term5.to_s
       assert term5.next.content.start_with?('Linux')
 
       assert_xpath '(//indexterm)[6]/*', output, 3

--- a/test/substitutions_test.rb
+++ b/test/substitutions_test.rb
@@ -1248,7 +1248,11 @@ context 'Substitutions' do
 
     test 'visible shorthand index term macro should not consume trailing round bracket' do
       input = '(text with ((index term)))'
-      expected = '(text with <indexterm><primary>index term</primary></indexterm>index term)'
+      expected = <<~'EOS'.chop
+      (text with <indexterm>
+      <primary>index term</primary>
+      </indexterm>index term)
+      EOS
       #expected_term = ['index term']
       para = block_from_string input, backend: :docbook
       output = para.sub_macros para.source
@@ -1260,7 +1264,11 @@ context 'Substitutions' do
 
     test 'visible shorthand index term macro should not consume leading round bracket' do
       input = '(((index term)) for text)'
-      expected = '(<indexterm><primary>index term</primary></indexterm>index term for text)'
+      expected = <<~'EOS'.chop
+      (<indexterm>
+      <primary>index term</primary>
+      </indexterm>index term for text)
+      EOS
       #expected_term = ['index term']
       para = block_from_string input, backend: :docbook
       output = para.sub_macros para.source
@@ -1340,6 +1348,86 @@ context 'Substitutions' do
       #assert_equal 2, terms.size
       #assert_equal ['panthera tigris'], terms[0]
       #assert_equal ['Big cats', 'Tigers'], terms[1]
+    end
+
+    test 'should parse visible shorthand index term with see and seealso' do
+      sentence = '((Flash >> HTML 5)) has been supplanted by ((HTML 5 &> CSS 3 &> SVG)).'
+      output = convert_string_to_embedded sentence, backend: 'docbook'
+      indexterm_flash = <<~'EOS'.chop
+      <indexterm>
+      <primary>Flash</primary>
+      <see>HTML 5</see>
+      </indexterm>
+      EOS
+      indexterm_html5 = <<~'EOS'.chop
+      <indexterm>
+      <primary>HTML 5</primary>
+      <seealso>CSS 3</seealso>
+      <seealso>SVG</seealso>
+      </indexterm>
+      EOS
+      assert_includes output, indexterm_flash
+      assert_includes output, indexterm_html5
+    end
+
+    test 'should parse concealed shorthand index term with see and seealso' do
+      sentence = 'Flash(((Flash >> HTML 5))) has been supplanted by HTML 5(((HTML 5 &> CSS 3 &> SVG))).'
+      output = convert_string_to_embedded sentence, backend: 'docbook'
+      indexterm_flash = <<~'EOS'.chop
+      <indexterm>
+      <primary>Flash</primary>
+      <see>HTML 5</see>
+      </indexterm>
+      EOS
+      indexterm_html5 = <<~'EOS'.chop
+      <indexterm>
+      <primary>HTML 5</primary>
+      <seealso>CSS 3</seealso>
+      <seealso>SVG</seealso>
+      </indexterm>
+      EOS
+      assert_includes output, indexterm_flash
+      assert_includes output, indexterm_html5
+    end
+
+    test 'should parse visible index term macro with see and seealso' do
+      sentence = 'indexterm2:[Flash,see=HTML 5] has been supplanted by indexterm2:[HTML 5,see-also="CSS 3, SVG"].'
+      output = convert_string_to_embedded sentence, backend: 'docbook'
+      indexterm_flash = <<~'EOS'.chop
+      <indexterm>
+      <primary>Flash</primary>
+      <see>HTML 5</see>
+      </indexterm>
+      EOS
+      indexterm_html5 = <<~'EOS'.chop
+      <indexterm>
+      <primary>HTML 5</primary>
+      <seealso>CSS 3</seealso>
+      <seealso>SVG</seealso>
+      </indexterm>
+      EOS
+      assert_includes output, indexterm_flash
+      assert_includes output, indexterm_html5
+    end
+
+    test 'should parse concealed index term macro with see and seealso' do
+      sentence = 'Flashindexterm:[Flash,see=HTML 5] has been supplanted by HTML 5indexterm:[HTML 5,see-also="CSS 3, SVG"].'
+      output = convert_string_to_embedded sentence, backend: 'docbook'
+      indexterm_flash = <<~'EOS'.chop
+      <indexterm>
+      <primary>Flash</primary>
+      <see>HTML 5</see>
+      </indexterm>
+      EOS
+      indexterm_html5 = <<~'EOS'.chop
+      <indexterm>
+      <primary>HTML 5</primary>
+      <seealso>CSS 3</seealso>
+      <seealso>SVG</seealso>
+      </indexterm>
+      EOS
+      assert_includes output, indexterm_flash
+      assert_includes output, indexterm_html5
     end
 
     context 'Button macro' do


### PR DESCRIPTION
- add support for see and see also relationships on index terms (shorthand and macro)
- parse attributes on indexterm* macros if text contains `=`