### PR TITLE
Deeper section numbers

### DIFF
--- a/lib/asciidoctor/converter/html5.rb
+++ b/lib/asciidoctor/converter/html5.rb
@@ -417,7 +417,7 @@ MathJax.Hub.Register.StartupHook("AsciiMath Jax Ready", function () {
 #{node.content})
     else
       %(<div class="sect#{level}#{(role = node.role) ? " #{role}" : ''}">
-<h#{level + 1}#{id_attr}>#{title}</h#{level + 1}>
+<h#{[level + 1, 6].min}#{id_attr}>#{title}</h#{[level + 1, 6].min}>
 #{level == 1 ? %[<div class="sectionbody">
 #{node.content}
 </div>] : node.content}

--- a/lib/asciidoctor/rx.rb
+++ b/lib/asciidoctor/rx.rb
@@ -1,3 +1,4 @@
+# coding: utf-8
 module Asciidoctor
   # A collection of regular expression constants used by the parser. (For speed, these are not defined in the Rx module,
   # but rather directly in the Asciidoctor module).
@@ -236,10 +237,10 @@ module Asciidoctor
   #   == Foo ==
   #   // ^ also a level 1 (h2) section title
   #
-  AtxSectionTitleRx = /^(=={0,5})[ \t]+(#{CC_ANY}+?)(?:[ \t]+\1)?$/
+  AtxSectionTitleRx = /^(=={0,8})[ \t]+(#{CC_ANY}+?)(?:[ \t]+\1)?$/
 
   # Matches an extended Atx section title that includes support for the Markdown variant.
-  ExtAtxSectionTitleRx = /^(=={0,5}|#\#{0,5})[ \t]+(#{CC_ANY}+?)(?:[ \t]+\1)?$/
+  ExtAtxSectionTitleRx = /^(=={0,8}|#\#{0,8})[ \t]+(#{CC_ANY}+?)(?:[ \t]+\1)?$/
 
   # Matches the title only (first line) of an Setext (two-line) section title.
   # The title cannot begin with a dot and must have at least one alphanumeric character.


### PR DESCRIPTION
Extend the section depth to 8. Cap the HTML5 converter to translate
all finer headers to `<h6>`

Partially addresses #3358 