### PR TITLE
resolves #3471 allow to specify multiple stylesheets

### DIFF
--- a/lib/asciidoctor/converter/html5.rb
+++ b/lib/asciidoctor/converter/html5.rb
@@ -133,13 +133,13 @@ class Converter::Html5Converter < Converter::Base
 #{Stylesheets.instance.primary_stylesheet_data}
 </style>)
       end
-    elsif node.attr? 'stylesheet'
-      if linkcss
-        result << %(<link rel="stylesheet" href="#{node.normalize_web_path((node.attr 'stylesheet'), (node.attr 'stylesdir', ''))}"#{slash}>)
+    elsif (stylesheet = node.attr 'stylesheet')
+      if stylesheet.include? ';'
+        (stylesheet.split ';').map {|v| v.strip }.reject {|v| v.empty? }.each do |style|
+          result << (generate_stylesheet node, style, linkcss, slash)
+        end
       else
-        result << %(<style>
-#{node.read_asset node.normalize_system_path((node.attr 'stylesheet'), (node.attr 'stylesdir', '')), warn_on_failure: true, label: 'stylesheet'}
-</style>)
+        result << (generate_stylesheet node, stylesheet, linkcss, slash)
       end
     end
 
@@ -1281,6 +1281,16 @@ Your browser does not support the video tag.
   end
 
   private
+
+  def generate_stylesheet node, stylesheet, linkcss, slash
+    if linkcss
+      %(<link rel="stylesheet" href="#{node.normalize_web_path(stylesheet, (node.attr 'stylesdir', ''))}"#{slash}>)
+    else
+      %(<style>
+#{node.read_asset node.normalize_system_path(stylesheet, (node.attr 'stylesdir', '')), warn_on_failure: true, label: 'stylesheet'}
+</style>)
+    end
+  end
 
   def append_boolean_attribute name, xml
     xml ? %( #{name}="#{name}") : %( #{name})

--- a/test/api_test.rb
+++ b/test/api_test.rb
@@ -1205,6 +1205,24 @@ context 'API' do
       assert_css 'html:root > head > link[rel="stylesheet"][href="file:///home/username/custom.css"]', output, 1
     end
 
+    test 'should link to multiple custom stylesheets if specified in stylesheet attribute' do
+      input = <<~'EOS'
+      = Document Title
+
+      text
+      EOS
+
+      output = Asciidoctor.convert input, standalone: true, attributes: { 'stylesheet' => './themes/variables.css;./client-y-variables.css;themes/dark.css' }
+      assert_css 'html:root > head > link[rel="stylesheet"][href^="https://fonts.googleapis.com"]', output, 0
+      assert_css 'html:root > head > link[rel="stylesheet"][href="./themes/variables.css"]', output, 1
+      assert_css 'html:root > head > link[rel="stylesheet"][href="./client-y-variables.css"]', output, 1
+      assert_css 'html:root > head > link[rel="stylesheet"][href="./themes/dark.css"]', output, 1
+
+      output = Asciidoctor.convert input, standalone: true, attributes: { 'stylesheet' => 'asciidoctor.css; override.css; ' }
+      assert_css 'html:root > head > link[rel="stylesheet"][href="./asciidoctor.css"]', output, 1
+      assert_css 'html:root > head > link[rel="stylesheet"][href="./override.css"]', output, 1
+    end
+
     test 'should resolve custom stylesheet relative to stylesdir' do
       input = <<~'EOS'
       = Document Title


### PR DESCRIPTION
Since `copycss` can point to a stylesheet file, should we also support multiple stylesheets? For instance:

```
-a copycss=variables.css;colony.css -a stylesheet=colony.css -a stylesdir=./styles
```

And what should we do if `copycss` contains multiples files but `stylesheet` contains a different number of files?
In the above case, we could infer that the user wants to copy *variables.css* and *colony.css* into a single file named *colony.css* (concat). But if we declare the following then the intent is unclear:

```
-a copycss=a.css -a stylesheet=b.css;c.css -a stylesdir=./styles
```

```
-a copycss=a.css;b.css;c.css -a stylesheet=d.css;e.css -a stylesdir=./styles
```

I tried to do the least amount of changes to make sure that if you are not using this feature the code is as fast as before.
For instance, I'm using the condition `stylesheet.include? ';'` but we could have a more readable/DRY code with:

```rb
stylesheets = ((doc.attr 'stylesheet').split ';').map {|v| v.strip }.reject {|v| v.empty? }
```

I've seen the following comment in the code "should Stylesheets also handle the user stylesheet?" and I think we should move some logic to `Stylesheets`:

```rb
Stylesheets.instance.write_user_stylesheets stylesoutdir # write user stylesheets to stylesoutdir
```