### PR TITLE
resolves #3336 fix how options are passed to the Rouge lexer

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,16 +7,20 @@ rvm:
 - &release_ruby 2.6.3
 - 2.5.5
 - 2.4.6
-- 2.3.8
+- &oldest_ruby 2.3.8
 - jruby-9.2.7.0
 - jruby-9.1.17.0
 # the test suite currently crashes on truffleruby
 #- truffleruby-rc13
+matrix:
+  include:
+  - rvm: *oldest_ruby
+    env: ROUGE_VERSION='~> 2.0.0'
 env:
   global:
   # use system libraries to speed up installation of nokogiri
   - NOKOGIRI_USE_SYSTEM_LIBRARIES=true
-  - PYGMENTS_VERSION='~> 1.2.1'
+  - PYGMENTS_VERSION='~> 1.2.0'
   - SOURCE_DATE_EPOCH=1521504000
 script: bundle exec rake coverage test:all
 after_success: bundle exec rake build:dependents

--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -17,6 +17,8 @@ For a detailed view of what has changed, refer to the {uri-repo}/commits/master[
 
 Bug Fixes::
 
+  * Pass options to constructor of Rouge lexer instead of #lex method; restores compatibility with Rouge >= 3.4 (#3336)
+  * Don't clobber cgi-style options on language when enabling start_inline option on the Rouge PHP lexer (#3336)
   * Fix parsing of wrapped link and xref text, including when an attrlist signature is detected (#3331)
   * Restore deprecated writable number property on AbstractBlock
 

--- a/Gemfile
+++ b/Gemfile
@@ -5,6 +5,7 @@ gemspec
 
 group :development do
   gem 'pygments.rb', ENV['PYGMENTS_VERSION'] if ENV.key? 'PYGMENTS_VERSION'
+  gem 'rouge', ENV['ROUGE_VERSION'] if ENV.key? 'ROUGE_VERSION'
 end
 
 group :doc do

--- a/asciidoctor.gemspec
+++ b/asciidoctor.gemspec
@@ -46,8 +46,8 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'minitest', '~> 5.11.0'
   s.add_development_dependency 'nokogiri', '~> 1.10.0'
   s.add_development_dependency 'rake', '~> 12.3.0'
-  # Asciidoctor supports Rouge >= 2
-  s.add_development_dependency 'rouge', '~> 3.3.0'
+  # Asciidoctor supports Rouge >= 2; Rouge 3.4.1 emits a superfluous warning in verbose mode
+  s.add_development_dependency 'rouge', '~> 3.4.0', '!= 3.4.1'
   s.add_development_dependency 'rspec-expectations', '~> 3.8.0'
   s.add_development_dependency 'slim', '~> 4.0.0'
   s.add_development_dependency 'tilt', '~> 2.0.0'

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -8,10 +8,10 @@ require File.join ASCIIDOCTOR_LIB_DIR, 'asciidoctor'
 Dir.chdir Asciidoctor::ROOT_DIR
 
 require 'nokogiri'
+# NOTE rouge has all sorts of warnings we don't want to see, so silence them
 proc do
   old_verbose, $VERBOSE = $VERBOSE, nil
   require 'rouge'
-  Rouge::Lexer.disable_debug!
   $VERBOSE = old_verbose
 end.call
 require 'socket'


### PR DESCRIPTION
resolves #3336

* fixes compatibility with Rouge >= 3.4
* pass options to Rouge lexer using constructor instead of #lex method
* don't clobber cgi-style options on language when enabling start_inline option on the Rouge PHP lexer
* add tests for passing options to the Rouge lexer
* upgrade Rouge in development to 3.4.0