### PR TITLE
Don't apply passthrough substitution inside stem macros

### DIFF
--- a/test/substitutions_test.rb
+++ b/test/substitutions_test.rb
@@ -1955,15 +1955,7 @@ context 'Substitutions' do
       end
 
       test 'should passthrough math macro inside another passthrough' do
-        input = 'the text `asciimath:[x = y]` should be passed through as +literal+ text'
-        para = block_from_string input, attributes: { 'compat-mode' => '' }
-        assert_equal 'the text <code>asciimath:[x = y]</code> should be passed through as <code>literal</code> text', para.content
-
-        input = 'the text [x-]`asciimath:[x = y]` should be passed through as `literal` text'
-        para = block_from_string input
-        assert_equal 'the text <code>asciimath:[x = y]</code> should be passed through as <code>literal</code> text', para.content
-
-        input = 'the text `+asciimath:[x = y]+` should be passed through as `literal` text'
+        input = 'the text `++asciimath:[x = y]++` should be passed through as `literal` text'
         para = block_from_string input
         assert_equal 'the text <code>asciimath:[x = y]</code> should be passed through as <code>literal</code> text', para.content
       end


### PR DESCRIPTION
I just moved processing of the stem substitutions before processing of the passthrough substitutions. It seems that it works well and the side effects of this change are acceptable, i.e. they will probably affect much fewer users than the current undesirable behaviour of `+` signs inside the stem macros.

Fixes #3409