### PR TITLE
use CI jobs and update match for TruffleRuby

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,41 +1,49 @@
+os: linux
 dist: bionic
 git:
   depth: 5 # use depth 5 to leave enough room for concurrent builds
 language: ruby
-# always specify exact versions so we know which version we are testing
-rvm:
-- &release_ruby 2.7.2
-- 2.6.6
-- 2.5.8
-- 2.4.10
-- &oldest_ruby 2.3.8
-matrix:
-  include:
-  - rvm: jruby-9.2.10.0
-    env: JRUBY_OPTS='-J-XX:+TieredCompilation -J-XX:TieredStopAtLevel=1 -J-Xss2m -Xcompile.invokedynamic=false'
-  - rvm: jruby-9.1.17.0
-    dist: trusty
-  - rvm: *oldest_ruby
-    env: ROUGE_VERSION='~> 2.0.0'
-  - rvm: truffleruby-20.2.0
-    # run against TruffleRuby nightly or if TruffleRuby is mentioned in commit message
-    if: type = cron OR commit_message =~ /TruffleRuby/ OR commit_message =~ /truffleruby/
 env:
   global:
   # use system libraries to speed up installation of nokogiri
   - NOKOGIRI_USE_SYSTEM_LIBRARIES=true
   - PYGMENTS_VERSION='~> 1.2.0'
   - SOURCE_DATE_EPOCH=1521504000
-script: bundle exec rake coverage test:all
-after_success: bundle exec rake build:dependents
-#notifications:
-#  email: false
-#  irc: 'irc.freenode.org#asciidoctor'
-deploy:
-  provider: rubygems
-  gem: asciidoctor
-  api_key: ${RUBYGEMS_API_KEY}
-  on:
-    tags: true
-    repo: asciidoctor/asciidoctor
-    rvm: *release_ruby
+stages:
+- test
+- name: release
+  if: repo = asciidoctor/asciidoctor AND tag IS present
+install:
+- bundle config --local path .bundle/gems
+- bundle config --local without coverage docs
+- bundle --jobs 3 --retry 3
+script: bundle exec ruby -w $(bundle exec which rake) test:all
+# always specify exact Ruby versions so we can control which version we're actually testing
+jobs:
+  include:
+  - stage: test
+    rvm: jruby-9.2.13.0
+    env: JRUBY_OPTS='-J-XX:+TieredCompilation -J-XX:TieredStopAtLevel=1 -J-Xss2m -Xcompile.invokedynamic=false'
+  - rvm: jruby-9.1.17.0
+    dist: trusty
+  - rvm: truffleruby-20.2.0
+    # run against TruffleRuby nightly or if TruffleRuby (case insensitive) is mentioned in commit message
+    if: type = cron OR commit_message =~ /(?i)truffleruby/
+  - rvm: &default_ruby 2.7.2
+    script: bundle exec ruby -w $(bundle exec which rake) coverage test:all
+    after_success: bundle exec rake build:dependents
+  - rvm: 2.6.6
+  - rvm: 2.5.8
+  - rvm: 2.4.10
+  - rvm: &oldest_ruby 2.3.8
+  - rvm: *oldest_ruby
+    env: ROUGE_VERSION='~> 2.0.0'
+  - stage: release
+    rvm: *default_ruby
+    script: skip
+    deploy:
+      provider: rubygems
+      gem: asciidoctor
+      api_key: ${RUBYGEMS_API_KEY}
+      on:
+        tags: true

--- a/tasks/dependents.rake
+++ b/tasks/dependents.rake
@@ -2,11 +2,9 @@
 namespace :build do
   desc 'Trigger builds for all dependent projects on Travis CI and Github Actions'
   task :dependents do
-    if ENV['TRAVIS'].to_s == 'true'
-      next unless ENV['TRAVIS_PULL_REQUEST'].to_s == 'false' &&
-        ENV['TRAVIS_TAG'].to_s.empty? &&
-        (ENV['TRAVIS_JOB_NUMBER'].to_s.end_with? '.1')
-    end
+    next unless ENV['TRAVIS'].to_s == 'true' &&
+      ENV['TRAVIS_PULL_REQUEST'].to_s == 'false' &&
+      ENV['TRAVIS_TAG'].to_s.empty?
 
     if (commit_hash = ENV['TRAVIS_COMMIT'])
       commit_memo = %( (#{commit_hash.slice 0, 8})\n\nhttps://github.com/#{ENV['TRAVIS_REPO_SLUG'] || 'asciidoctor/asciidoctor'}/commit/#{commit_hash})


### PR DESCRIPTION
- use jobs instead of matrix
- run slower jobs first to reduce overall build time
- use a single regex to match TruffleRuby in commit message