### PR TITLE
trigger Asciidoctor.js build running as GitHub Action

### DIFF
--- a/tasks/dependents.rake
+++ b/tasks/dependents.rake
@@ -29,7 +29,6 @@ namespace :build do
     require 'yaml'
 
     %w(
-      asciidoctor/asciidoctor.js
       asciidoctor/asciidoctor-diagram
       asciidoctor/asciidoctor-reveal.js
     ).each do |project|
@@ -53,6 +52,7 @@ namespace :build do
     end if travis_token
 
     %w(
+      asciidoctor/asciidoctor.js
       asciidoctor/asciidoctorj
     ).each do |project|
       org, name, branch = parse_project project


### PR DESCRIPTION
Asciidoctor.js now has a GitHub Action configured to run when a `repository_dispatch` event is received: https://github.com/asciidoctor/asciidoctor.js/blob/master/.github/workflows/build-upstream.yml

I took inspiration from AsciidoctorJ.
Pinging @robertpanzer for review :wink: 