### PR TITLE
adding a sponsor button to GitHub repo that links to open collective

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,13 @@
+# These are supported funding model platforms
+# https://help.github.com/en/articles/displaying-a-sponsor-button-in-your-repository
+
+# github: # Replace with up to 4 GitHub Sponsors-enabled usernames e.g., [user1, user2]
+# patreon: # Replace with a single Patreon username
+open_collective: asciidoctor # single Open Collective username
+# ko_fi: # Replace with a single Ko-fi username
+# tidelift: # Replace with a single Tidelift platform-name/package-name e.g., npm/babel
+# community_bridge: # Replace with a single Community Bridge project-name e.g., cloud-foundry
+# liberapay: # Replace with a single Liberapay username
+# issuehunt: # Replace with a single IssueHunt username
+# otechie: # Replace with a single Otechie username
+# custom: # Replace with up to 4 custom sponsorship URLs e.g., ['link1', 'link2']


### PR DESCRIPTION
This will look like this: 

![github_sponsor](https://user-images.githubusercontent.com/3957921/62066656-1b70d880-b232-11e9-99ac-9989071a930d.png)

This should make it easier for users to sponsor the project.

You see a live example here: https://github.com/asciidoctor/asciidoctor-intellij-plugin

More info here: https://help.github.com/en/articles/displaying-a-sponsor-button-in-your-repository