### PR TITLE
resolves #3745 always use title as xreftext if target block has an empty caption

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -26,6 +26,7 @@ Bug Fixes::
   * Don't clobber cgi-style options on language when enabling start_inline option on the Rouge PHP lexer (#3336)
   * Fix parsing of wrapped link and xref text, including when an attrlist signature is detected (#3331)
   * Restore deprecated writable number property on AbstractBlock
+  * Always use title as xreftext if target block has an empty caption, regardless of xrefstyle value (#3745)
   * Allow a bibliography reference to be used inside a footnote (#3325)
   * Fix bottom margin collapsing on AsciiDoc table cell (#3370)
   * Remove excess hard line break in multi-line AsciiMath blocks (#3407)

--- a/features/xref.feature
+++ b/features/xref.feature
@@ -630,6 +630,32 @@ Feature: Cross References
       .title Diagram 2. Managing Inventory
     """
 
+  Scenario: Create a full cross reference to a block with an empty caption
+  Given the AsciiDoc source
+    """
+    :xrefstyle: full
+
+    See <<ex1>>.
+
+    .Title
+    [#ex1,caption=]
+    ====
+    content
+    ====
+    """
+  When it is converted to html
+  Then the result should match the HTML structure
+    """
+    .paragraph: p
+      |See
+      a< href='#ex1' Title
+      |.
+    #ex1.exampleblock
+      .title Title
+      .content: .paragraph: p
+        |content
+    """
+
   Scenario: Create a short cross reference to a block with an explicit caption
   Given the AsciiDoc source
     """
@@ -660,6 +686,32 @@ Feature: Cross References
     #diagram-2.imageblock
       .content: img src='managing-inventory.png' alt='Managing Inventory'
       .title Diagram 2. Managing Inventory
+    """
+
+  Scenario: Create a short cross reference to a block with an empty caption
+  Given the AsciiDoc source
+    """
+    :xrefstyle: short
+
+    See <<ex1>>.
+
+    .Title
+    [#ex1,caption=]
+    ====
+    content
+    ====
+    """
+  When it is converted to html
+  Then the result should match the HTML structure
+    """
+    .paragraph: p
+      |See
+      a< href='#ex1' Title
+      |.
+    #ex1.exampleblock
+      .title Title
+      .content: .paragraph: p
+        |content
     """
 
   Scenario: Create a basic cross reference to an unnumbered formal block

--- a/lib/asciidoctor/abstract_block.rb
+++ b/lib/asciidoctor/abstract_block.rb
@@ -343,7 +343,7 @@ class AbstractBlock < AbstractNode
     if (val = reftext) && !val.empty?
       val
     # NOTE xrefstyle only applies to blocks with a title and a caption or number
-    elsif xrefstyle && @title && @caption
+    elsif xrefstyle && @title && !@caption.nil_or_empty?
       case xrefstyle
       when 'full'
         quoted_title = sub_placeholder (sub_quotes @document.compat_mode ? %q(``%s'') : '"`%s`"'), title


### PR DESCRIPTION
* ignore xrefstyle in this case