### PR TITLE
resolves #3827 defer use of Ruby >= 2.3 constructs to restore compatibility with Ruby 2.0

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -19,6 +19,10 @@ Bug Fixes::
 
   * Set type and target property on unresolved footnote reference and unset id property (fixes regression) (#3825)
 
+Compliance::
+
+  * Defer use of Ruby >= 2.3 constructs to restore compatibility with Ruby 2.0 until at least next minor release (#3827)
+
 // tag::compact[]
 == 2.0.11 (2020-11-02) - @mojavelinux
 

--- a/lib/asciidoctor/parser.rb
+++ b/lib/asciidoctor/parser.rb
@@ -2284,7 +2284,8 @@ class Parser
       table.has_header_option = true
     elsif skipped == 0 && !attributes['noheader-option']
       # NOTE: assume table has header until we know otherwise; if it doesn't (nil), cells in first row get reprocessed
-      table.has_header_option = implicit_header = true
+      table.has_header_option = :implicit
+      implicit_header = true
     end
     parser_ctx = Table::ParserContext.new table_reader, table, attributes
     format, loop_idx, implicit_header_boundary = parser_ctx.format, -1, nil
@@ -2393,7 +2394,7 @@ class Parser
     end
 
     table.assign_column_widths unless (table.attributes['colcount'] ||= table.columns.size) == 0 || explicit_colspecs
-    attributes['header-option'] = '' if implicit_header
+    table.has_header_option = true if implicit_header
     table.partition_header_footer attributes
 
     table

--- a/lib/asciidoctor/table.rb
+++ b/lib/asciidoctor/table.rb
@@ -78,10 +78,10 @@ class Table < AbstractBlock
     @attributes['orientation'] = 'landscape' if attributes['rotate-option']
   end
 
-  # Internal: Returns whether the current row being processed is
-  # the header row
+  # Internal: Returns the current state of the header option (true or :implicit) if
+  # the row being processed is (or is assumed to be) the header row, otherwise nil
   def header_row?
-    @has_header_option && @rows.body.empty?
+    (val = @has_header_option) && @rows.body.empty? ? val : nil
   end
 
   # Internal: Creates the Column objects from the column spec
@@ -239,10 +239,10 @@ class Table::Cell < AbstractBlock
     # NOTE: column is always set when parsing; may not be set when building table from the API
     if column
       if (in_header_row = column.table.header_row?)
-        if (cell_style = column.style || attributes&.[]('style')) == :asciidoc || cell_style == :literal
-          @reinitialize_args = [column, cell_text, attributes&.merge, opts]
+        if in_header_row == :implicit && (cell_style = column.style || (attributes && attributes['style']))
+          @reinitialize_args = [column, cell_text, attributes && attributes.merge, opts] if cell_style == :asciidoc || cell_style == :literal
+          cell_style = nil
         end
-        cell_style = nil
       else
         cell_style = column.style
       end


### PR DESCRIPTION
- although Ruby 2.0 is not supported, it was working through 2.0.10, and the change that broke it was unnecesary
- additionally, track implicit header row assumption until table parsing is complete to avoid unnecessary assignments