### PR TITLE
resolves #3193 bundle .yardopts in RubyGem

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -13,6 +13,12 @@ endif::[]
 This document provides a high-level view of the changes introduced in Asciidoctor by release.
 For a detailed view of what has changed, refer to the {uri-repo}/commits/master[commit history] on GitHub.
 
+== Unreleased
+
+Build / Infrastructure::
+
+  * bundle .yardopts in RubyGem (#3193)
+
 == 2.0.0 (2019-03-22) - @mojavelinux
 
 Enhancements / Compliance::

--- a/asciidoctor.gemspec
+++ b/asciidoctor.gemspec
@@ -28,7 +28,7 @@ Gem::Specification.new do |s|
   rescue
     Dir['**/*']
   end
-  s.files = files.grep %r/^(?:(?:data|lib|man)\/.+|LICENSE|(?:CHANGELOG|README(?:-\w+)?)\.adoc|#{s.name}\.gemspec)$/
+  s.files = files.grep %r/^(?:(?:data|lib|man)\/.+|LICENSE|(?:CHANGELOG|README(?:-\w+)?)\.adoc|\.yardopts|#{s.name}\.gemspec)$/
   s.executables = (files.grep %r/^bin\//).map {|f| File.basename f }
   s.require_paths = ['lib']
   #s.test_files = files.grep %r/^(?:(?:features|test)\/.+)$/


### PR DESCRIPTION
- bundle .yardopts so rubydoc.info selects correct README