### PR TITLE
resolves #3462 move style tag for convert-time syntax highlighters into head

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -31,6 +31,7 @@ Bug Fixes::
 Compliance::
 
   * Add support for muted option to self-hosted video (#3408)
+  * Move style tag for convert-time syntax highlighters (coderay, rouge, pygments) into head (#3462)
 
 Improvements::
 

--- a/lib/asciidoctor/converter/html5.rb
+++ b/lib/asciidoctor/converter/html5.rb
@@ -152,8 +152,8 @@ class Converter::Html5Converter < Converter::Base
       end
     end
 
-    if (syntax_hl = node.syntax_highlighter) && (syntax_hl.docinfo? :head)
-      result << (syntax_hl.docinfo :head, node, cdn_base_url: cdn_base_url, linkcss: linkcss, self_closing_tag_slash: slash)
+    if (syntax_hl = node.syntax_highlighter)
+      result << (syntax_hl_docinfo_head_idx = result.size)
     end
 
     unless (docinfo_content = node.docinfo).empty?
@@ -250,8 +250,15 @@ class Converter::Html5Converter < Converter::Base
     # JavaScript (and auxiliary stylesheets) loaded at the end of body for performance reasons
     # See http://www.html5rocks.com/en/tutorials/speed/script-loading/
 
-    if syntax_hl && (syntax_hl.docinfo? :footer)
-      result << (syntax_hl.docinfo :footer, node, cdn_base_url: cdn_base_url, linkcss: linkcss, self_closing_tag_slash: slash)
+    if syntax_hl
+      if syntax_hl.docinfo? :head
+        result[syntax_hl_docinfo_head_idx] = syntax_hl.docinfo :head, node, cdn_base_url: cdn_base_url, linkcss: linkcss, self_closing_tag_slash: slash
+      else
+        result.delete_at syntax_hl_docinfo_head_idx
+      end
+      if syntax_hl.docinfo? :footer
+        result << (syntax_hl.docinfo :footer, node, cdn_base_url: cdn_base_url, linkcss: linkcss, self_closing_tag_slash: slash)
+      end
     end
 
     if node.attr? 'stem'

--- a/lib/asciidoctor/syntax_highlighter/coderay.rb
+++ b/lib/asciidoctor/syntax_highlighter/coderay.rb
@@ -32,7 +32,7 @@ class SyntaxHighlighter::CodeRayAdapter < SyntaxHighlighter::Base
   end
 
   def docinfo? location
-    @requires_stylesheet && location == :footer
+    @requires_stylesheet && location == :head
   end
 
   def docinfo location, doc, opts

--- a/lib/asciidoctor/syntax_highlighter/pygments.rb
+++ b/lib/asciidoctor/syntax_highlighter/pygments.rb
@@ -52,7 +52,7 @@ class SyntaxHighlighter::PygmentsAdapter < SyntaxHighlighter::Base
   end
 
   def docinfo? location
-    @requires_stylesheet && location == :footer
+    @requires_stylesheet && location == :head
   end
 
   def docinfo location, doc, opts

--- a/lib/asciidoctor/syntax_highlighter/rouge.rb
+++ b/lib/asciidoctor/syntax_highlighter/rouge.rb
@@ -54,7 +54,7 @@ class SyntaxHighlighter::RougeAdapter < SyntaxHighlighter::Base
   end
 
   def docinfo? location
-    @requires_stylesheet && location == :footer
+    @requires_stylesheet && location == :head
   end
 
   def docinfo location, doc, opts

--- a/test/syntax_highlighter_test.rb
+++ b/test/syntax_highlighter_test.rb
@@ -265,6 +265,9 @@ context 'Syntax Highlighter' do
       output = convert_string input, safe: Asciidoctor::SafeMode::SAFE, linkcss_default: true
       assert_xpath '//pre[@class="CodeRay highlight"]/code[@data-lang="ruby"]//span[@class = "constant"][text() = "CodeRay"]', output, 1
       assert_match(/\.CodeRay *\{/, output)
+      style_node = xmlnodes_at_xpath '//style[contains(text(), ".CodeRay")]', output, 1
+      refute_nil style_node
+      assert_equal 'head', style_node.parent.name
     end
 
     test 'should not fail if source language is invalid' do
@@ -531,7 +534,9 @@ context 'Syntax Highlighter' do
       EOS
       output = convert_string input, safe: Asciidoctor::SafeMode::SAFE, attributes: { 'linkcss' => '' }
       assert_xpath '//pre[@class="CodeRay highlight"]/code[@data-lang="ruby"]//span[@class = "constant"][text() = "CodeRay"]', output, 1
-      assert_css 'link[rel="stylesheet"][href="./coderay-asciidoctor.css"]', output, 1
+      link_node = xmlnodes_at_xpath '//link[@rel="stylesheet"][@href="./coderay-asciidoctor.css"]', output, 1
+      refute_nil link_node
+      assert_equal 'head', link_node.parent.name
     end
 
     test 'should highlight source inline if source-highlighter attribute is coderay and coderay-css is style' do
@@ -675,6 +680,9 @@ context 'Syntax Highlighter' do
       output = convert_string input, safe: :safe, linkcss_default: true
       assert_xpath '//pre[@class="rouge highlight"]/code[@data-lang="ruby"]/span[@class="no"][text()="Rouge"]', output, 2
       assert_includes output, 'pre.rouge .no {'
+      style_node = xmlnodes_at_xpath '//style[contains(text(), "pre.rouge")]', output, 1
+      refute_nil style_node
+      assert_equal 'head', style_node.parent.name
     end
 
     test 'should highlight source using a mixed lexer (HTML + JavaScript)' do
@@ -1025,6 +1033,9 @@ context 'Syntax Highlighter' do
       output = convert_string input, safe: :safe, linkcss_default: true
       assert_xpath '//pre[@class="pygments highlight"]/code[@data-lang="python"]/span[@class="tok-kn"][text()="import"]', output, 3
       assert_includes output, 'pre.pygments '
+      style_node = xmlnodes_at_xpath '//style[contains(text(), "pre.pygments")]', output, 1
+      refute_nil style_node
+      assert_equal 'head', style_node.parent.name
     end
 
     test 'should gracefully fallback to default style if specified style not recognized' do


### PR DESCRIPTION
- move style tag for convert-time syntax highlighters into head
- invoke docinfo? :head method on syntax highlighter adapter after content has been converted