### PR TITLE
speedup CI by using Bundler cache

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,22 +53,6 @@ jobs:
     steps:
     - name: Checkout
       uses: actions/checkout@v2
-    - name: Install Ruby
-      uses: ruby/setup-ruby@v1
-      with:
-        ruby-version: ${{ matrix.ruby }}
-    - name: Configure Bundler
-      run: |
-        bundle config --local path .bundle/gems
-        bundle config --local without docs
-    - name: Configure Nokogiri installation (Linux)
-      if: matrix.os == 'ubuntu-latest'
-      run: |
-        bundle config --local build__nokogiri --use-system-libraries
-        sudo apt-get install libxslt1-dev
-    - name: Configure Nokogiri installation (macOS)
-      if: matrix.os == 'macos-latest'
-      run: bundle config --local build__nokogiri --use-system-libraries
     - name: Set AsciiMath version
       if: matrix.asciimath-version
       run: echo 'ASCIIMATH_VERSION=${{ matrix.asciimath-version }}' >> $GITHUB_ENV
@@ -78,8 +62,20 @@ jobs:
     - name: Set Rouge version
       if: matrix.rouge-version
       run: echo 'ROUGE_VERSION=${{ matrix.rouge-version }}' >> $GITHUB_ENV
-    - name: Install dependencies
-      run: bundle --jobs 3 --retry 3
+    - name: Install libxslt for Nokogiri (Linux)
+      if: matrix.os == 'ubuntu-latest'
+      run: sudo apt-get install libxslt1-dev
+    - name: Install Ruby
+      uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: ${{ matrix.ruby }}
+        bundler-cache: ${{ github.event_name != 'schedule' }}
+    - name: Install dependencies without cache
+      if: github.event_name == 'schedule'
+      shell: bash
+      run: |
+        bundle config --local path vendor/bundle
+        bundle install --jobs 4
     - name: Run tests
       run: bundle exec ruby -w $(bundle exec ruby -e 'print File.join Gem.bindir, %q(rake)') test:all
     - name: Build dependents

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,10 +49,17 @@ jobs:
     runs-on: ${{ matrix.os }}
     env:
       COVERAGE: ${{ matrix.primary }}
+      BUNDLE_WITHOUT: docs
       SOURCE_DATE_EPOCH: '1521504000'
     steps:
     - name: Checkout
       uses: actions/checkout@v2
+    - name: Install prerequisites for Nokogiri (Linux)
+      if: matrix.os == 'ubuntu-latest'
+      run: sudo apt-get install libxslt1-dev
+    - name: Configure Nokogiri installation (Linux, macOS)
+      if: matrix.os == 'macos-latest' || matrix.os == 'ubuntu-latest'
+      run: echo 'BUNDLE_BUILD__NOKOGIRI=--use-system-libraries' >> $GITHUB_ENV
     - name: Set AsciiMath version
       if: matrix.asciimath-version
       run: echo 'ASCIIMATH_VERSION=${{ matrix.asciimath-version }}' >> $GITHUB_ENV
@@ -62,20 +69,16 @@ jobs:
     - name: Set Rouge version
       if: matrix.rouge-version
       run: echo 'ROUGE_VERSION=${{ matrix.rouge-version }}' >> $GITHUB_ENV
-    - name: Install libxslt for Nokogiri (Linux)
-      if: matrix.os == 'ubuntu-latest'
-      run: sudo apt-get install libxslt1-dev
-    - name: Install Ruby
+    - name: Install Ruby (uses cached dependencies for non-scheduled build)
       uses: ruby/setup-ruby@v1
       with:
         ruby-version: ${{ matrix.ruby }}
         bundler-cache: ${{ github.event_name != 'schedule' }}
-    - name: Install dependencies without cache
+    - name: Install dependencies (scheduled build only)
       if: github.event_name == 'schedule'
-      shell: bash
       run: |
-        bundle config --local path vendor/bundle
-        bundle install --jobs 4
+        bundle config --local path .bundle/gems
+        bundle --jobs 3 --retry 3
     - name: Run tests
       run: bundle exec ruby -w $(bundle exec ruby -e 'print File.join Gem.bindir, %q(rake)') test:all
     - name: Build dependents


### PR DESCRIPTION
Before: 40s to install Ruby + Bundler and [around 9.5-10 min for bundle install on Windows + Ruby 3.0](https://github.com/asciidoctor/asciidoctor/runs/1635368583?check_suite_focus=true#step:10:1) (slowest platform currently, not sure why. Does it build libxslt from sources for Nokogiri instead of using prebuilt binary?)

After: [around 50s for Ruby + Bundler + bundle install combined on Windows + Ruby 3.0](https://github.com/slonopotamus/asciidoctor/runs/1637276403?check_suite_focus=true#step:7:1)

I'm not 100% happy with this change because we lose ability to do custom `bundle config` before installing deps, but benefits are pretty huge. @eregon do you want a feature request for this?