### PR TITLE
resolves #2441 substitute replacements in author values used in document header

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -86,6 +86,8 @@ Enhancements / Compliance::
   * drop lines that contain an invalid preprocessor directive (#3161)
   * rename AbstractBlock#find_by directives; use :prune in place of :skip_children and :reject in place of :skip
   * convert example block into details/summary tag set if collapsible option is set; open by default if open option is set (#1699)
+  * substitute replacements in author values used in document header (#2441)
+  * require space after semi-colon that separates multiple authors (#2441)
 
 Improvements::
 

--- a/lib/asciidoctor.rb
+++ b/lib/asciidoctor.rb
@@ -396,6 +396,14 @@ module Asciidoctor
     #
     AuthorInfoLineRx = /^(#{CG_WORD}[#{CC_WORD}\-'.]*)(?: +(#{CG_WORD}[#{CC_WORD}\-'.]*))?(?: +(#{CG_WORD}[#{CC_WORD}\-'.]*))?(?: +<([^>]+)>)?$/
 
+    # Matches the delimiter that separates multiple authors.
+    #
+    # Examples
+    #
+    #   Doc Writer; Junior Writer
+    #
+    AuthorDelimiterRx = /;(?: |$)/
+
     # Matches the revision info line, which appears immediately following
     # the author info line beneath the document title.
     #

--- a/lib/asciidoctor/converter/docbook5.rb
+++ b/lib/asciidoctor/converter/docbook5.rb
@@ -630,13 +630,13 @@ class Converter::DocBook5Converter < Converter::Base
     end
   end
 
-  def author_tag author
+  def author_tag doc, author
     result = []
     result << '<author>'
     result << '<personname>'
-    result << %(<firstname>#{author.firstname}</firstname>) if author.firstname
-    result << %(<othername>#{author.middlename}</othername>) if author.middlename
-    result << %(<surname>#{author.lastname}</surname>) if author.lastname
+    result << %(<firstname>#{doc.sub_replacements author.firstname}</firstname>) if author.firstname
+    result << %(<othername>#{doc.sub_replacements author.middlename}</othername>) if author.middlename
+    result << %(<surname>#{doc.sub_replacements author.lastname}</surname>) if author.lastname
     result << '</personname>'
     result << %(<email>#{author.email}</email>) if author.email
     result << '</author>'
@@ -667,10 +667,10 @@ class Converter::DocBook5Converter < Converter::Base
       unless (authors = doc.authors).empty?
         if authors.size > 1
           result << '<authorgroup>'
-          authors.each {|author| result << (author_tag author) }
+          authors.each {|author| result << (author_tag doc, author) }
           result << '</authorgroup>'
         else
-          result << author_tag(author = authors[0])
+          result << (author_tag doc, (author = authors[0]))
           result << %(<authorinitials>#{author.initials}</authorinitials>) if author.initials
         end
       end

--- a/lib/asciidoctor/converter/html5.rb
+++ b/lib/asciidoctor/converter/html5.rb
@@ -101,7 +101,7 @@ class Converter::Html5Converter < Converter::Base
     result << %(<meta name="application-name" content="#{node.attr 'app-name'}"#{slash}>) if node.attr? 'app-name'
     result << %(<meta name="description" content="#{node.attr 'description'}"#{slash}>) if node.attr? 'description'
     result << %(<meta name="keywords" content="#{node.attr 'keywords'}"#{slash}>) if node.attr? 'keywords'
-    result << %(<meta name="author" content="#{((authors = node.attr 'authors').include? '<') ? (authors.gsub XmlSanitizeRx, '') : authors}"#{slash}>) if node.attr? 'authors'
+    result << %(<meta name="author" content="#{((authors = node.sub_replacements node.attr 'authors').include? '<') ? (authors.gsub XmlSanitizeRx, '') : authors}"#{slash}>) if node.attr? 'authors'
     result << %(<meta name="copyright" content="#{node.attr 'copyright'}"#{slash}>) if node.attr? 'copyright'
     if node.attr? 'favicon'
       if (icon_href = node.attr 'favicon').empty?
@@ -184,7 +184,7 @@ class Converter::Html5Converter < Converter::Base
           details = []
           idx = 1
           node.authors.each do |author|
-            details << %(<span id="author#{idx > 1 ? idx : ''}" class="author">#{author.name}</span>#{br})
+            details << %(<span id="author#{idx > 1 ? idx : ''}" class="author">#{node.sub_replacements author.name}</span>#{br})
             details << %(<span id="email#{idx > 1 ? idx : ''}" class="email">#{node.sub_macros author.email}</span>#{br}) if author.email
             idx += 1
           end

--- a/test/document_test.rb
+++ b/test/document_test.rb
@@ -876,6 +876,32 @@ context 'Document' do
       assert_xpath '/article/info/authorinitials[text()="DW"]', output, 1
     end
 
+    test 'should substitute replacements in author names in HTML output' do
+      input = <<~'EOS'
+      = Document Title
+      Stephen O'Grady <founder@redmonk.com>
+
+      content
+      EOS
+
+      output = convert_string input
+      assert_xpath %(//meta[@name="author"][@content="Stephen O#{decode_char 8217}Grady"]), output, 1
+      assert_xpath %(//span[@id="author"][text()="Stephen O#{decode_char 8217}Grady"]), output, 1
+    end
+
+    test 'should substitute replacements in author names in DocBook output' do
+      input = <<~'EOS'
+      = Document Title
+      Stephen O'Grady <founder@redmonk.com>
+
+      content
+      EOS
+
+      output = convert_string input, backend: 'docbook'
+      assert_xpath '//author', output, 1
+      assert_xpath %(//author/personname/surname[text()="O#{decode_char 8217}Grady"]), output, 1
+    end
+
     test 'should sanitize content of HTML meta authors tag' do
       input = <<~'EOS'
       = Document Title

--- a/test/parser_test.rb
+++ b/test/parser_test.rb
@@ -308,7 +308,7 @@ context "Parser" do
   end
 
   test "parse author condenses whitespace" do
-    metadata, _ = parse_header_metadata '   Stuart       Rackham     <founder@asciidoc.org>'
+    metadata, _ = parse_header_metadata 'Stuart       Rackham     <founder@asciidoc.org>'
     assert_equal 7, metadata.size
     assert_equal 1, metadata['authorcount']
     assert_equal 'Stuart Rackham', metadata['author']
@@ -336,6 +336,11 @@ context "Parser" do
     assert_equal 'Doc Writer', metadata['author']
     assert_equal 'Doc Writer', metadata['author_1']
     assert_equal 'John Smith', metadata['author_2']
+  end
+
+  test 'should not parse multiple authors if semi-colon is not followed by space' do
+    metadata, _ = parse_header_metadata 'Joe Doe;Smith Johnson'
+    assert_equal 1, metadata['authorcount']
   end
 
   test 'skips blank author entries in implicit author line' do


### PR DESCRIPTION
- apply replacements substitution to author values
- only split multiple authors on semi-colon followed by space