### PR TITLE
Remove direction property from default stylesheet

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -65,6 +65,7 @@ Improvements::
   * Allow a URL macro to have a preceding single or double quote (#3376)
   * Add support for erubi template engine; use it in place of erubis in test suite; note the use of erubis is deprecated (#3737)
   * Download and embed remote custom stylesheet if allow-uri-read is set (#3765)
+  * Remove direction property from default stylesheet (#3753) (*@abdnh*)
 
 Build / Infrastructure::
 

--- a/data/stylesheets/asciidoctor-default.css
+++ b/data/stylesheets/asciidoctor-default.css
@@ -55,7 +55,7 @@ select{width:100%}
 .center{margin-left:auto;margin-right:auto}
 .stretch{width:100%}
 .subheader,.admonitionblock td.content>.title,.audioblock>.title,.exampleblock>.title,.imageblock>.title,.listingblock>.title,.literalblock>.title,.stemblock>.title,.openblock>.title,.paragraph>.title,.quoteblock>.title,table.tableblock>.title,.verseblock>.title,.videoblock>.title,.dlist>.title,.olist>.title,.ulist>.title,.qlist>.title,.hdlist>.title{line-height:1.45;color:#7a2518;font-weight:400;margin-top:0;margin-bottom:.25em}
-div,dl,dt,dd,ul,ol,li,h1,h2,h3,#toctitle,.sidebarblock>.content>.title,h4,h5,h6,pre,form,p,blockquote,th,td{margin:0;padding:0;direction:ltr}
+div,dl,dt,dd,ul,ol,li,h1,h2,h3,#toctitle,.sidebarblock>.content>.title,h4,h5,h6,pre,form,p,blockquote,th,td{margin:0;padding:0}
 a{color:#2156a5;text-decoration:underline;line-height:inherit}
 a:hover,a:focus{color:#1d4b8f}
 a img{border:0}


### PR DESCRIPTION
Is there any reason direction has to be set explicitly to LTR?
This can be inconvenient when trying to set the document direction to RTL.