### PR TITLE
resolves #3202 convert cataloged titles containing attribute references eagerly

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -17,6 +17,7 @@ For a detailed view of what has changed, refer to the {uri-repo}/commits/master[
 
 Bug Fixes::
 
+  * convert titles of cataloged block and section nodes containing attribute references eagerly to resolve attributes while in scope (#3202)
   * customize MathJax (using a postfilter hook) to apply displaymath formatting to AsciiMath block (#2498)
   * fix misspelling of deprecated default_attrs DSL function (missing trailing "s")
   * remove unused location property (attr_accessor :location) on DocinfoProcessor class

--- a/lib/asciidoctor.rb
+++ b/lib/asciidoctor.rb
@@ -293,6 +293,8 @@ module Asciidoctor
   DELIMITED_BLOCK_HEADS = {}.tap {|accum| DELIMITED_BLOCKS.each_key {|k| accum[k.slice 0, 2] = true } }
   DELIMITED_BLOCK_TAILS = {}.tap {|accum| DELIMITED_BLOCKS.each_key {|k| accum[k] = k[k.length - 1] if k.length == 4 } }
 
+  CAPTIONABLE_BLOCKS = { example: true, listing: true, table: true }
+
   LAYOUT_BREAK_CHARS = {
     '\'' => :thematic_break,
     '<'  => :page_break

--- a/test/blocks_test.rb
+++ b/test/blocks_test.rb
@@ -3573,6 +3573,33 @@ context 'Blocks' do
       assert_equal 'debian', (doc.resolve_id 'Debian, Ubuntu')
     end
 
+    test 'should resolve attribute reference in title using attribute defined at location of block' do
+      input = <<~'EOS'
+      = Document Title
+      :foo: baz
+
+      intro paragraph. see <<free-standing>>.
+
+      :foo: bar
+
+      .foo is {foo}
+      [#formal-para]
+      paragraph with title
+
+      [discrete#free-standing]
+      == foo is still {foo}
+      EOS
+
+      doc = document_from_string input
+      ref = doc.catalog[:refs]['formal-para']
+      refute_nil ref
+      assert_equal 'foo is bar', ref.title
+      assert_equal 'formal-para', (doc.resolve_id 'foo is bar')
+      output = doc.convert standalone: false
+      assert_include '<a href="#free-standing">foo is still bar</a>', output
+      assert_include '<h2 id="free-standing" class="discrete">foo is still bar</h2>', output
+    end
+
     test 'should substitute attribute references in reftext when registering block reference' do
       input = <<~'EOS'
       :label-tiger: Tiger

--- a/test/sections_test.rb
+++ b/test/sections_test.rb
@@ -266,8 +266,37 @@ context 'Sections' do
       assert_equal '_install', (doc.resolve_id 'Install Procedure')
     end
 
+    test 'should resolve attribute reference in title using attribute defined at location of section title' do
+      input = <<~'EOS'
+      :platform-id: linux
+      :platform-name: Linux
+
+      [#install-{platform-id}]
+      == Install on {platform-name}
+
+      content
+
+      :platform-id: win32
+      :platform-name: Windows
+
+      [#install-{platform-id}]
+      == Install on {platform-name}
+
+      content
+      EOS
+
+      doc = document_from_string input
+      ref = doc.catalog[:refs]['install-win32']
+      refute_nil ref
+      assert_equal 'Install on Windows', ref.title
+      assert_equal 'install-win32', (doc.resolve_id 'Install on Windows')
+    end
+
     test 'should substitute attributes when registering reftext for section' do
       input = <<~'EOS'
+      :platform-name: n/a
+      == Overview
+
       :platform-name: Linux
 
       [[install,install on {platform-name}]]


### PR DESCRIPTION
- convert titles of cataloged block and section nodes containing attribute references eagerly to resolve attributes while in scope
- consolidate all processing of title and caption for block at end of next_block
- add tests to verify behavior
