### PR TITLE
test: adjust message when asciimath is not available

### DIFF
--- a/test/blocks_test.rb
+++ b/test/blocks_test.rb
@@ -1859,7 +1859,7 @@ context 'Blocks' do
           assert_equal expect, actual.strip
           assert_equal :loaded, doc.converter.instance_variable_get(:@asciimath_status)
         else
-          assert_message logger, :WARN, 'optional gem \'asciimath\' is not installed. Functionality disabled.'
+          assert_message logger, :WARN, 'optional gem \'asciimath\' is not available. Functionality disabled.'
           assert_equal :unavailable, doc.converter.instance_variable_get(:@asciimath_status)
         end
       end

--- a/test/substitutions_test.rb
+++ b/test/substitutions_test.rb
@@ -1856,7 +1856,7 @@ context 'Substitutions' do
             assert_equal expected, actual
             assert_equal :loaded, para.document.converter.instance_variable_get(:@asciimath_status)
           else
-            assert_message logger, :WARN, 'optional gem \'asciimath\' is not installed. Functionality disabled.'
+            assert_message logger, :WARN, 'optional gem \'asciimath\' is not available. Functionality disabled.'
             assert_equal :unavailable, para.document.converter.instance_variable_get(:@asciimath_status)
           end
         end


### PR DESCRIPTION
The asciidoctor/helpers text was changed in a667772a ("resolves #1884
add detail to load error message if path is not gem name (PR #3195)",
2019-03-25).

This breaks test/blocks_test.rb and test/substitutions_test.rb,
resulting in a failure like:

--- expected
+++ actual
@@ -1 +1 @@
-"optional gem 'asciimath' is not installed. Functionality disabled."
+"optional gem 'asciimath' is not available. Functionality disabled."

Ensure the text in the asciimath tests matches what we output from
asciidoctor/helpers.