### PR TITLE
Fix autoload of the syntax highlighter in specific installations like Debian

### DIFF
--- a/lib/asciidoctor.rb
+++ b/lib/asciidoctor.rb
@@ -511,8 +511,8 @@ module Asciidoctor
   end unless RUBY_ENGINE == 'opal'
 
   unless RUBY_ENGINE == 'opal'
-    autoload :SyntaxHighlighter, %(#{LIB_DIR}/asciidoctor/syntax_highlighter)
-    autoload :Timings, %(#{LIB_DIR}/asciidoctor/timings)
+    autoload :SyntaxHighlighter, %(#{__dir__}/asciidoctor/syntax_highlighter)
+    autoload :Timings, %(#{__dir__}/asciidoctor/timings)
   end
 end
 


### PR DESCRIPTION
Tested in Debian, this fixes our issue.
Thanks for the pointer @mojavelinux ! :) (I did the PR so that you didn't have to ;)

Closes: #3394 