### PR TITLE
Add missing Danish, Spanish, French, Polish and Portuguese attribute translations

### DIFF
--- a/data/locale/attributes-da.adoc
+++ b/data/locale/attributes-da.adoc
@@ -1,9 +1,9 @@
-// Danish translation, courtesy of Max Rydahl Andersen <manderse@redhat.com>
+// Danish translation, courtesy of Max Rydahl Andersen <manderse@redhat.com>, with updates from Morten Høfft <mhoefft@gbif.org>
 :appendix-caption: Appendix
 :appendix-refsig: {appendix-caption}
 :caution-caption: Forsigtig
-//:chapter-label: ???
-//:chapter-refsig: {chapter-label}
+:chapter-label: Kapitel
+:chapter-refsig: {chapter-label}
 :example-caption: Eksempel
 :figure-caption: Figur
 :important-caption: Vigtig
@@ -11,9 +11,9 @@
 ifdef::listing-caption[:listing-caption: List]
 ifdef::manname-title[:manname-title: Navn]
 :note-caption: Notat
-//:part-refsig: ???
+:part-refsig: Del
 ifdef::preface-title[:preface-title: Forord]
-//:section-refsig: ???
+:section-refsig: Sektion
 :table-caption: Tabel
 :tip-caption: Tips
 :toc-title: Indholdsfortegnelse

--- a/data/locale/attributes-es.adoc
+++ b/data/locale/attributes-es.adoc
@@ -1,9 +1,9 @@
-// Spanish translation, courtesy of Eddú Meléndez <eddu.melendez@gmail.com>
+// Spanish translation, courtesy of Eddú Meléndez <eddu.melendez@gmail.com> with updates from Fede Mendez <federicomh@gmail.com>
 :appendix-caption: Apéndice
 :appendix-refsig: {appendix-caption}
 :caution-caption: Precaución
-//:chapter-label: ???
-//:chapter-refsig: {chapter-label}
+:chapter-label: Capítulo
+:chapter-refsig: {chapter-label}
 :example-caption: Ejemplo
 :figure-caption: Figura
 :important-caption: Importante
@@ -11,9 +11,9 @@
 ifdef::listing-caption[:listing-caption: Lista]
 ifdef::manname-title[:manname-title: Nombre]
 :note-caption: Nota
-//:part-refsig: ???
+:part-refsig: Parte
 ifdef::preface-title[:preface-title: Prefacio]
-//:section-refsig: ???
+:section-refsig: Sección
 :table-caption: Tabla
 :tip-caption: Sugerencia
 :toc-title: Tabla de Contenido

--- a/data/locale/attributes-fr.adoc
+++ b/data/locale/attributes-fr.adoc
@@ -1,4 +1,4 @@
-// French translation, courtesy of Nicolas Comet <nicolas.comet@gmail.com>
+// French translation, courtesy of Nicolas Comet <nicolas.comet@gmail.com> with updates from Maheva Bagard Laursen <mblaursen@gbif.org>
 :appendix-caption: Annexe
 :appendix-refsig: {appendix-caption}
 :caution-caption: Avertissement
@@ -11,9 +11,9 @@
 ifdef::listing-caption[:listing-caption: Liste]
 ifdef::manname-title[:manname-title: Nom]
 :note-caption: Note
-//:part-refsig: ???
+:part-refsig: Partie
 ifdef::preface-title[:preface-title: Préface]
-//:section-refsig: ???
+:section-refsig: Section
 :table-caption: Tableau
 :tip-caption: Astuce
 :toc-title: Table des matières

--- a/data/locale/attributes-pl.adoc
+++ b/data/locale/attributes-pl.adoc
@@ -8,7 +8,7 @@
 :figure-caption: Rysunek
 :important-caption: Ważne
 :last-update-label: Ostatnio zmodyfikowany
-ifdef::listing-caption[:listing-caption: Spis]
+ifdef::listing-caption[:listing-caption: Listing]
 ifdef::manname-title[:manname-title: Nazwa]
 :note-caption: Notka
 :part-refsig: Część

