### PR TITLE
resolves #3274 update register_for methods to accept symbol arguments

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -25,6 +25,7 @@ Bug Fixes::
 
 Improvements::
 
+  * register_for methods accept arguments as symbols (#3274)
   * use Concurrent::Map instead of Concurrent::Hash in template converter
   * use module_function keyword to define methods in Helpers
   * move regular expression definitions to separate source file (internal change)

--- a/lib/asciidoctor/converter.rb
+++ b/lib/asciidoctor/converter.rb
@@ -148,7 +148,7 @@ module Converter
     #
     # Returns nothing.
     def register_for *backends
-      Converter.register self, *backends
+      Converter.register self, *(backends.map {|backend| backend.to_s })
     end
   end
 

--- a/lib/asciidoctor/syntax_highlighter.rb
+++ b/lib/asciidoctor/syntax_highlighter.rb
@@ -100,14 +100,20 @@ module SyntaxHighlighter
   module Config
     # Public: Statically register the current class in the registry for the specified names.
     #
+    # names - one or more String or Symbol names with which to register the current class as a syntax highlighter
+    #         implementation. Symbol arguments are coerced to Strings.
+    #
     # Returns nothing.
     def register_for *names
-      SyntaxHighlighter.register self, *names
+      SyntaxHighlighter.register self, *(names.map {|name| name.to_s })
     end
   end
 
   module Factory
     # Public: Associates the syntax highlighter class or object with the specified names.
+    #
+    # syntax_highlighter - the syntax highlighter implementation to register
+    # names              - one or more String names with which to register this syntax highlighter implementation.
     #
     # Returns nothing.
     def register syntax_highlighter, *names

--- a/test/converter_test.rb
+++ b/test/converter_test.rb
@@ -441,6 +441,23 @@ context 'Converter' do
       end
     end
 
+    test 'should be able to register converter using symbol' do
+      begin
+        converter = Class.new Asciidoctor::Converter::Base do
+          register_for :foobaz
+          def initialize *args
+            super
+            basebackend 'text'
+            filetype 'text'
+            outfilesuffix '.fb'
+          end
+        end
+        assert_equal converter, (Asciidoctor::Converter.for 'foobaz')
+      ensure
+        Asciidoctor::Converter.unregister_all
+      end
+    end
+
     test 'should be able to register converter from converter class itself' do
       begin
         assert_nil Asciidoctor::Converter.for 'foobar'

--- a/test/syntax_highlighter_test.rb
+++ b/test/syntax_highlighter_test.rb
@@ -106,6 +106,22 @@ context 'Syntax Highlighter' do
     assert_equal syntax_highlighter, (Asciidoctor::SyntaxHighlighter.for 'foobar')
   end
 
+  test 'should be able to register syntax highlighter using symbol' do
+    syntax_highlighter = Class.new Asciidoctor::SyntaxHighlighter::Base do
+      register_for :foobaz
+
+      def format node, language, opts
+        %(<pre class="highlight"><code class="language-#{language}" data-lang="#{language}">#{node.content}</code></pre>)
+      end
+
+      def highlight?
+        false
+      end
+    end
+
+    assert_equal syntax_highlighter, (Asciidoctor::SyntaxHighlighter.for 'foobaz')
+  end
+
   test 'should set language on output of source block when source-highlighter attribute is not set' do
     input = <<~'EOS'
     [source, ruby]


### PR DESCRIPTION
- coerce symbol arguments to register_for to strings
- fill in missing API doc for register_for and register methods in SyntaxHighlighter module