### PR TITLE
resolves #3569 add sourcemap flag to the CLI

### DIFF
--- a/lib/asciidoctor/cli/options.rb
+++ b/lib/asciidoctor/cli/options.rb
@@ -71,6 +71,9 @@ module Asciidoctor
             'disables potentially dangerous macros in source files, such as include::[]' do |name|
             self[:safe] = SafeMode.value_for_name name
           end
+          opts.on '--sourcemap', 'add source location information to each parsed block (default: false)' do
+            self[:sourcemap] = true
+          end
           opts.on '-s', '--no-header-footer', 'suppress enclosing document structure and output an embedded document (default: false)' do
             self[:standalone] = false
           end

--- a/man/asciidoctor.adoc
+++ b/man/asciidoctor.adoc
@@ -113,6 +113,10 @@ This option may be specified more than once.
   Output an embeddable document, which excludes the header, the footer, and everything outside the body of the document.
   This option is useful for producing documents that can be inserted into an external template.
 
+*--sourcemap*::
+    Enable the sourcemap option on the parser, which instructs the parser to add source location information to each parsed block.
+    The sourcemap information is useful for extensions that need access to the file and line number of blocks in the source document.
+
 *-T, --template-dir*=_DIR_::
   A directory containing custom converter templates that override one or more templates from the built-in set.
   (requires _tilt_ gem)

--- a/test/invoker_test.rb
+++ b/test/invoker_test.rb
@@ -579,6 +579,19 @@ context 'Invoker' do
     refute_match(/WARNING/, warnings)
   end
 
+  test 'should add source location to blocks when sourcemap option is specified' do
+    sample_filepath = fixture_path 'sample.adoc'
+    invoker = invoke_cli_to_buffer %w(--sourcemap -o -)
+    doc = invoker.document
+    all_blocks = doc.find_by
+    refute_equal 0, all_blocks.size
+    doc.find_by.each do |block|
+      refute_nil block.source_location
+    end
+    assert_equal sample_filepath, doc.blocks[0].source_location.file
+    assert_equal 6, doc.blocks[0].source_location.lineno
+  end
+
   test 'should locate custom templates based on template dir, template engine and backend' do
     custom_backend_root = fixture_path 'custom-backends'
     invoker = invoke_cli_to_buffer %W(-E haml -T #{custom_backend_root} -o -)

--- a/test/options_test.rb
+++ b/test/options_test.rb
@@ -294,8 +294,18 @@ context 'Options' do
     assert options[:timings]
   end
 
-  test 'timings option is disable by default' do
+  test 'timings option is disabled by default' do
     options = Asciidoctor::Cli::Options.parse! %w(test/fixtures/sample.adoc)
     refute options[:timings]
+  end
+
+  test 'should enable sourcemap when --sourcemap flag is specified' do
+    options = Asciidoctor::Cli::Options.parse! %w(--sourcemap test/fixtures/sample.adoc)
+    assert options[:sourcemap]
+  end
+
+  test 'sourcemap option is disabled by default' do
+    options = Asciidoctor::Cli::Options.parse! %w(test/fixtures/sample.adoc)
+    refute options[:sourcemap]
   end
 end


### PR DESCRIPTION
Fixes #3569

When writing an extension to asciidoctor the source location can be useful information. However it is not populated when the sourcmap option is not enabled which currently can only be done from the ruby API but not the CLI.

This pull request fixes that. The flag is -m because -s and -S are both taken already.