### PR TITLE
resolves #3660 look up asset dir attribute from node with inheritance enabled to resolve asset path prefix

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -23,6 +23,7 @@ Enhancements::
   * Allow the CLI to control the logging level using the `--log-level` option (#3868)
   * Ignore `--log-level` CLI option if `-q` is specified; ignore `-v` CLI option if `--log-level` is specified (#3868)
   * Add support for inline linenums mode when using Rouge as source highlighter (`rouge-linenums-mode=inline`) (#3641)
+  * Look up asset dir attribute (i.e., `imagesdir` or `iconsdir`) on node to resolve asset path prefix, inheriting from document if not otherwise set (#3661) (*@mogztter*)
   * Omit meta generator tag in HTML output if `reproducible` document attribute is set (#4143) (*@rpavlik*)
   * Add `--sourcemap` option to the CLI to enable the `:sourcemap` option on the parser (#3569) (*@hackingotter*)
   * Allow section ID to be unset by assigning an empty value to the `id` block attribute (#4139)

--- a/lib/asciidoctor/abstract_node.rb
+++ b/lib/asciidoctor/abstract_node.rb
@@ -322,14 +322,14 @@ class AbstractNode
   def image_uri target_image, asset_dir_key = 'imagesdir'
     if (doc = @document).safe < SafeMode::SECURE && (doc.attr? 'data-uri')
       if ((Helpers.uriish? target_image) && (target_image = Helpers.encode_spaces_in_uri target_image)) ||
-          (asset_dir_key && (images_base = doc.attr asset_dir_key) && (Helpers.uriish? images_base) &&
+          (asset_dir_key && (images_base = attr asset_dir_key, nil, true) && (Helpers.uriish? images_base) &&
           (target_image = normalize_web_path target_image, images_base, false))
         (doc.attr? 'allow-uri-read') ? (generate_data_uri_from_uri target_image, (doc.attr? 'cache-uri')) : target_image
       else
         generate_data_uri target_image, asset_dir_key
       end
     else
-      normalize_web_path target_image, (asset_dir_key ? (doc.attr asset_dir_key) : nil)
+      normalize_web_path target_image, (asset_dir_key ? (attr asset_dir_key, nil, true) : nil)
     end
   end
 
@@ -348,7 +348,7 @@ class AbstractNode
   #
   # Returns A String reference for the target media
   def media_uri target, asset_dir_key = 'imagesdir'
-    normalize_web_path target, (asset_dir_key ? (@document.attr asset_dir_key) : nil)
+    normalize_web_path target, (asset_dir_key ? (attr asset_dir_key, nil, true) : nil)
   end
 
   # Public: Generate a data URI that can be used to embed an image in the output document
@@ -371,7 +371,7 @@ class AbstractNode
     end
 
     if asset_dir_key
-      image_path = normalize_system_path target_image, (@document.attr asset_dir_key), nil, target_name: 'image'
+      image_path = normalize_system_path(target_image, (attr asset_dir_key, nil, true), nil, target_name: 'image')
     else
       image_path = normalize_system_path target_image
     end

--- a/lib/asciidoctor/parser.rb
+++ b/lib/asciidoctor/parser.rb
@@ -625,7 +625,7 @@ class Parser
               end
               if blk_ctx == :image
                 document.register :images, target
-                attributes['imagesdir'] = doc_attrs['imagesdir']
+                attributes['imagesdir'] ||= doc_attrs['imagesdir']
                 # NOTE style is the value of the first positional attribute in the block attribute line
                 attributes['alt'] ||= style || (attributes['default-alt'] = (Helpers.basename target, true).tr '_-', ' ')
                 unless (scaledwidth = attributes.delete 'scaledwidth').nil_or_empty?

--- a/lib/asciidoctor/substitutors.rb
+++ b/lib/asciidoctor/substitutors.rb
@@ -425,7 +425,7 @@ module Substitutors
         attrs = parse_attributes $2, posattrs, unescape_input: true
         unless type == 'icon'
           doc.register :images, target
-          attrs['imagesdir'] = doc_attrs['imagesdir']
+          attrs['imagesdir'] ||= doc_attrs['imagesdir']
         end
         attrs['alt'] ||= (attrs['default-alt'] = (Helpers.basename target, true).tr '_-', ' ')
         Inline.new(self, :image, nil, type: type, target: target, attributes: attrs).convert

--- a/test/substitutions_test.rb
+++ b/test/substitutions_test.rb
@@ -774,6 +774,17 @@ context 'Substitutions' do
       assert_equal '<span class="image"><img src="tiger.png" alt="tiger"></span>', para.sub_macros(para.source).gsub(/>\s+</, '><')
     end
 
+    test 'should use the imagesdir attribute defined on image macro when resolving image path' do
+      input = <<~'EOS'
+      :imagesdir: images
+
+      Great job! image:rainbow.png[imagesdir=stickers]
+      '''
+      EOS
+      output = convert_string_to_embedded input
+      assert_includes output, 'src="stickers/rainbow.png"'
+    end
+
     test 'should replace underscore and hyphen with space in generated alt text for an inline image' do
       para = block_from_string 'image:tiger-with-family_1.png[]'
       assert_equal '<span class="image"><img src="tiger-with-family_1.png" alt="tiger with family 1"></span>', para.sub_macros(para.source).gsub(/>\s+</, '><')
@@ -1042,6 +1053,13 @@ context 'Substitutions' do
     test 'an icon macro with a role and title should be interpreted as a font-based icon with a class and title when icons=font' do
       para = block_from_string 'icon:heart[role="red", title="Heart me"]', attributes: { 'icons' => 'font' }
       assert_equal '<span class="icon red"><i class="fa fa-heart" title="Heart me"></i></span>', para.sub_macros(para.source).gsub(/>\s+</, '><')
+    end
+
+    test 'should use the imagesdir attribute on the node when resolving the icon path' do
+      doc = empty_document attributes: { 'iconsdir' => 'assets/icons', 'icons' => 'image' }
+      icon = Asciidoctor::Inline.new doc, :image, nil, type: 'icon', attributes: { 'iconsdir' => 'chapter-1/icons' }
+      icon_uri = icon.icon_uri 'wave'
+      assert_equal 'chapter-1/icons/wave.png', icon_uri
     end
 
     test 'a single-line footnote macro should be registered and output as a footnote' do


### PR DESCRIPTION
By default, the asset directory is `imagesdir` or `iconsdir` depending on the type of asset.

If the asset directory attribute is defined on the node, then we prefer it. Otherwise, we use the value defined on the `Document`.

I've decided to apply the same rule on all type of assets (video, audio, icon and image). I think it would be inconsistent and confusing to implement this behavior only on images.

resolves #3660