### PR TITLE
Fix documentation for options passed to SyntaxHighlighter constructor

### DIFF
--- a/lib/asciidoctor/syntax_highlighter.rb
+++ b/lib/asciidoctor/syntax_highlighter.rb
@@ -139,7 +139,7 @@ module SyntaxHighlighter
     # name    - The String name of the syntax highlighter to create.
     # backend - The String name of the backend for which this syntax highlighter is being used (default: 'html5').
     # opts    - A Hash of options providing information about the context in which this syntax highlighter is used:
-    #           :doc - The Document for which this syntax highlighter was created.
+    #           :document - The Document for which this syntax highlighter was created.
     #
     # Returns a [SyntaxHighlighter] instance for the specified name.
     def create name, backend = 'html5', opts = {}


### PR DESCRIPTION
Just a very small fix for the documentation of `SyntaxHighlighterFactory::create`.
The document is passed with the key `:document` instead of `:doc`:

https://github.com/asciidoctor/asciidoctor/blob/35c1f9a8f7c1cee310d6c1d1ad46ec5ae4702d54/lib/asciidoctor/document.rb#L1232-L1238