### PR TITLE
PROTOTYPE katex server side stem math rendering in HTML5

### DIFF
--- a/a.adoc
+++ b/a.adoc
@@ -1,0 +1,46 @@
+= bla
+:stem:
+
+stem: stem:[sqrt(1+1) = 2]
+
+asciimath: asciimath:[sqrt(1+1) = 2]
+
+latexmath: latexmath:[\sqrt{1+1} = 2]
+
+katexmath: katexmath:[\sqrt{1+1} = 2]
+
+stem: stem:[[[a,b\],[c,d\]\]]
+
+asciimath asciimath:[[[a,b\],[c,d\]\]]
+
+latexmath: latexmath:[\begin{bmatrix}a & b\\c & d\end{bmatrix}]
+
+katexmath: katexmath:[\begin{bmatrix}a & b\\c & d\end{bmatrix}]
+
+stem:
+
+[stem]
+++++
+sqrt(1+1) = 2
+++++
+
+asciimath:
+
+[asciimath]
+++++
+sqrt(1+1) = 2
+++++
+
+latexmath:
+
+[latexmath]
+++++
+\sqrt{1+1} = 2
+++++
+
+katexmath:
+
+[katexmath]
+++++
+\sqrt{1+1} = 2
+++++

--- a/lib/asciidoctor.rb
+++ b/lib/asciidoctor.rb
@@ -283,7 +283,7 @@ module Asciidoctor
     '====' => [:example, ['admonition'].to_set],
     '****' => [:sidebar, ::Set.new],
     '____' => [:quote, ['verse'].to_set],
-    '++++' => [:pass, ['stem', 'latexmath', 'asciimath'].to_set],
+    '++++' => [:pass, ['stem', 'latexmath', 'asciimath', 'katexmath'].to_set],
     '|===' => [:table, ::Set.new],
     ',===' => [:table, ::Set.new],
     ':===' => [:table, ::Set.new],
@@ -342,11 +342,13 @@ module Asciidoctor
   BLOCK_MATH_DELIMITERS = {
     asciimath: ['\$', '\$'],
     latexmath: ['\[', '\]'],
+    katexmath: ['', ''],
   }
 
   INLINE_MATH_DELIMITERS = {
     asciimath: ['\$', '\$'],
     latexmath: ['\(', '\)'],
+    katexmath: ['', ''],
   }
 
   (STEM_TYPE_ALIASES = {

--- a/lib/asciidoctor/parser.rb
+++ b/lib/asciidoctor/parser.rb
@@ -862,7 +862,7 @@ class Parser
       when :quote, :verse
         AttributeList.rekey(attributes, [nil, 'attribution', 'citetitle'])
         block = build_block(block_context, (block_context == :verse ? :verbatim : :compound), terminator, parent, reader, attributes)
-      when :stem, :latexmath, :asciimath
+      when :stem, :latexmath, :asciimath, :katexmath
         attributes['style'] = STEM_TYPE_ALIASES[attributes[2] || doc_attrs['stem']] if block_context == :stem
         block = build_block(:stem, :raw, terminator, parent, reader, attributes)
       when :pass

--- a/lib/asciidoctor/rx.rb
+++ b/lib/asciidoctor/rx.rb
@@ -540,7 +540,7 @@ module Asciidoctor
   #   asciimath:[x != 0]
   #   latexmath:[\sqrt{4} = 2]
   #
-  InlineStemMacroRx = /\\?(stem|(?:latex|ascii)math):([a-z]+(?:,[a-z-]+)*)?\[(#{CC_ALL}*?[^\\])\]/m
+  InlineStemMacroRx = /\\?(stem|(?:latex|ascii|katex)math):([a-z]+(?:,[a-z-]+)*)?\[(#{CC_ALL}*?[^\\])\]/m
 
   # Matches a menu inline macro.
   #


### PR DESCRIPTION
Related issue: https://github.com/asciidoctor/asciidoctor/issues/1735

Server side rendering is awesome as it is faster on the browser, so the page doesn't keep reflowing if you have a ton of formulas

This is now just a prototype, first install katex with:

```
npm install -g katex
```

then convert the `a.adoc` test from this PR.

Outcome: the block katex works, inline not yet.

If people think that this is of interest, I am willing to clean it up into a proper version with some help, since this is relatively high interest to me. Otherwise I'll likely just extract into an extension.

TODOs:

- [] inline not working, don't know how to make `def convert` get an `inline_katex` block yet
- [] `stem: katex` not working yet to make it the default for `stem:` throughout document
- [] error handling if katex not installed / other errors
- [] only include katex if `stem: katex` or if there is at least one `katex:` in document. LIkewise for mathjax.
- [] maybe it would be cleaner to implement katex calls with: https://github.com/Shopify/schmooze instead of
- [] proper testing

Bibliography:

- https://stackoverflow.com/questions/39269611/display-mathjax-equations-smoothly-and-only-once-they-are-fully-rendered
- https://github.com/mathjax/MathJax-node
- https://meta.stackexchange.com/questions/268308/implement-server-side-mathjax-rendering
- https://meta.mathoverflow.net/questions/2360/can-we-replace-client-side-mathjax-with-server-side-mathjax
