### PR TITLE
resolves #3793 don't apply border-collapse: separate to HTML for table blocks

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -44,6 +44,7 @@ Bug Fixes::
   * Use custom init function for highlight.js to select the correct `code` elements (#3761)
   * Fix resolved value of :to_dir when both :to_file and :to_dir options are set to absolute paths (#3778)
   * Restore label in front of each bibliography entry in DocBook output that was dropped by fix for #3085 (#3782)
+  * Don't apply border-collapse: separate to HTML for table blocks; fixes double border at boundary of colspan/rowspan (#3793) (*@ahus1*)
 
 Compliance::
 

--- a/data/stylesheets/asciidoctor-default.css
+++ b/data/stylesheets/asciidoctor-default.css
@@ -251,7 +251,7 @@ pre.pygments .lineno::before{content:"";margin-right:-.125em}
 .quoteblock.excerpt,.quoteblock .quoteblock{margin-left:0}
 .quoteblock.excerpt blockquote,.quoteblock.excerpt p,.quoteblock .quoteblock blockquote,.quoteblock .quoteblock p{color:inherit;font-size:1.0625rem}
 .quoteblock.excerpt .attribution,.quoteblock .quoteblock .attribution{color:inherit;text-align:left;margin-right:0}
-table.tableblock{max-width:100%;border-collapse:separate}
+table.tableblock{max-width:100%}
 p.tableblock:last-child{margin-bottom:0}
 td.tableblock>.content{margin-bottom:1.25em}
 td.tableblock>.content>:last-child{margin-bottom:-1.25em}


### PR DESCRIPTION
I found that applying border-collapse solves the disappearing cell borders. I tried to trace the history of this CSS settings, but wasn't able to determine the case why this was added here 58149743db9f59d4036879ff73da5b06eaf9ae9e

An example like this

```asciidoc
[options="header"]
|===
| Column 1 | Column 2 | Column 3
.2+|Content in a single cell that spans rows 1 and 2  |Cell in column 2, row 1 .2+|Content in a single cell that spans rows 1 and 2
|Cell in column 2, row 2
|===
```

that rendered before in Chrome like this using the asciidoctor CSS from master 

![image](https://user-images.githubusercontent.com/3957921/69901786-810ed600-1386-11ea-9ffb-47847b963f46.png)

now renders like this

![image](https://user-images.githubusercontent.com/3957921/69901779-650b3480-1386-11ea-93be-80c9c021030b.png)
