### PR TITLE
resolves #3694 add support for style attribute to icon macro

### DIFF
--- a/lib/asciidoctor/converter/html5.rb
+++ b/lib/asciidoctor/converter/html5.rb
@@ -1174,9 +1174,15 @@ Your browser does not support the video tag.
     end
   end
 
+  # Convert {AbstractNode}s with the {AbstractNode.node_name} +"inline_image"+ to their associated _HTML_ markup
+  #
+  # node  - the {AbstractNode} to convert
+  #
+  # Returns (String) stringified _HTML_ markup representing the inline image node
   def convert_inline_image node
     if (type = node.type || 'image') == 'icon' && (node.document.attr? 'icons', 'font')
-      class_attr_val = %(fa fa-#{node.target})
+      icon_style = node.attr('style', node.document.attr('icon_style',''))[0]
+      class_attr_val = %(fa#{icon_style} fa-#{node.target})
       { 'size' => 'fa-', 'rotate' => 'fa-rotate-', 'flip' => 'fa-flip-' }.each do |key, prefix|
         class_attr_val = %(#{class_attr_val} #{prefix}#{node.attr key}) if node.attr? key
       end

--- a/test/substitutions_test.rb
+++ b/test/substitutions_test.rb
@@ -863,34 +863,63 @@ context 'Substitutions' do
       end
     end
 
-    test 'an icon macro should be interpreted as an icon if icons are enabled' do
-      para = block_from_string 'icon:github[]', attributes: { 'icons' => '' }
-      assert_equal %{<span class="icon"><img src="./images/icons/github.png" alt="github"></span>}, para.sub_macros(para.source).gsub(/>\s+</, '><')
-    end
+    context 'icon macro' do
+      test 'an icon macro should be interpreted as an icon if icons are enabled' do
+        para = block_from_string 'icon:github[]', attributes: { 'icons' => '' }
+        assert_equal %{<span class="icon"><img src="./images/icons/github.png" alt="github"></span>}, para.sub_macros(para.source).gsub(/>\s+</, '><')
+      end
 
-    test 'an icon macro should be interpreted as alt text if icons are disabled' do
-      para = block_from_string 'icon:github[]'
-      assert_equal %{<span class="icon">[github]</span>}, para.sub_macros(para.source).gsub(/>\s+</, '><')
-    end
+      test 'an icon macro should be interpreted as alt text if icons are disabled' do
+        para = block_from_string 'icon:github[]'
+        assert_equal %{<span class="icon">[github]</span>}, para.sub_macros(para.source).gsub(/>\s+</, '><')
+      end
 
-    test 'an icon macro should output alt text if icons are disabled and alt is given' do
-      para = block_from_string 'icon:github[alt="GitHub"]'
-      assert_equal %{<span class="icon">[GitHub]</span>}, para.sub_macros(para.source).gsub(/>\s+</, '><')
-    end
+      test 'an icon macro should output alt text if icons are disabled and alt is given' do
+        para = block_from_string 'icon:github[alt="GitHub"]'
+        assert_equal %{<span class="icon">[GitHub]</span>}, para.sub_macros(para.source).gsub(/>\s+</, '><')
+      end
 
-    test 'an icon macro should be interpreted as a font-based icon when icons=font' do
-      para = block_from_string 'icon:github[]', attributes: { 'icons' => 'font' }
-      assert_equal %{<span class="icon"><i class="fa fa-github"></i></span>}, para.sub_macros(para.source).gsub(/>\s+</, '><')
-    end
+      context 'font-based icon' do
+        test 'an icon macro should be interpreted as a font-based icon when icons=font' do
+          para = block_from_string 'icon:github[]', attributes: { 'icons' => 'font' }
+          assert_equal %{<span class="icon"><i class="fa fa-github"></i></span>}, para.sub_macros(para.source).gsub(/>\s+</, '><')
+        end
 
-    test 'an icon macro with a size should be interpreted as a font-based icon with a size when icons=font' do
-      para = block_from_string 'icon:github[4x]', attributes: { 'icons' => 'font' }
-      assert_equal %{<span class="icon"><i class="fa fa-github fa-4x"></i></span>}, para.sub_macros(para.source).gsub(/>\s+</, '><')
-    end
+        test 'an icon macro with a size should be interpreted as a font-based icon with a size when icons=font' do
+          para = block_from_string 'icon:github[4x]', attributes: { 'icons' => 'font' }
+          assert_equal %{<span class="icon"><i class="fa fa-github fa-4x"></i></span>}, para.sub_macros(para.source).gsub(/>\s+</, '><')
+        end
 
-    test 'an icon macro with a role and title should be interpreted as a font-based icon with a class and title when icons=font' do
-      para = block_from_string 'icon:heart[role="red", title="Heart me"]', attributes: { 'icons' => 'font' }
-      assert_equal %{<span class="icon red"><i class="fa fa-heart" title="Heart me"></i></span>}, para.sub_macros(para.source).gsub(/>\s+</, '><')
+        test 'an icon macro with a role and title should be interpreted as a font-based icon with a class and title when icons=font' do
+          para = block_from_string 'icon:heart[role="red", title="Heart me"]', attributes: { 'icons' => 'font' }
+          assert_equal %{<span class="icon red"><i class="fa fa-heart" title="Heart me"></i></span>}, para.sub_macros(para.source).gsub(/>\s+</, '><')
+        end
+
+        test 'an icon macro interpreted as a font-based icon should have an icon style based on the abreviated icon_style document attribute value' do
+          para = block_from_string 'icon:sass[]', attributes: { 'icons' => 'font', 'icon_style' => 'b' }
+          assert_equal %{<span class="icon"><i class="fab fa-sass"></i></span>}, para.sub_macros(para.source).gsub(/>\s+</, '><')
+        end
+
+        test 'an icon macro interpreted as a font-based icon should have an icon style based on the icon_style document attribute value' do
+          para = block_from_string 'icon:sass[]', attributes: { 'icons' => 'font', 'icon_style' => 'brand' }
+          assert_equal %{<span class="icon"><i class="fab fa-sass"></i></span>}, para.sub_macros(para.source).gsub(/>\s+</, '><')
+        end
+
+        test 'an icon macro interpreted as a font-based icon should have an icon style based on the abreviated style macro attribute value' do
+          para = block_from_string 'icon:sass[style="b"]', attributes: { 'icons' => 'font' }
+          assert_equal %{<span class="icon"><i class="fab fa-sass"></i></span>}, para.sub_macros(para.source).gsub(/>\s+</, '><')
+        end
+
+        test 'an icon macro interpreted as a font-based icon should have an icon style based on the style macro attribute value' do
+          para = block_from_string 'icon:sass[style="brand"]', attributes: { 'icons' => 'font' }
+          assert_equal %{<span class="icon"><i class="fab fa-sass"></i></span>}, para.sub_macros(para.source).gsub(/>\s+</, '><')
+        end
+
+        test 'an icon macro interpreted as a font-based icon should prioratiset the icon style macro attribute value over the icon_style document attribute value' do
+          para = block_from_string 'icon:sass[style="brand"]', attributes: { 'icons' => 'font', 'icon_style' => 'light' }
+          assert_equal %{<span class="icon"><i class="fab fa-sass"></i></span>}, para.sub_macros(para.source).gsub(/>\s+</, '><')
+        end
+      end
     end
 
     test 'a single-line footnote macro should be registered and output as a footnote' do


### PR DESCRIPTION
My proposed changes regarding different icon styles for the icon macro, for detailed information see my comment on the issue #3694 itself.

* The contribution guidelines wish for documentation, so I tried adding basic documentation to the `convert_inline_image` method.
  I did not comment on my change directly, as I did not want to repeat the issue description and clutter the source code.
  But if wished, I can add a short summary. 

* Further I tried cleaning up the related test cases by grouping them based on a common test `context`.

Looking forward to hearing some feedback! 

_NOTE_: If my changes get approved, I recommend renaming the issue from _set_ to _style_ to avoid future confusion.