### PR TITLE
Use Ubuntu bionic (18.04 LTS) instead of trusty (14.04 LTS)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-dist: trusty
+dist: bionic
 git:
   # use depth 2 just in case two refs get pushed at once (like a tag)
   depth: 2


### PR DESCRIPTION
14.04 LTS has reached its end of support lifecycle and 20.04 LTS is still relatively new.