### PR TITLE
upgrade to jruby 9.2.8.0 fixes some bugs in assertions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ rvm:
 - &oldest_ruby 2.3.8
 matrix:
   include:
-  - rvm: jruby-9.2.7.0
+  - rvm: jruby-9.2.8.0
     env: JRUBY_OPTS='--dev'
   - rvm: jruby-9.1.17.0
     env: JRUBY_OPTS='--dev'


### PR DESCRIPTION
When investigating issue https://github.com/asciidoctor/asciidoctor-intellij-plugin/issues/337 I found that the latest ruby version fixes some assertions, see https://github.com/jruby/jruby/pull/5693.

As the test suite of Asciidoctor runs without errors on this new JRuby release, I suggest an update of JRuby with this PR.