### PR TITLE
Adds missing Catalan attributes translation + fixes appendix

### DIFF
--- a/data/locale/attributes-ca.adoc
+++ b/data/locale/attributes-ca.adoc
@@ -1,9 +1,9 @@
 // Catalan translation, courtesy of Abel Salgado Romero <abelromero@gmail.com> and Alex Soto
-:appendix-caption: Apendix
+:appendix-caption: Apèndix
 :appendix-refsig: {appendix-caption}
 :caution-caption: Atenció
-//:chapter-label: ???
-//:chapter-refsig: {chapter-label}
+:chapter-label: Capítol
+:chapter-refsig: {chapter-label}
 :example-caption: Exemple
 :figure-caption: Figura
 :important-caption: Important
@@ -11,9 +11,9 @@
 ifdef::listing-caption[:listing-caption: Llista]
 ifdef::manname-title[:manname-title: Nom]
 :note-caption: Nota
-//:part-refsig: ???
+:part-refsig: Part
 ifdef::preface-title[:preface-title: Prefaci]
-//:section-refsig: ???
+:section-refsig: Secció
 :table-caption: Taula
 :tip-caption: Suggeriment
 :toc-title: Índex


### PR DESCRIPTION
* Fixes missing grave accent in `appendix-caption`.
* Adds missing Catalan values.

**Before merging,** I'd like double check `part-refsig`. What's its use?
Depending on it, I think it would be more appropiate to use "apartat", which is specific to designate a document seccion with a function and clearly separated, for examaple, by spacing, title and/or numbering. It also tends to be a short element, like a sub-section of a chapter. "Part" is a very generic term for anything, even without estructure or boundaries.
For exemple, you would say "the pre-installation chapter has 2 'apartats': hardware requirements and software requirements", or "All novels have 3 'parts'; introduction, development and conclusion"...but not the other way arround.
