### PR TITLE
resolves #3214 extract as variables to workaround a scope conflict in Opal

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -18,6 +18,7 @@ For a detailed view of what has changed, refer to the {uri-repo}/commits/master[
 Bug Fixes::
 
   * fix crash when attrlist is used on literal monospace phrase (#3216)
+  * update use of magic regexp variables to fix compatibility with Opal / Asciidoctor.js (#3214)
 
 == 2.0.2 (2019-03-26) - @mojavelinux
 

--- a/lib/asciidoctor/converter/docbook5.rb
+++ b/lib/asciidoctor/converter/docbook5.rb
@@ -740,9 +740,10 @@ class Converter::DocBook5Converter < Converter::Base
       width_attr = ''
       depth_attr = ''
       if (cover_image.include? ':') && ImageMacroRx =~ cover_image
+        attrlist = $2
         cover_image = doc.image_uri $1
-        unless $2.empty?
-          attrs = (AttributeList.new $2).parse ['alt', 'width', 'height']
+        unless attrlist.empty?
+          attrs = (AttributeList.new attrlist).parse ['alt', 'width', 'height']
           if attrs.key? 'scaledwidth'
             # NOTE scalefit="1" is the default in this case
             width_attr = %( width="#{attrs['scaledwidth']}")

--- a/lib/asciidoctor/document.rb
+++ b/lib/asciidoctor/document.rb
@@ -1102,7 +1102,8 @@ class Document < AbstractBlock
   # Returns The String value with substitutions performed
   def apply_attribute_value_subs value
     if AttributeEntryPassMacroRx =~ value
-      value = $1 ? (apply_subs $2, (resolve_pass_subs $1)) : $2
+      value = $2
+      value = apply_subs value, (resolve_pass_subs $1) if $1
     else
       value = apply_header_subs value
     end

--- a/lib/asciidoctor/reader.rb
+++ b/lib/asciidoctor/reader.rb
@@ -955,8 +955,11 @@ class PreprocessorReader < Reader
         if no_target
           # the text in brackets must match a conditional expression
           if text && EvalExpressionRx =~ text.strip
+            lhs = $1
+            op = $2
+            rhs = $3
             # regex enforces a restricted set of math-related operations (==, !=, <=, >=, <, >)
-            skip = ((resolve_expr_val $1).send $2, (resolve_expr_val $3)) ? false : true
+            skip = ((resolve_expr_val lhs).send op, (resolve_expr_val rhs)) ? false : true
           else
             logger.error message_with_context %(malformed preprocessor directive - #{text ? 'invalid expression' : 'missing expression'}: ifeval::[#{text}]), source_location: cursor
             return true


### PR DESCRIPTION
resolves #3214

Workaround for this issue: https://github.com/opal/opal/issues/1961

Resolve a major issue in Asciidoctor.js 2.0.0 when using conditional expressions: https://github.com/oncletom/nodebook/pull/371

If necessary we could use this code only when running in Opal to avoid the variables assignments in other runtimes.
