### PR TITLE
resolves #3994 fix instructions for Confluence XHTML migration

### DIFF
--- a/docs/modules/migrate/pages/confluence-xhtml.adoc
+++ b/docs/modules/migrate/pages/confluence-xhtml.adoc
@@ -24,6 +24,6 @@ The script is designed to be run locally on HTML files or directories containing
 . Save the script contents to a `convert.groovy` file in a working directory.
 . Make the file executable according to your specific OS requirements.
 . Create a `html` directory for input files and a `asciidoc` directory for output files, both inside the working directory.
-. Place individual files, or a directory containing files into the aforementioned `html` directory.
+. Place individual files, or a directory containing files, into the aforementioned `html` directory.
 . Run `groovy convert` to convert the files contained inside the `html` directory.
 . Confirm the output file located in the `asciidoc` directory meets requirements.

--- a/docs/modules/migrate/pages/confluence-xhtml.adoc
+++ b/docs/modules/migrate/pages/confluence-xhtml.adoc
@@ -26,4 +26,4 @@ The script is designed to be run locally on HTML files or directories containing
 . Create a `html` directory for input files and a `asciidoc` directory for output files, both inside the working directory.
 . Place individual files, or a directory containing files, into the aforementioned `html` directory.
 . Run `groovy convert` to convert the files contained inside the `html` directory.
-. Confirm the output file located in the `asciidoc` directory meets requirements.
+. Look for the generated output file in the `asciidoc` directory and confirm it meets your requirements.

--- a/docs/modules/migrate/pages/confluence-xhtml.adoc
+++ b/docs/modules/migrate/pages/confluence-xhtml.adoc
@@ -23,7 +23,7 @@ The script is designed to be run locally on HTML files or directories containing
 
 . Save the script contents to a `convert.groovy` file in a working directory.
 . Make the file executable according to your specific OS requirements.
-. Place individual files, or a directory containing files into the working directory.
-. Run `groovy convert filename.html` to convert a single file.
-. Confirm the output file meets requirements
-. Recurse through a directory by using this command pattern: `groovy convert directory/*.html`
+. Create a `html` directory for input files and a `asciidoc` directory for output files, both inside the working directory.
+. Place individual files, or a directory containing files into the aforementioned `html` directory.
+. Run `groovy convert` to convert the files contained inside the `html` directory.
+. Confirm the output file located in the `asciidoc` directory meets requirements.

--- a/docs/modules/migrate/pages/confluence-xhtml.adoc
+++ b/docs/modules/migrate/pages/confluence-xhtml.adoc
@@ -23,7 +23,7 @@ The script is designed to be run locally on HTML files or directories containing
 
 . Save the script contents to a `convert.groovy` file in a working directory.
 . Make the file executable according to your specific OS requirements.
-. Create a `html` directory for input files and a `asciidoc` directory for output files, both inside the working directory.
+. Create an `html` directory for input files and an `asciidoc` directory for output files, both inside the working directory.
 . Place individual files, or a directory containing files, into the aforementioned `html` directory.
 . Run `groovy convert` to convert the files contained inside the `html` directory.
 . Look for the generated output file in the `asciidoc` directory and confirm it meets your requirements.


### PR DESCRIPTION
Fixes #3994 by modifying the instructions to match actual behavior of the provided groovy script.
Previous instructions were describing a behavior inconsistent with the groovy script provided. 
I've chosen to not change at all the script, only adapt the intructions for them to work.