### PR TITLE
Warn on auto-generated ID conflicts. Fix #3147.

### DIFF
--- a/lib/asciidoctor/section.rb
+++ b/lib/asciidoctor/section.rb
@@ -209,6 +209,7 @@ class Section < AbstractBlock
       gen_id = gen_id.slice 1, gen_id.length if pre.empty? && (gen_id.start_with? sep)
     end
     if document.catalog[:refs].key? gen_id
+      logger.warn %(auto-generated header id conflict: #{gen_id})
       ids = document.catalog[:refs]
       cnt = Compliance.unique_id_start_index
       cnt += 1 while ids[candidate_id = %(#{gen_id}#{sep}#{cnt})]


### PR DESCRIPTION
This is just a quick RFC that more or less reaches the behaviour I would like at: https://github.com/asciidoctor/asciidoctor/issues/3147

If you run `asciidcotor a.readme` with:

```
= bla
:idprefix:
:idseparator: -
:sectanchors:
:sectlinks:
:sectnumlevels: 6
:sectnums:
:toc: macro
:toclevels: 6
:toc-title:

toc::[]

== asdf qwer

== asdf qwer
```

it produces my desired warning:

```
asciidoctor: WARNING: auto-generated header id conflict: asdf-qwer
```

If this behaviour were in general accepted, the following changes would need to be done to this patch:

- add testing
- add line number to warning (not sure how)
- possibly convert to `info`. TODO: `logger.info` does not show on terminal, how to enable it from CLI?
