### PR TITLE
resolves #3491 allow template to override outline

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -40,6 +40,7 @@ Improvements::
   * Preserve guard around XML-style callout when icons are not enabled (#3319)
   * Remove redundant test for halign and valign attributes on table cell in DocBook converter
   * Allow encoding of include file to be specified using encoding attribute (#3248)
+  * Allow template to be used to override outline by only specifying the outline template (#3491)
 
 Build / Infrastructure::
 

--- a/lib/asciidoctor/converter/html5.rb
+++ b/lib/asciidoctor/converter/html5.rb
@@ -183,7 +183,7 @@ class Converter::Html5Converter < Converter::Base
         if sectioned && (node.attr? 'toc') && (node.attr? 'toc-placement', 'auto')
           result << %(<div id="toc" class="#{node.attr 'toc-class', 'toc'}">
 <div id="toctitle">#{node.attr 'toc-title'}</div>
-#{convert_outline node}
+#{node.converter.convert node, 'outline'}
 </div>)
         end
         result << (generate_manname_section node) if node.attr? 'manpurpose'
@@ -216,7 +216,7 @@ class Converter::Html5Converter < Converter::Base
         if sectioned && (node.attr? 'toc') && (node.attr? 'toc-placement', 'auto')
           result << %(<div id="toc" class="#{node.attr 'toc-class', 'toc'}">
 <div id="toctitle">#{node.attr 'toc-title'}</div>
-#{convert_outline node}
+#{node.converter.convert node, 'outline'}
 </div>)
         end
       end
@@ -318,7 +318,7 @@ MathJax.Hub.Register.StartupHook("AsciiMath Jax Ready", function () {
     if node.sections? && (node.attr? 'toc') && (toc_p = node.attr 'toc-placement') != 'macro' && toc_p != 'preamble'
       result << %(<div id="toc" class="toc">
 <div id="toctitle">#{node.attr 'toc-title'}</div>
-#{convert_outline node}
+#{node.converter.convert node, 'outline'}
 </div>)
     end
 
@@ -803,7 +803,7 @@ Your browser does not support the audio tag.
       toc = %(
 <div id="toc" class="#{doc.attr 'toc-class', 'toc'}">
 <div id="toctitle">#{doc.attr 'toc-title'}</div>
-#{convert_outline doc}
+#{doc.converter.convert doc, 'outline'}
 </div>)
     else
       toc = ''
@@ -941,7 +941,7 @@ Your browser does not support the audio tag.
 
     %(<div#{id_attr} class="#{role}">
 <div#{title_id_attr} class="title">#{title}</div>
-#{convert_outline doc, toclevels: levels}
+#{doc.converter.convert doc, 'outline', toclevels: levels}
 </div>)
   end
 

--- a/test/converter_test.rb
+++ b/test/converter_test.rb
@@ -316,6 +316,24 @@ context 'Converter' do
       assert_xpath '//aside/header/h1[text()="Related"]', output, 1
       assert_xpath '//aside/header/following-sibling::p[text()="Sidebar content"]', output, 1
     end
+
+    test 'should be able to override the outline using a custom template' do
+      input = <<~'EOS'
+      :toc:
+      = Document Title
+
+      == Section One
+
+      == Section Two
+
+      == Section Three
+      EOS
+
+      output = document_from_string(input, template_dir: (fixture_path 'custom-backends/slim/html5-custom-outline'), template_cache: false).convert
+      assert_xpath '//*[@id="toc"]/ul', output, 1
+      assert_xpath '//*[@id="toc"]/ul[1]/li', output, 3
+      assert_xpath '//*[@id="toc"]/ul[1]/li[1][text()="Section One"]', output, 1
+    end
   end
 
   context 'Custom converters' do

--- a/test/fixtures/custom-backends/slim/html5-custom-outline/outline.html.slim
+++ b/test/fixtures/custom-backends/slim/html5-custom-outline/outline.html.slim
@@ -1,0 +1,3 @@
+ul
+  - sections.each do |section|
+    li = section.title


### PR DESCRIPTION
Allows plugging templates in to the html5 converter's "outline" by
replacing all direct calls to `convert_outline` with calls to the to the
conversion named `outline`.

Resolves #3491