### PR TITLE
resolves #3645 escape ellipsis at start of line in manpage output

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -34,6 +34,7 @@ Bug Fixes::
   * Removing leading and trailing blank lines in AsciiDoc include file to match assumption of parser (#3470)
   * Activate extensions when :extensions option is set even if Extensions API is not yet loaded (#3570)
   * Don't activate global extensions if :extensions option is false (#3570)
+  * In manpages backend, escape ellipsis at start of line
 
 Compliance::
 

--- a/lib/asciidoctor/converter/manpage.rb
+++ b/lib/asciidoctor/converter/manpage.rb
@@ -704,6 +704,7 @@ allbox tab(:);'
     end
     str = str.
       gsub(LiteralBackslashRx) { %[#{$1}#{'\\(rs' * $2.length}] }. # literal backslash (not a troff escape sequence)
+      gsub(EllipsisCharRefRx, '...'). # horizontal ellipsis
       gsub(LeadingPeriodRx, '\\\&.'). # leading . is used in troff for macro call or other formatting; replace with \&.
       # drop orphaned \c escape lines, unescape troff macro, quote adjacent character, isolate macro line
       gsub(EscapedMacroRx) { (rest = $3.lstrip).empty? ? %(.#$1"#$2") : %(.#$1"#$2"#{LF}#{rest}) }.
@@ -721,7 +722,6 @@ allbox tab(:);'
       gsub('&#8217;', '\(cq').  # right single quotation mark
       gsub('&#8220;', '\(lq').  # left double quotation mark
       gsub('&#8221;', '\(rq').  # right double quotation mark
-      gsub(EllipsisCharRefRx, '...'). # horizontal ellipsis
       gsub('&#8592;', '\(<-').  # leftwards arrow
       gsub('&#8594;', '\(->').  # rightwards arrow
       gsub('&#8656;', '\(lA').  # leftwards double arrow

--- a/test/manpage_test.rb
+++ b/test/manpage_test.rb
@@ -216,6 +216,34 @@ context 'Manpage' do
       assert_equal '\&.if 1 .nx', output.lines[-2].chomp
     end
 
+    test 'should escape ellipsis at start of line' do
+      input = <<~EOS.chop
+      #{SAMPLE_MANPAGE_HEADER}
+
+      -x::
+	Ao gravar o commit, acrescente uma linha que diz "(cherry picked from commit
+	...)" à mensagem de commit original para indicar qual commit esta mudança
+	foi escolhida. Isso é feito apenas para picaretas de cereja sem conflitos.
+	EOS
+      output = Asciidoctor.convert input, backend: :manpage
+      assert_equal '\&...', output.lines[-3][0..4].chomp
+    end
+
+    test 'should not escape ellipsis in the middle of a line' do
+      input = <<~EOS.chop
+      #{SAMPLE_MANPAGE_HEADER}
+
+      -x::
+	Ao gravar o commit, acrescente uma linha que diz
+	"(cherry picked from commit...)" à mensagem de commit
+	 original para indicar qual commit esta mudança
+	foi escolhida. Isso é feito apenas para picaretas
+	de cereja sem conflitos.
+	EOS
+      output = Asciidoctor.convert input, backend: :manpage
+      assert(output.lines[-5].include? 'commit...')
+    end
+
     test 'should normalize whitespace in a paragraph' do
       input = <<~EOS.chop
       #{SAMPLE_MANPAGE_HEADER}


### PR DESCRIPTION
when an ellipsis is at the start of line, is should be:

 1. converted back to "..."
 2. escaped so that the first period does not trigger a macro