--- a/data/locale/attributes-pl.adoc
+++ b/data/locale/attributes-pl.adoc
@@ -1,4 +1,4 @@
-// Polish translation, courtesy of Łukasz Dziedziul <l.dziedziul@gmail.com>
+// Polish translation, courtesy of Łukasz Dziedziul <l.dziedziul@gmail.com> with updates via Matthew Blissett <mblissett@gbif.org>
 :appendix-caption: Dodatek
 :appendix-refsig: {appendix-caption}
 :caution-caption: Uwaga
@@ -8,12 +8,12 @@
 :figure-caption: Rysunek
 :important-caption: Ważne
 :last-update-label: Ostatnio zmodyfikowany
-//ifdef::listing-caption[:listing-caption: ???]
+ifdef::listing-caption[:listing-caption: Spis]
 ifdef::manname-title[:manname-title: Nazwa]
 :note-caption: Notka
-//:part-refsig: ???
-//ifdef::preface-title[:preface-title: ???]
-//:section-refsig: ???
+:part-refsig: Część
+ifdef::preface-title[:preface-title: Wstęp]
+:section-refsig: Sekcja
 :table-caption: Tabela
 :tip-caption: Sugestia
 :toc-title: Spis treści

--- a/data/locale/attributes-pt.adoc
+++ b/data/locale/attributes-pt.adoc
@@ -1,9 +1,9 @@
-// Portuguese translation, courtesy of Roberto Cortez <radcortez@yahoo.com>
+// Portuguese translation, courtesy of Roberto Cortez <radcortez@yahoo.com> with updates from Andrew Rodrigues <arodrigues@gbif.org>
 :appendix-caption: Apêndice
 :appendix-refsig: {appendix-caption}
 :caution-caption: Atenção
-//:chapter-label: ???
-//:chapter-refsig: {chapter-label}
+:chapter-label: Capítulo
+:chapter-refsig: {chapter-label}
 :example-caption: Exemplo
 :figure-caption: Figura
 :important-caption: Importante
@@ -11,9 +11,9 @@
 ifdef::listing-caption[:listing-caption: Listagem]
 ifdef::manname-title[:manname-title: Nome]
 :note-caption: Nota
-//:part-refsig: ???
+:part-refsig: Parte
 ifdef::preface-title[:preface-title: Prefácio]
-//:section-refsig: ???
+:section-refsig: Secção
 :table-caption: Tabela
 :tip-caption: Sugestão
 :toc-title: Índice

--- a/data/locale/attributes-pt_BR.adoc
+++ b/data/locale/attributes-pt_BR.adoc
@@ -1,9 +1,9 @@
-// Brazilian Portuguese translation, courtesy of Rafael Pestano <rmpestano@gmail.com>
+// Brazilian Portuguese translation, courtesy of Rafael Pestano <rmpestano@gmail.com> with updates from Andrew Rodrigues <arodrigues@gbif.org>
 :appendix-caption: Apêndice
 :appendix-refsig: {appendix-caption}
 :caution-caption: Cuidado
-//:chapter-label: ???
-//:chapter-refsig: {chapter-label}
+:chapter-label: Capítulo
+:chapter-refsig: {chapter-label}
 :example-caption: Exemplo
 :figure-caption: Figura
 :important-caption: Importante
@@ -11,9 +11,9 @@
 ifdef::listing-caption[:listing-caption: Listagem]
 ifdef::manname-title[:manname-title: Nome]
 :note-caption: Nota
-//:part-refsig: ???
+:part-refsig: Parte
 ifdef::preface-title[:preface-title: Prefácio]
-//:section-refsig: ???
+:section-refsig: Seção
 :table-caption: Tabela
 :tip-caption: Dica
 :toc-title: Índice


### PR DESCRIPTION
The translations for "part", "chapter", "section" and "listing" are missing in several languages.

This adds them for Danish, Spanish, French, Polish, Portuguese and Brazilian Portuguese.