### PR TITLE
docbook backend: restore reftext after anchor

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -43,6 +43,7 @@ Bug Fixes::
   * Prevent collapsible block from incrementing example number by assigning an empty caption (#3639)
   * Use custom init function for highlight.js to select the correct `code` elements (#3761)
   * Fix resolved value of :to_dir when both :to_file and :to_dir options are set to absolute paths (#3778)
+  * Restore label in front of each bibliography entry in DocBook output that was dropped by fix for #3085 (#3782)
 
 Compliance::
 

--- a/lib/asciidoctor/converter/docbook5.rb
+++ b/lib/asciidoctor/converter/docbook5.rb
@@ -485,7 +485,7 @@ class Converter::DocBook5Converter < Converter::Base
     when :link
       %(<link xl:href="#{node.target}">#{node.text}</link>)
     when :bibref
-      %(<anchor#{common_attributes node.id, nil, "[#{node.reftext || node.id}]"}/>#{text})
+      %(<anchor#{common_attributes node.id, nil, (text = "[#{node.reftext || node.id}]")}/>#{text})
     else
       logger.warn %(unknown anchor type: #{node.type.inspect})
       nil

--- a/test/lists_test.rb
+++ b/test/lists_test.rb
@@ -3354,8 +3354,10 @@ context "Description lists (:dlist)" do
       assert_css 'bibliodiv > bibliomixed > bibliomisc', output, 2
       assert_css 'bibliodiv > bibliomixed:nth-child(1) > bibliomisc > anchor', output, 1
       assert_css 'bibliodiv > bibliomixed:nth-child(1) > bibliomisc > anchor[xreflabel="[taoup]"]', output, 1
+      assert_xpath '(//bibliomixed)[1]/bibliomisc/anchor[starts-with(following-sibling::text(), "[taoup] Eric")]', output, 1
       assert_css 'bibliodiv > bibliomixed:nth-child(2) > bibliomisc > anchor', output, 1
       assert_css 'bibliodiv > bibliomixed:nth-child(2) > bibliomisc > anchor[xreflabel="[walsh-muellner]"]', output, 1
+      assert_xpath '(//bibliomixed)[2]/bibliomisc/anchor[starts-with(following-sibling::text(), "[walsh-muellner] Norman")]', output, 1
     end
 
     test 'should warn if a bibliography ID is already in use' do
@@ -3478,7 +3480,7 @@ context "Description lists (:dlist)" do
       EOS
 
       result = convert_string_to_embedded input, backend: :docbook
-      assert_includes result, '<anchor xml:id="Fowler_1997" xreflabel="[1]"/>'
+      assert_includes result, '<anchor xml:id="Fowler_1997" xreflabel="[1]"/>[1] Fowler'
     end
   end
 end


### PR DESCRIPTION
Was previously dropped - seemingly by accident - add to unit test.