### PR TITLE
resolves #3829 fix crash when inlining an SVG if the explicit width or height value on image node is not a string

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -18,10 +18,12 @@ For a detailed view of what has changed, refer to the {uri-repo}/commits/master[
 Bug Fixes::
 
   * Set type and target property on unresolved footnote reference and unset id property (fixes regression) (#3825)
+  * Fix crash when inlining an SVG if the explicit width or height value on the image node is not a string (#3829)
 
 Compliance::
 
   * Defer use of Ruby >= 2.3 constructs to restore compatibility with Ruby 2.0 until at least next minor release (#3827)
+  * Don't append the default px unit identifier to the explicit width or height value when inlining an SVG (#3829)
 
 // tag::compact[]
 == 2.0.11 (2020-11-02) - @mojavelinux

--- a/lib/asciidoctor/converter/html5.rb
+++ b/lib/asciidoctor/converter/html5.rb
@@ -1268,17 +1268,13 @@ Your browser does not support the video tag.
       old_start_tag = new_start_tag = start_tag_match = nil
       # NOTE width, height and style attributes are removed if either width or height is specified
       ['width', 'height'].each do |dim|
-        if node.attr? dim
-          unless new_start_tag
-            next if (start_tag_match ||= (svg.match SvgStartTagRx) || :no_match) == :no_match
-            new_start_tag = (old_start_tag = start_tag_match[0]).gsub DimensionAttributeRx, ''
-          end
-          unless (dim_val = node.attr dim).end_with? '%'
-            # QUESTION should we add px since it's already the default?
-            dim_val += 'px'
-          end
-          new_start_tag = %(#{new_start_tag.chop} #{dim}="#{dim_val}">)
+        next unless node.attr? dim
+        unless new_start_tag
+          next if (start_tag_match ||= (svg.match SvgStartTagRx) || :no_match) == :no_match
+          new_start_tag = (old_start_tag = start_tag_match[0]).gsub DimensionAttributeRx, ''
         end
+        # NOTE a unitless value in HTML is assumed to be px, so we can pass the value straight through
+        new_start_tag = %(#{new_start_tag.chop} #{dim}="#{node.attr dim}">)
       end
       svg = %(#{new_start_tag}#{svg[old_start_tag.length..-1]}) if new_start_tag
     end

--- a/test/substitutions_test.rb
+++ b/test/substitutions_test.rb
@@ -728,15 +728,15 @@ context 'Substitutions' do
     test 'an image macro with an inline SVG image should be converted to an svg element' do
       para = block_from_string('image:circle.svg[Tiger,100,opts=inline]', safe: Asciidoctor::SafeMode::SERVER, attributes: { 'imagesdir' => 'fixtures', 'docdir' => testdir })
       result = para.sub_macros(para.source).gsub(/>\s+</, '><')
-      assert_match(/<svg\s[^>]*width="100px"[^>]*>/, result)
-      refute_match(/<svg\s[^>]*width="500px"[^>]*>/, result)
-      refute_match(/<svg\s[^>]*height="500px"[^>]*>/, result)
-      refute_match(/<svg\s[^>]*style="width:500px;height:500px"[^>]*>/, result)
+      assert_match(/<svg\s[^>]*width="100"[^>]*>/, result)
+      refute_match(/<svg\s[^>]*width="500"[^>]*>/, result)
+      refute_match(/<svg\s[^>]*height="500"[^>]*>/, result)
+      refute_match(/<svg\s[^>]*style="[^>]*>/, result)
     end
 
     test 'an image macro with an inline SVG image should be converted to an svg element even when data-uri is set' do
       para = block_from_string('image:circle.svg[Tiger,100,opts=inline]', safe: Asciidoctor::SafeMode::SERVER, attributes: { 'data-uri' => '', 'imagesdir' => 'fixtures', 'docdir' => testdir })
-      assert_match(/<svg\s[^>]*width="100px">/, para.sub_macros(para.source).gsub(/>\s+</, '><'))
+      assert_match(/<svg\s[^>]*width="100">/, para.sub_macros(para.source).gsub(/>\s+</, '><'))
     end
 
     test 'an image macro with an SVG image should not use an object element when safe mode is secure' do


### PR DESCRIPTION
- the width or height value could be coming from an extension, such as Asciidoctor Diagram