### PR TITLE
resolves #3893 allow footnotes in footnotes

### DIFF
--- a/lib/asciidoctor/rx.rb
+++ b/lib/asciidoctor/rx.rb
@@ -469,7 +469,7 @@ module Asciidoctor
   #   footnoteref:[id,text] (legacy)
   #   footnoteref:[id] (legacy)
   #
-  InlineFootnoteMacroRx = /\\?footnote(?:(ref):|:([#{CC_WORD}-]+)?)\[(?:|(#{CC_ALL}*?[^\\]))\](?!<\/a>)/m
+  InlineFootnoteMacroRx = /\\?footnote(?:(ref):|:([#{CC_WORD}-]+)?)\[(?:|((([^\]]|\\\])*\g<0>)?#{CC_ALL}*?[^\\]))\](?!<\/a>)/m
 
   # Matches an image or icon inline macro.
   #

--- a/test/substitutions_test.rb
+++ b/test/substitutions_test.rb
@@ -2298,5 +2298,35 @@ context 'Substitutions' do
       block.commit_subs
       assert_equal [:specialcharacters, :quotes, :attributes, :replacements, :macros, :post_replacements], block.subs
     end
+
+    test 'should parse footnote inside footnote' do
+      para = block_from_string('Sentence text footnote:[An examplefootnote:[Footnote to footnote.] footnote.].')
+      assert_equal %(Sentence text <sup class="footnote">[<a id="_footnoteref_1" class="footnote" href="#_footnotedef_1" title="View footnote.">1</a>]</sup>.), para.sub_macros(para.source)
+      assert_equal 2, para.document.catalog[:footnotes].size
+      footnote = para.document.catalog[:footnotes][0]
+      assert_equal 1, footnote.index
+      assert_nil footnote.id
+      assert_equal 'An example<sup class="footnote">[<a id="_footnoteref_2" class="footnote" href="#_footnotedef_2" title="View footnote.">2</a>]</sup> footnote.', footnote.text
+
+      footnote = para.document.catalog[:footnotes][1]
+      assert_equal 2, footnote.index
+      assert_nil footnote.id
+      assert_equal 'Footnote to footnote.', footnote.text
+    end
+
+    test 'should accept escaped square bracket before footnote inside footnote' do
+      para = block_from_string('Sentence text footnote:[An \] examplefootnote:[Footnote to footnote.] footnote.].')
+      assert_equal %(Sentence text <sup class="footnote">[<a id="_footnoteref_1" class="footnote" href="#_footnotedef_1" title="View footnote.">1</a>]</sup>.), para.sub_macros(para.source)
+      assert_equal 2, para.document.catalog[:footnotes].size
+      footnote = para.document.catalog[:footnotes][0]
+      assert_equal 1, footnote.index
+      assert_nil footnote.id
+      assert_equal 'An ] example<sup class="footnote">[<a id="_footnoteref_2" class="footnote" href="#_footnotedef_2" title="View footnote.">2</a>]</sup> footnote.', footnote.text
+
+      footnote = para.document.catalog[:footnotes][1]
+      assert_equal 2, footnote.index
+      assert_nil footnote.id
+      assert_equal 'Footnote to footnote.', footnote.text
+    end
   end
 end


### PR DESCRIPTION
I've tryed my best at following `CONTRIBUTING.adoc`, but I have no experience with Ruby and ascidoctor code.

Details:

* Add 2 tests: basic support of footnotes in footnotes
  and support for escaped ]
* Change InlineFootnoteMacroRx so that it allows recursive footnotes
* Move footnote processing code from sub_macros to separate function
  sub_footnote, call it recursively on matches. It is important not
  to call sub_macros recursively as this results to multiple expansion
  of some macros (e.g. URL)