### PR TITLE
resolves #3283 register images in catalog correctly

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -18,6 +18,7 @@ For a detailed view of what has changed, refer to the {uri-repo}/commits/master[
 Bug Fixes::
 
   * process multiple single-item menu macros in same line (#3279)
+  * register images in catalog correctly (#3283)
 
 // tag::compact[]
 == 2.0.8 (2019-04-22) - @mojavelinux

--- a/lib/asciidoctor/document.rb
+++ b/lib/asciidoctor/document.rb
@@ -606,11 +606,10 @@ class Document < AbstractBlock
     when :refs
       @catalog[:refs][value[0]] ||= (ref = value[1])
       ref
-    #when :footnotes, :indexterms
     when :footnotes
       @catalog[type] << value
     else
-      @catalog[type] << (type == :images ? (ImageReference.new value[0], value[1]) : value) if @options[:catalog_assets]
+      @catalog[type] << (type == :images ? (ImageReference.new value, @attributes['imagesdir']) : value) if @options[:catalog_assets]
     end
   end
 

--- a/lib/asciidoctor/parser.rb
+++ b/lib/asciidoctor/parser.rb
@@ -596,7 +596,8 @@ class Parser
                 end
               end
               if blk_ctx == :image
-                document.register :images, [target, (attributes['imagesdir'] = doc_attrs['imagesdir'])]
+                document.register :images, target
+                attributes['imagesdir'] = doc_attrs['imagesdir']
                 # NOTE style is the value of the first positional attribute in the block attribute line
                 attributes['alt'] ||= style || (attributes['default-alt'] = Helpers.basename(target, true).tr('_-', ' '))
                 unless (scaledwidth = attributes.delete 'scaledwidth').nil_or_empty?

--- a/lib/asciidoctor/substitutors.rb
+++ b/lib/asciidoctor/substitutors.rb
@@ -422,7 +422,10 @@ module Substitutors
         end
         target = $1
         attrs = parse_attributes $2, posattrs, unescape_input: true
-        doc.register :images, [target, (attrs['imagesdir'] = doc_attrs['imagesdir'])] unless type == 'icon'
+        unless type == 'icon'
+          doc.register :images, target
+          attrs['imagesdir'] = doc_attrs['imagesdir']
+        end
         attrs['alt'] ||= (attrs['default-alt'] = Helpers.basename(target, true).tr('_-', ' '))
         Inline.new(self, :image, nil, type: type, target: target, attributes: attrs).convert
       end

--- a/test/document_test.rb
+++ b/test/document_test.rb
@@ -1241,6 +1241,14 @@ context 'Document' do
       assert_equal 'foobar', (doc.resolve_id 'Foo Bar')
     end
 
+    test 'should record imagesdir when image is registered with catalog' do
+      doc = empty_document attributes: { 'imagesdir' => 'img' }, catalog_assets: true
+      doc.register :images, 'diagram.svg'
+      assert_equal doc.catalog[:images].size, 1
+      assert_equal 'diagram.svg', doc.catalog[:images][0].target
+      assert_equal 'img', doc.catalog[:images][0].imagesdir
+    end
+
     test 'should catalog assets inside nested document' do
       input = <<~'EOS'
       image::outer.png[]


### PR DESCRIPTION
- register method accepts image as string
- register method reads value of imagesdir attribute from document