### PR TITLE
resolves #3797 normalize frame value "topbot" to "ends" in HTML output

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -68,6 +68,7 @@ Improvements::
   * Add support for erubi template engine; use it in place of erubis in test suite; note the use of erubis is deprecated (#3737)
   * Download and embed remote custom stylesheet if allow-uri-read is set (#3765)
   * Remove direction property from default stylesheet (#3753) (*@abdnh*)
+  * Normalize frame value "topbot" to "ends" in HTML output (consistently use frame-ends class) (#3797)
 
 Build / Infrastructure::
 

--- a/lib/asciidoctor/converter/html5.rb
+++ b/lib/asciidoctor/converter/html5.rb
@@ -853,7 +853,8 @@ Your browser does not support the audio tag.
   def convert_table node
     result = []
     id_attribute = node.id ? %( id="#{node.id}") : ''
-    classes = ['tableblock', %(frame-#{node.attr 'frame', 'all', 'table-frame'}), %(grid-#{node.attr 'grid', 'all', 'table-grid'})]
+    frame = 'ends' if (frame = node.attr 'frame', 'all', 'table-frame') == 'topbot'
+    classes = ['tableblock', %(frame-#{frame}), %(grid-#{node.attr 'grid', 'all', 'table-grid'})]
     if (stripes = node.attr 'stripes', nil, 'table-stripes')
       classes << %(stripes-#{stripes})
     end

--- a/test/tables_test.rb
+++ b/test/tables_test.rb
@@ -554,7 +554,7 @@ context 'Tables' do
 
     test 'table with header and footer' do
       input = <<~'EOS'
-      [frame="topbot",options="header,footer"]
+      [options="header,footer"]
       |===
       |Item       |Quantity
       |Item 1     |1
@@ -581,7 +581,7 @@ context 'Tables' do
     test 'table with header and footer docbook' do
       input = <<~'EOS'
       .Table with header, body and footer
-      [frame="topbot",options="header,footer"]
+      [options="header,footer"]
       |===
       |Item       |Quantity
       |Item 1     |1
@@ -592,7 +592,6 @@ context 'Tables' do
       EOS
       output = convert_string_to_embedded input, backend: 'docbook'
       assert_css 'table', output, 1
-      assert_css 'table[frame="topbot"]', output, 1
       assert_css 'table > title', output, 1
       assert_css 'table > tgroup', output, 1
       assert_css 'table > tgroup[cols="2"]', output, 1
@@ -633,7 +632,40 @@ context 'Tables' do
       assert_css 'informaltable tbody > row > entry[align="right"][valign="top"]', output, 1
     end
 
-    test 'should recognize ends as an alias to topbot for frame when converting to DocBook' do
+    test 'should preserve frame value ends when converting to HTML' do
+      input = <<~'EOS'
+      [frame=ends]
+      |===
+      |A |B |C
+      |===
+      EOS
+      output = convert_string_to_embedded input
+      assert_css 'table.frame-ends', output, 1
+    end
+
+    test 'should normalize frame value topbot as ends when converting to HTML' do
+      input = <<~'EOS'
+      [frame=topbot]
+      |===
+      |A |B |C
+      |===
+      EOS
+      output = convert_string_to_embedded input
+      assert_css 'table.frame-ends', output, 1
+    end
+
+    test 'should preserve frame value topbot when converting to DocBook' do
+      input = <<~'EOS'
+      [frame=topbot]
+      |===
+      |A |B |C
+      |===
+      EOS
+      output = convert_string_to_embedded input, backend: 'docbook'
+      assert_css 'informaltable[frame="topbot"]', output, 1
+    end
+
+    test 'should convert frame value ends to topbot when converting to DocBook' do
       input = <<~'EOS'
       [frame=ends]
       |===
@@ -1270,7 +1302,7 @@ context 'Tables' do
 
     test 'AsciiDoc content' do
       input = <<~'EOS'
-      [cols="1e,1,5a",frame="topbot",options="header"]
+      [cols="1e,1,5a"]
       |===
       |Name |Backends |Description
 


### PR DESCRIPTION
- consistently use frame-ends class rather than allowing it to be mixed based on input