### PR TITLE
CI: Use jruby-9.2.7.0, 2.4.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,9 +6,9 @@ language: ruby
 rvm:
 - &release_ruby 2.6.2
 - 2.5.5
-- 2.4.5
+- 2.4.6
 - 2.3.8
-- jruby-9.2.6.0
+- jruby-9.2.7.0
 - jruby-9.1.17.0
 # the test suite currently crashes on truffleruby
 #- truffleruby-rc13


### PR DESCRIPTION
 - Also: Removes an old setting from Travis. See https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration