### PR TITLE
resolves #3205 apply verbatim substitutions to literal paragraphs attached to list item

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -13,6 +13,12 @@ endif::[]
 This document provides a high-level view of the changes introduced in Asciidoctor by release.
 For a detailed view of what has changed, refer to the {uri-repo}/commits/master[commit history] on GitHub.
 
+== Unreleased
+
+Bug Fixes::
+
+  * apply verbatim substitutions to literal paragraphs attached to list item (#3205)
+
 == 2.0.1 (2019-03-25) - @mojavelinux
 
 Bug Fixes::

--- a/lib/asciidoctor/abstract_block.rb
+++ b/lib/asciidoctor/abstract_block.rb
@@ -32,9 +32,6 @@ class AbstractBlock < AbstractNode
   # Public: Substitutions to be applied to content in this block.
   attr_reader :subs
 
-  # Internal: Set the default subs applied to this block; used during block creation
-  attr_writer :default_subs
-
   def initialize parent, context, opts = {}
     super
     @content_model = :compound

--- a/lib/asciidoctor/list.rb
+++ b/lib/asciidoctor/list.rb
@@ -103,27 +103,11 @@ class ListItem < AbstractBlock
     !simple?
   end
 
-  # Internal: Fold the first paragraph block into the text
-  #
-  # Here are the rules for when a folding occurs:
-  #
-  # Given: this list item has at least one block
-  # When: the first block is a paragraph that's not connected by a list continuation
-  # Or: the first block is an indented paragraph that's adjacent (wrapped line)
-  # Or: the first block is an indented paragraph that's not connected by a list continuation
-  # Then: then drop the first block and fold it's content (buffer) into the list text
+  # Internal: Fold the adjacent paragraph block into the list item text
   #
   # Returns nothing
-  def fold_first(continuation_connects_first_block = false, content_adjacent = false)
-    if (first_block = @blocks[0])
-      if first_block.context == :literal
-        if (content_adjacent || !continuation_connects_first_block) # && first_block.attributes['listparagraph-option']
-          @text = @text.nil_or_empty? ? @blocks.shift.source : %(#{@text}#{LF}#{@blocks.shift.source})
-        end
-      elsif first_block.context == :paragraph && !continuation_connects_first_block
-        @text = @text.nil_or_empty? ? @blocks.shift.source : %(#{@text}#{LF}#{@blocks.shift.source})
-      end
-    end
+  def fold_first
+    @text = @text.nil_or_empty? ? @blocks.shift.source : %(#{@text}#{LF}#{@blocks.shift.source})
     nil
   end
 


### PR DESCRIPTION
- improve detection of an indented paragraph that's a continuation of the primary list text
- apply verbatim substitutions to all other literal paragraphs
- simplify the logic in the ListItem#fold_first method (and stop tracking continuation_connects_first_block)
- add tests to verify change