### PR TITLE
resolves #3550 run tests on JRuby for Windows in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest]
-        ruby: ['2.3', '2.4', '2.5', '2.6', '2.7', '3.0']
+        ruby: ['jruby-9.2.17.0', '2.3', '2.4', '2.5', '2.6', '2.7', '3.0']
         asciimath-version: [~]
         pygments-version: ['~> 2.0']
         rouge-version: [~]
@@ -33,8 +33,9 @@ jobs:
         - os: ubuntu-latest
           ruby: jruby-9.1.17.0
           pygments-version: ~
-        - os: ubuntu-latest
-          ruby: jruby-9.2.17.0
+        - os: windows-latest
+          ruby: jruby-9.1.17.0
+          pygments-version: ~
         - os: macos-latest
           ruby: '3.0'
         - os: ubuntu-latest

--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -15,10 +15,18 @@ For a detailed view of what has changed, refer to the {uri-repo}/commits/master[
 
 == Unreleased
 
-Improvments::
+Bug Fixes::
+
+ * Ensure mtime of input file honors TZ environment variable on JRuby for Windows (affects value of docdatetime attribute) (#3550)
+
+Improvements::
 
  * Increment counter (but not the corresponding attribute) if attribute is locked (#4013)
  * Use attribute as seed value for counter even if not already registered as a counter (#4014)
+
+Build / Infrastructure::
+
+ * Run tests on JRuby for Windows (#3550)
 
 // tag::compact[]
 == 2.0.13 (2021-04-10) - @mojavelinux

--- a/lib/asciidoctor/load.rb
+++ b/lib/asciidoctor/load.rb
@@ -53,7 +53,8 @@ module Asciidoctor
       end
 
       if ::File === input
-        options[:input_mtime] = input.mtime
+        # JRuby for Windows does not honor TZ environment value when reading mtime on IO; run it through ::Time.at to fix
+        options[:input_mtime] = RUBY_ENGINE == 'jruby' ? (::Time.at input.mtime.to_i) : input.mtime
         # NOTE defer setting infile and indir until we get a better sense of their purpose
         # TODO cli checks if input path can be read and is file, but might want to add check to API too
         attrs['docfile'] = input_path = ::File.absolute_path input.path

--- a/test/api_test.rb
+++ b/test/api_test.rb
@@ -84,7 +84,8 @@ context 'API' do
       assert_match(/reader\.rb.*prepare_lines/, exception.backtrace[0..4].join(?\n))
     end
 
-    test 'should convert filename that contains non-ASCII characters independent of default encodings' do
+    # NOTE JRuby for Windows does not permit creating a file with non-Windows-1252 characters in the filename
+    test 'should convert filename that contains non-ASCII characters independent of default encodings', unless: (jruby? && windows?) do
       old_external = Encoding.default_external
       old_internal = Encoding.default_internal
       old_verbose = $VERBOSE

--- a/test/invoker_test.rb
+++ b/test/invoker_test.rb
@@ -678,7 +678,7 @@ context 'Invoker' do
     assert_equal 'erubi', doc.instance_variable_get('@options')[:eruby]
   end
 
-  test 'should force default external encoding to UTF-8' do
+  test 'should force default external encoding to UTF-8', unless: jruby_9_1_windows? do
     input_path = fixture_path 'encoding.adoc'
     # using open3 to work around a bug in JRuby process_manager.rb,
     # which tries to run a gsub on stdout prematurely breaking the test
@@ -691,7 +691,7 @@ context 'Invoker' do
     assert_includes stdout_str, 'Codierungen sind verrückt auf älteren Versionen von Ruby'
   end
 
-  test 'should force stdio encoding to UTF-8' do
+  test 'should force stdio encoding to UTF-8', unless: jruby_9_1_windows? do
     cmd = asciidoctor_cmd ['-E', 'IBM866:IBM866']
     # NOTE configure-stdin.rb populates stdin
     result = run_command(cmd, '-r', (fixture_path 'configure-stdin.rb'), '-s', '-o', '-', '-') {|out| out.read }
@@ -702,7 +702,7 @@ context 'Invoker' do
     assert_include '<p>IBM866:IBM866</p>', result
   end
 
-  test 'should not fail to load if call to Dir.home fails' do
+  test 'should not fail to load if call to Dir.home fails', unless: jruby_9_1_windows? do
     cmd = asciidoctor_cmd ['-r', (fixture_path 'undef-dir-home.rb')]
     result = run_command(cmd, '-s', '-o', '-', (fixture_path 'basic.adoc')) {|out| out.read }
     assert_include 'Body content', result
@@ -721,7 +721,7 @@ context 'Invoker' do
     assert_match(/Total time/, error)
   end
 
-  test 'should show timezone as UTC if system TZ is set to UTC' do
+  test 'should show timezone as UTC if system TZ is set to UTC', unless: jruby_9_1_windows? do
     input_path = fixture_path 'doctime-localtime.adoc'
     output = run_command(asciidoctor_cmd, '-d', 'inline', '-o', '-', '-s', input_path, env: { 'TZ' => 'UTC', 'SOURCE_DATE_EPOCH' => nil, 'IGNORE_SOURCE_DATE_EPOCH' => '1' }) {|out| out.read }
     doctime, localtime = output.lines.map(&:chomp)
@@ -729,7 +729,7 @@ context 'Invoker' do
     assert localtime.end_with?(' UTC')
   end
 
-  test 'should show timezone as offset if system TZ is not set to UTC' do
+  test 'should show timezone as offset if system TZ is not set to UTC', unless: jruby_9_1_windows? do
     input_path = fixture_path 'doctime-localtime.adoc'
     output = run_command(asciidoctor_cmd, '-d', 'inline', '-o', '-', '-s', input_path, env: { 'TZ' => 'EST+5', 'SOURCE_DATE_EPOCH' => nil, 'IGNORE_SOURCE_DATE_EPOCH' => '1' }) {|out| out.read }
     doctime, localtime = output.lines.map(&:chomp)

--- a/test/syntax_highlighter_test.rb
+++ b/test/syntax_highlighter_test.rb
@@ -1095,7 +1095,7 @@ context 'Syntax Highlighter' do
       assert_includes css, 'background-color: #49483e;'
     end
 
-    test 'should not fail to load rouge if the Asciidoctor module is included into the global namespace' do
+    test 'should not fail to load rouge if the Asciidoctor module is included into the global namespace', unless: jruby_9_1_windows? do
       result = run_command(asciidoctor_cmd, '-r', (fixture_path 'include-asciidoctor.rb'), '-s', '-o', '-', '-a', 'source-highlighter=rouge', (fixture_path 'source-block.adoc'), use_bundler: true) {|out| out.read }
       assert_xpath '//pre[@class="rouge highlight"]', result, 1
     end


### PR DESCRIPTION
* run tests on JRuby 9.1 and 9.2 for Windows in CI
* don't run Pygments tests on JRuby 9.1 for Windows
* exclude tests that use run_command on JRuby 9.1 for Windows
* ensure mtime of input file honors TZ environment variable on JRuby for Windows