### PR TITLE
trigger build of AsciidoctorJ job running as GitHub Action

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -45,6 +45,7 @@ Improvements::
 Build / Infrastructure::
 
   * Run test suite on TruffleRuby nightly (*@mogztter*, *@erebor*)
+  * Trigger upstream builds for AsciidoctorJ on Github Actions (*@robertpanzer*)
 
 // tag::compact[]
 == 2.0.10 (2019-05-31) - @mojavelinux

--- a/tasks/dependents.rake
+++ b/tasks/dependents.rake
@@ -1,39 +1,46 @@
 # frozen_string_literal: true
 namespace :build do
-  desc 'Trigger builds for all dependent projects on Travis CI'
+  desc 'Trigger builds for all dependent projects on Travis CI and Github Actions'
   task :dependents do
     if ENV['TRAVIS'].to_s == 'true'
       next unless ENV['TRAVIS_PULL_REQUEST'].to_s == 'false' &&
-          ENV['TRAVIS_TAG'].to_s.empty? &&
-          (ENV['TRAVIS_JOB_NUMBER'].to_s.end_with? '.1')
+        ENV['TRAVIS_TAG'].to_s.empty? &&
+        (ENV['TRAVIS_JOB_NUMBER'].to_s.end_with? '.1')
     end
+
+    if (commit_hash = ENV['TRAVIS_COMMIT'])
+      commit_memo = %( (#{commit_hash.slice 0, 8})\n\nhttps://github.com/#{ENV['TRAVIS_REPO_SLUG'] || 'asciidoctor/asciidoctor'}/commit/#{commit_hash})
+    end
+
     # NOTE The TRAVIS_TOKEN env var must be defined in Travis interface.
     # Retrieve this token using the `travis token` command.
     # The GitHub user corresponding to the Travis user must have write access to the repository.
     # After granting permission, sign into Travis and resync the repositories.
-    next unless (token = ENV['TRAVIS_TOKEN'])
+    travis_token = ENV['TRAVIS_TOKEN']
+
+    # NOTE The GITHUB_TOKEN env var must be defined in GitHub Actions interface.
+    # Retrieve this token using the settings of the account/org -> Developer Settings -> Personal Access Tokens
+    # and generate a new "Personal Access Token" with the "repo" scope
+    github_token = ENV['GITHUB_TOKEN']
+
     require 'json'
     require 'net/http'
     require 'open-uri'
     require 'yaml'
+
     %w(
       asciidoctor/asciidoctor.js
-      asciidoctor/asciidoctorj
       asciidoctor/asciidoctor-diagram
       asciidoctor/asciidoctor-reveal.js
     ).each do |project|
-      org, name, branch = project.split '/', 3
-      branch ||= 'master'
+      org, name, branch = parse_project project
       project = [org, name, branch] * '/'
       header = {
         'Content-Type' => 'application/json',
         'Accept' => 'application/json',
         'Travis-API-Version' => '3',
-        'Authorization' => %(token #{token})
+        'Authorization' => %(token #{travis_token})
       }
-      if (commit_hash = ENV['TRAVIS_COMMIT'])
-        commit_memo = %( (#{commit_hash.slice 0, 8})\n\nhttps://github.com/#{ENV['TRAVIS_REPO_SLUG'] || 'asciidoctor/asciidoctor'}/commit/#{commit_hash})
-      end
       config = YAML.load open(%(https://raw.githubusercontent.com/#{project}/.travis-upstream-only.yml)) {|fd| fd.read } rescue {}
       payload = {
         'request' => {
@@ -42,15 +49,45 @@ namespace :build do
           'config' => config
         }
       }.to_json
-      (http = Net::HTTP.new 'api.travis-ci.org', 443).use_ssl = true
-      request = Net::HTTP::Post.new %(/repo/#{org}%2F#{name}/requests), header
-      request.body = payload
-      response = http.request request
-      if response.code == '202'
-        puts %(Successfully triggered build on #{project} repository)
-      else
-        warn %(Unable to trigger build on #{project} repository: #{response.code} - #{response.message})
-      end
+      trigger_build project, header, payload, 'api.travis-ci.org', %(/repo/#{org}%2F#{name}/requests)
+    end if travis_token
+
+    %w(
+      asciidoctor/asciidoctorj
+    ).each do |project|
+      org, name, branch = parse_project project
+      project = [org, name, branch] * '/'
+      header = {
+        'Content-Type' => 'application/json',
+        'Accept' => 'application/vnd.github.everest-preview+json',
+        'Authorization' => %(token #{github_token})
+      }
+      payload = {
+        'event_type' => 'test_upstream',
+        'client_payload' => {
+          'branch' => branch,
+          'message' => %(Build triggered by Asciidoctor#{commit_memo})
+        }
+      }.to_json
+      trigger_build project, header, payload, 'api.github.com', %(/repos/#{org}/#{name}/dispatches)
+    end if github_token
+  end
+
+  def trigger_build project, header, payload, host, path
+    (http = Net::HTTP.new host, 443).use_ssl = true
+    request = Net::HTTP::Post.new path, header
+    request.body = payload
+    response = http.request request
+    if /^20\d$/.match? response.code
+      puts %(Successfully triggered build on #{project} repository)
+    else
+      warn %(Unable to trigger build on #{project} repository: #{response.code} - #{response.message})
     end
+  end
+
+  def parse_project project
+    org, name, branch = project.split '/', 3
+    branch ||= 'master'
+    return org, name, branch
   end
 end


### PR DESCRIPTION
This PR changes the build:dependents task to trigger the upstream build on Github instead of on Travis CI.
To get this running on TravisCI it is necessary to provision a Github auth token in the environment variable `GITHUB_TOKEN`.
This needs to have the `repo` scope.

Even though the tasks of triggering a build in Travis and Github are very similar, I duplicated the `:dependents` task, as I currently think it would make the logic too complex to distinguish between Github and Travis in the same task.
There are a few differences:
- Obviously a different URL to call
- The payload differs
- The request headers differ, including the auth token
- The response code for a successful trigger differs

Testing locally it seems like 2 `task`-s with the same name are called one after the other on `rake build:dependents`.