### PR TITLE
escape &<> in attributes

### DIFF
--- a/lib/asciidoctor/substitutors.rb
+++ b/lib/asciidoctor/substitutors.rb
@@ -232,7 +232,7 @@ module Substitutors
           @document.counter(*args)
         end
       elsif doc_attrs.key?(key = $2.downcase)
-        doc_attrs[key]
+        sub_specialchars doc_attrs[key]
       elsif (value = INTRINSIC_ATTRIBUTES[key])
         value
       else


### PR DESCRIPTION
this fixes: "asciidoctor: ERROR: failed to parse formatted text ..."
for asciidoctor-pdf when using e.g. & in an attribute.

Example file:

== Demo
Oh why oh why is {whatever} causing headaches?

[kjell@localhost ~]$ asciidoctor-pdf -a whatever="Fish & Chips" t.adoc
asciidoctor: ERROR: failed to parse formatted text: Oh why oh why is Fish & Chips causing headaches?

I am not sure if this is the right way to fix the problem, but it seems to work fine.
