### PR TITLE
resolves #3261 fix regexp for SVG preamble so it works the same in Asciidoctor.js

### DIFF
--- a/lib/asciidoctor/converter/html5.rb
+++ b/lib/asciidoctor/converter/html5.rb
@@ -23,9 +23,9 @@ class Converter::Html5Converter < Converter::Base
 
   DropAnchorRx = /<(?:a[^>+]+|\/a)>/
   StemBreakRx = / *\\\n(?:\\?\n)*|\n\n+/
-  SvgPreambleRx = /\A.*?(?=<svg\b)/m
+  SvgPreambleRx = /\A#{CC_ALL}*?(?=<svg\b)/m
   SvgStartTagRx = /\A<svg[^>]*>/
-  DimensionAttributeRx = /\s(?:width|height|style)=(["']).*?\1/
+  DimensionAttributeRx = /\s(?:width|height|style)=(["'])#{CC_ANY}*?\1/
 
   def initialize backend, opts = {}
     @backend = backend

--- a/test/converter_test.rb
+++ b/test/converter_test.rb
@@ -620,7 +620,7 @@ context 'Converter' do
       assert_css 'p', result, 1
     end
 
-    test 'can call read_svg_contents on built-in HTML5 converter' do
+    test 'can call read_svg_contents on built-in HTML5 converter; should remove markup prior the root svg element' do
       doc = document_from_string 'image::circle.svg[]', base_dir: fixturedir
       result = doc.converter.read_svg_contents doc.blocks[0], 'circle.svg'
       refute_nil result


### PR DESCRIPTION
- replace . with CC_ALL
- also replace . with CC_ANY when matching dimension attribute