### PR TITLE
manpage: use monospaced font for literal and listing blocks

### DIFF
--- a/lib/asciidoctor/converter/manpage.rb
+++ b/lib/asciidoctor/converter/manpage.rb
@@ -247,7 +247,9 @@ r lw(\n(.lu*75u/100u).'
     result << %(.sp
 .if n .RS 4
 .nf
+.fam C
 #{manify node.content, whitespace: :preserve}
+.fam
 .fi
 .if n .RE)
     result.join LF
@@ -261,7 +263,9 @@ r lw(\n(.lu*75u/100u).'
     result << %(.sp
 .if n .RS 4
 .nf
+.fam C
 #{manify node.content, whitespace: :preserve}
+.fam
 .fi
 .if n .RE)
     result.join LF


### PR DESCRIPTION
Most of man page viewing happens on the terminal, which
is monospaced anyway, but one can generate a PDF or PostScript
of a man page as well.

For example:

```console
$ man -Tps man > man.ps
```

or
```console
$ groff -Tps -t -man page.1 > page.ps
$ ps2pdf page.ps page.pdf # optional
```

In this case, if a man page was generated by asciidoctor, all the
blocks that are supposed to be using monospaced font, won't.

Fix is easy.