### PR TITLE
Update Russian and Ukrainian locale attributes translation

### DIFF
--- a/data/locale/attributes-ru.adoc
+++ b/data/locale/attributes-ru.adoc
@@ -2,18 +2,19 @@
 :appendix-caption: Приложение
 :appendix-refsig: {appendix-caption}
 :caution-caption: Внимание
-//:chapter-label: ???
-//:chapter-refsig: {chapter-label}
+:chapter-label: Глава
+:chapter-refsig: {chapter-label}
 :example-caption: Пример
 :figure-caption: Рисунок
 :important-caption: Важно
-:last-update-label: Последний раз обновлено
+:last-update-label: Последнее обновление
 ifdef::listing-caption[:listing-caption: Листинг]
 ifdef::manname-title[:manname-title: Название]
 :note-caption: Примечание
-//:part-refsig: ???
+:part-label: Часть
+:part-refsig: {part-label}
 ifdef::preface-title[:preface-title: Предисловие]
-//:section-refsig: ???
+:section-refsig: Раздел
 :table-caption: Таблица
 :tip-caption: Подсказка
 :toc-title: Содержание

--- a/data/locale/attributes-uk.adoc
+++ b/data/locale/attributes-uk.adoc
@@ -2,18 +2,19 @@
 :appendix-caption: Додаток
 :appendix-refsig: {appendix-caption}
 :caution-caption: Обережно
-//:chapter-label: ???
-//:chapter-refsig: {chapter-label}
+:chapter-label: Розділ
+:chapter-refsig: {chapter-label}
 :example-caption: Приклад
-:figure-caption: Зображення
+:figure-caption: Рисунок
 :important-caption: Важливо
 :last-update-label: Востаннє оновлено
 ifdef::listing-caption[:listing-caption: Лістинг]
 ifdef::manname-title[:manname-title: Назва]
 :note-caption: Зауваження
-//:part-refsig: ???
+:part-label: Частина
+:part-refsig: {part-label}
 ifdef::preface-title[:preface-title: Передмова]
-//:section-refsig: ???
+:section-refsig: Підрозділ
 :table-caption: Таблиця
 :tip-caption: Підказка
 :toc-title: Зміст


### PR DESCRIPTION
Updated Russian (by @AlexanderZobkov) and Ukrainian (by @hedrok) translations for locale/attributes - to include new strings according to reference English attributes.
Add some strings, that were not translated before.
Changed "Последний раз обновлено" (Last time updated) into "Последнее обновление" (Last updated + a bit shorter) in Russian.
Changed "Зображення" (image) into "Рисунок" (technical/scientifical "figure") in Ukrainian. In general there are multiple terms that can mean "figure", however "Рисунок" is _usually_ recommended for technical documentation, e.g. see pt. 7.5.5 of Державний стандарт України. Документація. Звіти у сфері науки і техніки. Структура і правила оформлення. ДСТУ 3008-95 https://zakon.rada.gov.ua/rada/show/n0001217-96 (State Standard of Ukraine. Documentation. Reports in science and engineering. Structure and rules. DSTU 3008-95).

P.S. Thanks @mojavelinux and @ahus1 for help with creating the PR correctly!