### PR TITLE
Docs: add a pandoc command using docker and update command.

### DIFF
--- a/docs/modules/migrate/pages/ms-word.adoc
+++ b/docs/modules/migrate/pages/ms-word.adoc
@@ -16,10 +16,19 @@ However, in this case, it's a good choice.
 
 To perform the conversion from MS Word docx to AsciiDoc, you need to perform the following command:
 
+.pandoc < 2.11.2
+ 
+ $ pandoc --from=docx --to=asciidoc --wrap=none --atx-headers \
+     --extract-media=extracted-media input.docx > output.adoc
+ 
+.pandoc (2.11.2 or newer)
+ 
  $ pandoc input.docx -f docx -t asciidoc --wrap=none --markdown-headings=atx \                                                                             
     --extract-media=extracted-media  -o output2.adoc
-     
-If you use docker you can also use pandoc with docker without installing it:
+
+.pandoc (2.11.2 or newer) and docker
+
+If you use docker you can also use the latest version of pandoc with docker without installing it:
 
  $ docker run --rm --volume "`pwd`:/data" --user `id -u`:`id -g` pandoc/core input.docx -f docx \
  -t asciidoc --wrap=none --markdown-headings=atx --extract-media=extracted-media  -o output2.adoc

--- a/docs/modules/migrate/pages/ms-word.adoc
+++ b/docs/modules/migrate/pages/ms-word.adoc
@@ -23,11 +23,6 @@ If you use docker you can also use pandoc with docker without installing it:
 
  $ docker run --rm --volume "`pwd`:/data" --user `id -u`:`id -g` pandoc/core input.docx -f docx \
  -t asciidoc --wrap=none --markdown-headings=atx --extract-media=extracted-media  -o output2.adoc
-    
-or simply running the following as pandoc should recognize the input and output format from the extensions
-
- $ docker run --rm --volume "`pwd`:/data" --user `id -u`:`id -g` pandoc/core input.docx -o output.adoc
-
 
 Then, edit the output file to tidy it up.
 

--- a/docs/modules/migrate/pages/ms-word.adoc
+++ b/docs/modules/migrate/pages/ms-word.adoc
@@ -16,8 +16,18 @@ However, in this case, it's a good choice.
 
 To perform the conversion from MS Word docx to AsciiDoc, you need to perform the following command:
 
- $ pandoc --from=docx --to=asciidoc --wrap=none --atx-headers \
-     --extract-media=extracted-media input.docx > output.adoc
+ $ pandoc input.docx -f docx -t asciidoc --wrap=none --markdown-headings=atx \                                                                             
+    --extract-media=extracted-media  -o output2.adoc
+     
+If you use docker you can also use pandoc with docker without installing it:
+
+ $ docker run --rm --volume "`pwd`:/data" --user `id -u`:`id -g` pandoc/core input.docx -f docx \
+ -t asciidoc --wrap=none --markdown-headings=atx --extract-media=extracted-media  -o output2.adoc
+    
+or simply running the following as pandoc should recognize the input and output format from the extensions
+
+ $ docker run --rm --volume "`pwd`:/data" --user `id -u`:`id -g` pandoc/core input.docx -o output.adoc
+
 
 Then, edit the output file to tidy it up.
 


### PR DESCRIPTION
- Update pandoc command by removing deprecated --atx-headers. Use --markdown-headings=atx instead.
- Add pandoc command with docker to be able to use pandoc without installing it.
- Update pandoc command in general to work with the latest version as in https://pandoc.org/getting-started.html#step-6-converting-a-file