### PR TITLE
sections? returns false for anything that isn't itself a section

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -27,6 +27,7 @@ Bug Fixes::
 
   * Remove unnamespaced selectors in Pygments stylesheet
   * Normalize output from Pygments to use `linenos` class for inline line numbering and trim space after number; update default stylesheet accordingly
+  * Change `AbstractBlock#sections?` to return false when called on block that isn't a Section or Document
 
 Improvements::
 

--- a/lib/asciidoctor/abstract_block.rb
+++ b/lib/asciidoctor/abstract_block.rb
@@ -130,11 +130,13 @@ class AbstractBlock < AbstractNode
 
   # Public: Check whether this block has any child Section objects.
   #
-  # Only applies to Document and Section instances
+  # Acts an an abstract method that always returns false unless this block is an
+  # instance of Document or Section.
+  # Both Document and Section provide overrides for this method.
   #
-  # Returns A [Boolean] to indicate whether this block has child Section objects
+  # Returns false
   def sections?
-    @next_section_index > 0
+    false
   end
 
   # Deprecated: Legacy property to get the String or Integer numeral of this section.

--- a/lib/asciidoctor/document.rb
+++ b/lib/asciidoctor/document.rb
@@ -633,6 +633,13 @@ class Document < AbstractBlock
     end
   end
 
+  # Public: Check whether this Document has any child Section objects.
+  #
+  # Returns A [Boolean] to indicate whether this Document has child Section objects
+  def sections?
+    @next_section_index > 0
+  end
+
   def footnotes?
     @catalog[:footnotes].empty? ? false : true
   end

--- a/lib/asciidoctor/section.rb
+++ b/lib/asciidoctor/section.rb
@@ -64,6 +64,13 @@ class Section < AbstractBlock
     Section.generate_id title, @document
   end
 
+  # Public: Check whether this Section has any child Section objects.
+  #
+  # Returns A [Boolean] to indicate whether this Section has child Section objects
+  def sections?
+    @next_section_index > 0
+  end
+
   # Public: Get the section number for the current Section
   #
   # The section number is a dot-separated String that uniquely describes the position of this

--- a/test/api_test.rb
+++ b/test/api_test.rb
@@ -1890,5 +1890,59 @@ context 'API' do
       doc = document_from_string input
       assert_equal doc.blocks[0].items[1], doc.blocks[0].items[0][1].blocks[0].next_adjacent_block
     end
+
+    test 'should return true when sections? is called on a document or section that has sections' do
+      input = <<~'EOS'
+      = Document Title
+
+      == First Section
+
+      === First subsection
+
+      content
+      EOS
+
+      doc = document_from_string input
+      assert doc.sections?
+      assert doc.blocks[0].sections?
+    end
+
+    test 'should return false when sections? is called on a document with no sections' do
+      input = <<~'EOS'
+      = Document Title
+
+      content
+      EOS
+
+      doc = document_from_string input
+      refute doc.sections?
+    end
+
+    test 'should return false when sections? is called on a section with no sections' do
+      input = <<~'EOS'
+      = Document Title
+
+      == First Section
+      EOS
+
+      doc = document_from_string input
+      refute doc.blocks[0].sections?
+    end
+
+    test 'should return false when sections? is called on anything that is not a section' do
+      input = <<~'EOS'
+      .Title
+      ====
+      I'm not section!
+      ====
+
+      [NOTE]
+      I'm not a section either!
+      EOS
+
+      doc = document_from_string input
+      refute doc.blocks[0].sections?
+      refute doc.blocks[1].sections?
+    end
   end
 end


### PR DESCRIPTION
resolves https://github.com/asciidoctor/asciidoctor.js/issues/850

Another solution would be to assign a default value (0) in the constructor.
Also, I believe that the internal method `assign_numeral` will fail if `@next_section_index` is `nil`. But since it's an internal method it should only be called on `Section`.