### PR TITLE
Use an NBSP between outline number and text

### DIFF
--- a/lib/asciidoctor/converter/html5.rb
+++ b/lib/asciidoctor/converter/html5.rb
@@ -352,14 +352,14 @@ MathJax.Hub.Register.StartupHook("AsciiMath Jax Ready", function () {
       elsif section.numbered && slevel <= sectnumlevels
         if slevel < 2 && node.document.doctype == 'book'
           if section.sectname == 'chapter'
-            stitle =  %(#{(signifier = node.document.attributes['chapter-signifier']) ? "#{signifier} " : ''}#{section.sectnum} #{section.title})
+            stitle =  %(#{(signifier = node.document.attributes['chapter-signifier']) ? "#{signifier} " : ''}#{section.sectnum}&nbsp;#{section.title})
           elsif section.sectname == 'part'
-            stitle =  %(#{(signifier = node.document.attributes['part-signifier']) ? "#{signifier} " : ''}#{section.sectnum nil, ':'} #{section.title})
+            stitle =  %(#{(signifier = node.document.attributes['part-signifier']) ? "#{signifier} " : ''}#{section.sectnum nil, ':'}&nbsp;#{section.title})
           else
-            stitle = %(#{section.sectnum} #{section.title})
+            stitle = %(#{section.sectnum}&nbsp;#{section.title})
           end
         else
-          stitle = %(#{section.sectnum} #{section.title})
+          stitle = %(#{section.sectnum}&nbsp;#{section.title})
         end
       else
         stitle = section.title


### PR DESCRIPTION
Makes the TOC more appealing for OpenXR specification, at least. We have sections that start with a long "word".

Before:

![Screenshot from 2020-05-21 13-21-46](https://user-images.githubusercontent.com/61129/82592253-3d8f6a80-9b66-11ea-98be-755b0592c1c0.png)


After:

![Screenshot from 2020-05-21 13-21-19](https://user-images.githubusercontent.com/61129/82592275-43854b80-9b66-11ea-89ec-681f92a8ad86.png)


This has bugged me for a while, but hadn't gotten around to poking it until now. Ideally we could do this via stylesheet, which we can override easily, but I'm not sure of a way to do that offhand.

cc @oddhack