### PR TITLE
Helpers.rootname should only consider final path segment when dropping file extension

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -13,6 +13,12 @@ endif::[]
 This document provides a high-level view of the changes introduced in Asciidoctor by release.
 For a detailed view of what has changed, refer to the {uri-repo}/commits/master[commit history] on GitHub.
 
+== Unreleased
+
+Bug Fixes::
+
+  * Helpers.rootname should only consider final path segment when dropping file extension
+
 == 2.0.5 (2019-04-01) - @mojavelinux
 
 Bug Fixes::

--- a/lib/asciidoctor/helpers.rb
+++ b/lib/asciidoctor/helpers.rb
@@ -159,7 +159,7 @@ module Helpers
 
   # Public: Removes the file extension from filename and returns the result
   #
-  # filename - The String file name to process
+  # filename - The String file name to process; expected to be a posix path
   #
   # Examples
   #
@@ -168,7 +168,11 @@ module Helpers
   #
   # Returns the String filename with the file extension removed
   def self.rootname filename
-    filename.slice 0, ((filename.rindex '.') || filename.length)
+    if (last_dot_idx = filename.rindex '.')
+      (filename.index '/', last_dot_idx) ? filename : (filename.slice 0, last_dot_idx)
+    else
+      filename
+    end
   end
 
   # Public: Retrieves the basename of the filename, optionally removing the extension, if present

--- a/lib/asciidoctor/reader.rb
+++ b/lib/asciidoctor/reader.rb
@@ -686,20 +686,20 @@ class PreprocessorReader < Reader
         (@dir = file.dup).path = (dir = ::File.dirname file.path) == '/' ? '' : dir
         file = file.to_s
       end
-      path ||= ::File.basename file
+      @path = (path ||= ::File.basename file)
       # only process lines in AsciiDoc files
-      @process_lines = ASCIIDOC_EXTENSIONS[::File.extname file]
+      if (@process_lines = ASCIIDOC_EXTENSIONS[::File.extname file])
+        @includes[path.slice 0, (path.rindex '.')] = attributes['partial-option'] ? nil : true
+      end
     else
       @dir = '.'
       # we don't know what file type we have, so assume AsciiDoc
       @process_lines = true
-    end
-
-    if path
-      @path = path
-      @includes[Helpers.rootname path] = attributes['partial-option'] ? nil : true if @process_lines
-    else
-      @path = '<stdin>'
+      if (@path = path)
+        @includes[Helpers.rootname path] = attributes['partial-option'] ? nil : true
+      else
+        @path = '<stdin>'
+      end
     end
 
     @lineno = lineno

--- a/test/helpers_test.rb
+++ b/test/helpers_test.rb
@@ -28,6 +28,11 @@ context 'Helpers' do
       assert_equal 'docs/master', Asciidoctor::Helpers.rootname('docs/master')
     end
 
+    test 'rootname should ignore dot not in last segment' do
+      assert_equal 'include.d/master', Asciidoctor::Helpers.rootname('include.d/master')
+      assert_equal 'include.d/master', Asciidoctor::Helpers.rootname('include.d/master.adoc')
+    end
+
     test 'UriSniffRx should detect URIs' do
       assert Asciidoctor::UriSniffRx =~ 'http://example.com'
       assert Asciidoctor::UriSniffRx =~ 'https://example.com'

--- a/test/reader_test.rb
+++ b/test/reader_test.rb
@@ -564,6 +564,7 @@ class ReaderTest < Minitest::Test
         reader.push_include append_lines, '/tmp/lines.adoc'
         assert_equal '/tmp/lines.adoc', reader.file
         assert_equal 'lines.adoc', reader.path
+        assert doc.catalog[:includes]['lines']
       end
 
       test 'PreprocessorReader#push_include method should accept file as a URI and compute dir and path' do
@@ -593,6 +594,17 @@ class ReaderTest < Minitest::Test
         reader.push_include nil, '', '<stdin>'
         assert_equal 0, reader.include_stack.size
         assert_equal 'a', reader.read_line.rstrip
+      end
+
+      test 'PreprocessorReader#push_include method should ignore dot in directory name when computing include path' do
+        lines = %w(a b c)
+        doc = Asciidoctor::Document.new lines
+        reader = doc.reader
+        append_lines = %w(one two three)
+        reader.push_include append_lines, nil, 'include.d/data'
+        assert_nil reader.file
+        assert_equal 'include.d/data', reader.path
+        assert doc.catalog[:includes]['include.d/data']
       end
     end
 


### PR DESCRIPTION
- if final segment does not contain a dot, return original filename
- optimize assignments in PreprocessorReader#push_include
- add additional tests