### PR TITLE
Add the 'horizontal' node.style similar to html5.rb

### DIFF
--- a/lib/asciidoctor/converter/html5.rb
+++ b/lib/asciidoctor/converter/html5.rb
@@ -554,14 +554,38 @@ Your browser does not support the audio tag.
       end
       node.items.each do |terms, dd|
         result << '<tr>'
-        result << %(<td class="hdlist1#{(node.option? 'strong') ? ' strong' : ''}">)
+
+        len=0 
+        labelspan=(node.attr 'labelspan').to_i
+        if(labelspan!=0)      
+          terms.each do |dt|  
+            termstr=dt.text
+            termstr.gsub!(/<[^>]+>/,'')
+            if(termstr.length>len)
+              len=termstr.length;
+            end
+          end
+
+          if(len<labelspan)
+            result << %(<td class="hdlist1#{(node.option? 'strong') ? ' strong' : ''}">)
+          else
+            result << %(<td class="hdlist2#{(node.option? 'strong') ? ' strong' : ''}"  colspan="2">)
+          end
+        else
+          result << %(<td class="hdlist1#{(node.option? 'strong') ? ' strong' : ''}">)
+        end
+
         first_term = true
         terms.each do |dt|
           result << %(<br#{slash}>) unless first_term
           result << dt.text
           first_term = nil
         end
-        result << '</td>'
+        if( (labelspan==0) || (len<labelspan) )
+          result << '</td>'
+        else
+          result << '</td></tr><tr><td></td>'
+        end
         result << '<td class="hdlist2">'
         if dd
           result << %(<p>#{dd.text}</p>) if dd.text?

--- a/lib/asciidoctor/converter/manpage.rb
+++ b/lib/asciidoctor/converter/manpage.rb
@@ -201,6 +201,9 @@ r lw(\n(.lu*75u/100u).'
         result << %(.sp
 #{counter}. #{manify terms.map {|dt| dt.text }.join ' '}
 .RS 4)
+      when 'horizontal'
+        result << %(.TP
+#{manify terms.map {|dt| dt.text }.join(', '), whitespace: :normalize})
       else
         result << %(.sp
 #{manify terms.map {|dt| dt.text }.join(', '), whitespace: :normalize}


### PR DESCRIPTION
Hi, 
This is a tiny patch to manpage.rb to get it on pare with html5.rb regarding dlist formating, i.e list of options, exit statis list etc....
I join a tiny `.ad` file here to demo the fix.

I am not fluent in ascidoctor development enough, to provide QA tests, neither I can fix the documentation thats seems to be behind de developement code, because I dicovered the `horizontal` style by reading the source code and find no evidence of it in the docco.

With this fix and `[horizontal]` placed in the `.ad` file I got this
rendering from man(1).

```
OPTIONS
       -s     short option name, doc start on the same line.

       -t     short option name, doc start on the same line yet continue to
              next line with some more usefull informations that can be safely
              ignored.

       -l, --long
              Long option name, doc start on the next line yet continue to
              next line with some more usefull informations that can be safely
              ignored.

EXIT STATUS
       0      Success.

       1      Failure (syntax or usage error; configuration error; document
              processing failure; unexpected error).

```
Cheers,
Phi
[man-short.txt](https://github.com/asciidoctor/asciidoctor/files/5603497/man-short.txt)


