### PR TITLE
Add Open Graph and Twitter card support to html5 backend

### DIFF
--- a/lib/asciidoctor/converter/html5.rb
+++ b/lib/asciidoctor/converter/html5.rb
@@ -109,6 +109,22 @@ class Converter::Html5Converter < Converter::Base
     result << %(<meta name="keywords" content="#{node.attr 'keywords'}"#{slash}>) if node.attr? 'keywords'
     result << %(<meta name="author" content="#{((authors = node.sub_replacements node.attr 'authors').include? '<') ? (authors.gsub XmlSanitizeRx, '') : authors}"#{slash}>) if node.attr? 'authors'
     result << %(<meta name="copyright" content="#{node.attr 'copyright'}"#{slash}>) if node.attr? 'copyright'
+    # Open Graph tags - Basic and Optional Metadata - https://ogp.me/
+    result << %(<meta property="og:title" content="#{node.attr 'social-title'}"#{slash}>) if node.attr? 'social-title'
+    result << %(<meta property="og:type" content="#{node.attr 'social-type'}"#{slash}>) if node.attr? 'social-type'
+    result << %(<meta property="og:url" content="#{node.attr 'social-url'}"#{slash}>) if node.attr? 'social-url'
+    result << %(<meta property="og:image" content="#{node.attr 'social-image'}"#{slash}>) if node.attr? 'social-image'
+    result << %(<meta property="og:image:width" content="#{node.attr 'social-image-width'}"#{slash}>) if node.attr? 'social-image-width'
+    result << %(<meta property="og:image:height" content="#{node.attr 'social-image-height'}"#{slash}>) if node.attr? 'social-image-height'
+    result << %(<meta property="og:site_name" content="#{node.attr 'social-site-name'}"#{slash}>) if node.attr? 'social-site-name'
+    result << %(<meta property="og:description" content="#{node.attr 'social-description'}"#{slash}>) if node.attr? 'social-description'
+    result << %(<meta property="og:locale" content="#{node.attr 'social-locale'}"#{slash}>) if node.attr? 'social-locale'
+    # Twitter tags - https://developer.twitter.com/en/docs/tweets/optimize-with-cards/overview/summary
+    result << %(<meta name="twitter:card" content="#{node.attr 'social-twitter-card'}"#{slash}>) if node.attr? 'social-twitter-card'
+    result << %(<meta name="twitter:site" content="#{node.attr 'social-twitter-site'}"#{slash}>) if node.attr? 'social-twitter-site'
+    result << %(<meta name="twitter:title" content="#{node.attr 'social-title'}"#{slash}>) if node.attr? 'social-title'
+    result << %(<meta name="twitter:description" content="#{node.attr 'social-description'}"#{slash}>) if node.attr? 'social-description'
+    result << %(<meta name="twitter:image" content="#{node.attr 'social-image'}"#{slash}>) if node.attr? 'social-image'
     if node.attr? 'favicon'
       if (icon_href = node.attr 'favicon').empty?
         icon_href = 'favicon.ico'


### PR DESCRIPTION
Not sure if there was further thinking on how to implement issues #199 and #503, but it is something I need in a set of pages I'm working on. So I added this to the html5 backend. I can add documentation and tests too, but before investing time there I'd like to know if this is roughly a reasonable approach.

This might impact Jekyll users of the jekyll-seo-tag plugin (I'm actually one of them), if they declare these attributes in the document header, but usually the SEO config there is part of the `_config.yml` file. In that case they might get double the Open Graph and Twitter tags, but that might not actually be a problem.