### PR TITLE
Correct extension registry errors in options.adoc

### DIFF
--- a/docs/modules/api/pages/options.adoc
+++ b/docs/modules/api/pages/options.adoc
@@ -57,8 +57,8 @@ _(Experimental)._
 |_not set_
 |A Ruby block that conforms to the Asciidoctor extensions API (the same code that would be passed to the `Extensions.register` method).
 
-|`:extensions_registry`
-|Overrides the xref:extensions:register.adoc[extensions registry] instance.
+|`:extension_registry`
+|Overrides the extensions registry instance.
 Instead of providing a Ruby block containing extensions to register, this option lets you replace the extension registry itself, giving you complete control over how extensions are registered for this processor.
 |_not set_
 |`Extensions::Registry` instance


### PR DESCRIPTION
- correct symbol is `:extension_registry`
- there is no current documentation of the extension registry.  I'm working on it.