### PR TITLE
ref #2749 distinguish title and subtitle

### DIFF
--- a/lib/asciidoctor/converter/semantic-html5.rb
+++ b/lib/asciidoctor/converter/semantic-html5.rb
@@ -12,7 +12,12 @@ class Converter::SemanticHtml5Converter < Converter::Base
   end
 
   def convert_embedded node
-    node.content
+    result = []
+    if (header = generate_header node)
+      result << header
+    end
+    result << node.content
+    result.join LF
   end
 
   def convert_paragraph node
@@ -26,6 +31,25 @@ class Converter::SemanticHtml5Converter < Converter::Base
       %(<p#{attributes}>
 #{node.content}
 </p>)
+    end
+  end
+
+  def generate_header node
+    if node.header? && !node.noheader
+      result = ['<header>']
+      if (doctitle = generate_document_title node)
+        result << doctitle
+      end
+      result << '</header>'
+      result.join LF
+    end
+  end
+
+  def generate_document_title node
+    unless node.notitle
+      doctitle = node.doctitle partition: true, sanitize: true
+      attributes = common_html_attributes node.id, node.role
+      %(<h1#{attributes}>#{doctitle.main}#{doctitle.subtitle? ? %( <small class="subtitle">#{doctitle.subtitle}</small>) : ''}</h1>)
     end
   end
 

--- a/test/fixtures/semantic-html5-scenarios/document-title-subtitle.adoc
+++ b/test/fixtures/semantic-html5-scenarios/document-title-subtitle.adoc
@@ -1,0 +1,2 @@
+= Document Title: Subtitle
+:showtitle:

--- a/test/fixtures/semantic-html5-scenarios/document-title-subtitle.html
+++ b/test/fixtures/semantic-html5-scenarios/document-title-subtitle.html
@@ -1,0 +1,3 @@
+<header>
+<h1>Document Title <small class="subtitle">Subtitle</small></h1>
+</header>

--- a/test/fixtures/semantic-html5-scenarios/document-title-with-id-roles.adoc
+++ b/test/fixtures/semantic-html5-scenarios/document-title-with-id-roles.adoc
@@ -1,0 +1,3 @@
+[#start.dummy]
+= Document Title
+:showtitle:

--- a/test/fixtures/semantic-html5-scenarios/document-title-with-id-roles.html
+++ b/test/fixtures/semantic-html5-scenarios/document-title-with-id-roles.html
@@ -1,0 +1,3 @@
+<header>
+<h1 id="start" class="dummy">Document Title</h1>
+</header>

--- a/test/fixtures/semantic-html5-scenarios/document-title-with-id.adoc
+++ b/test/fixtures/semantic-html5-scenarios/document-title-with-id.adoc
@@ -1,0 +1,3 @@
+[#start]
+= Document Title
+:showtitle:

--- a/test/fixtures/semantic-html5-scenarios/document-title-with-id.html
+++ b/test/fixtures/semantic-html5-scenarios/document-title-with-id.html
@@ -1,0 +1,3 @@
+<header>
+<h1 id="start">Document Title</h1>
+</header>

--- a/test/fixtures/semantic-html5-scenarios/document-title-with-notitle.adoc
+++ b/test/fixtures/semantic-html5-scenarios/document-title-with-notitle.adoc
@@ -1,0 +1,2 @@
+= Document Title
+:notitle:

--- a/test/fixtures/semantic-html5-scenarios/document-title-with-notitle.html
+++ b/test/fixtures/semantic-html5-scenarios/document-title-with-notitle.html
@@ -1,0 +1,2 @@
+<header>
+</header>

--- a/test/fixtures/semantic-html5-scenarios/document-title.adoc
+++ b/test/fixtures/semantic-html5-scenarios/document-title.adoc
@@ -1,0 +1,2 @@
+= Document Title
+:showtitle:

--- a/test/fixtures/semantic-html5-scenarios/document-title.html
+++ b/test/fixtures/semantic-html5-scenarios/document-title.html
@@ -1,0 +1,3 @@
+<header>
+<h1>Document Title</h1>
+</header>

--- a/test/semantic_html5_converter_test.rb
+++ b/test/semantic_html5_converter_test.rb
@@ -10,7 +10,7 @@ context 'Semantic HTML 5 converter' do
     test scenario_name do
       input = IO.read input_filename, mode: 'r:UTF-8', newline: :universal
       expected = (IO.read output_filename, mode: 'r:UTF-8', newline: :universal).chomp
-      result = (convert_string_to_embedded input, backend: 'semantic-html5')
+      result = (convert_string_to_embedded input, backend: 'semantic-html5').chomp
       assert_equal expected, result
     end
   end


### PR DESCRIPTION
### What I did

* Introduce a method to generate the header
* Introduce a method to generate the document title (title + subtitle)
* Generate a *simplified header* that includes the document title + subtitle on the embedded output

### Limitations

The implementation is *deliberately* incomplete to make it easier to review.
A more complete header will be implemented as part of https://github.com/asciidoctor/asciidoctor/issues/3967


### Open Questions

#### generate methods

Currently, `generate_*` methods can return `nil`.
More specifically, `generate_header` returns `nil` when `noheader` attribute is defined or when there's no header block. Similarly, `generate_document_title` returns `nil` when `notitle` attribute is defined.

Should we move conditions outside of these methods?

```rb
def generate_document_title node
  doctitle = node.doctitle partition: true, sanitize: true
  attributes = common_html_attributes node.id, node.role
  %(<h1#{attributes}>#{doctitle.main}#{doctitle.subtitle? ? %( <small class="subtitle">#{doctitle.subtitle}</small>) : ''}</h1>)
end
```

If not, should we return empty instead of `nil`? My understanding is that returning `nil` is (somehow) more idiomatic Ruby?

#### Roles and id

It's possible to assign and id (and roles!) to a document title.

```
[#start.dummy]
= Document Title
```

Currently, the converter will produce:

```html
<header>
<h1 id="start" class="dummy">Document Title</h1>
</header>
```

I wonder if we should assign roles to the parent element (i.e., in this case the `<header>` element)? And, more broadly, should we define a rule to make it consistent and predictable? 

ref #242