### PR TITLE
resolves #3997 rollback change for #3470; skip empty lines before processing document header instead

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -19,6 +19,7 @@ Bug Fixes::
 
   * Don't allow counter and counter2 attribute directives to override locked attributes (#3939)
   * Fix crash when resolving next value in sequence for counter with non-numeric value (#3940)
+  * Rollback change for #3470, which added logic to remove leading and trailing empty lines in an AsciiDoc include file; instead skip empty lines before processing document header (#3997)
   * Update default stylesheet to remove dash in front of cite on nested quote block (#3847)
   * Don't escape hyphen in manname in man page output
   * Remove extra .sp before content of verse block in man page output

--- a/lib/asciidoctor/parser.rb
+++ b/lib/asciidoctor/parser.rb
@@ -119,7 +119,7 @@ class Parser
   # returns the Hash of orphan block attributes captured above the header
   def self.parse_document_header(reader, document)
     # capture lines of block-level metadata and plow away comment lines that precede first block
-    block_attrs = parse_block_metadata_lines reader, document
+    block_attrs = reader.skip_blank_lines ? (parse_block_metadata_lines reader, document) : {}
     doc_attrs = document.attributes
 
     # special case, block title is not allowed above document title,

--- a/lib/asciidoctor/reader.rb
+++ b/lib/asciidoctor/reader.rb
@@ -44,11 +44,11 @@ class Reader
       @file = nil
       @dir = '.'
       @path = '<stdin>'
-      @lineno = 1 # IMPORTANT lineno assignment must proceed prepare_lines call!
+      @lineno = 1
     elsif ::String === cursor
       @file = cursor
       @dir, @path = ::File.split @file
-      @lineno = 1 # IMPORTANT lineno assignment must proceed prepare_lines call!
+      @lineno = 1
     else
       if (@file = cursor.file)
         @dir = cursor.dir || (::File.dirname @file)
@@ -57,7 +57,7 @@ class Reader
         @dir = cursor.dir || '.'
         @path = cursor.path || '<stdin>'
       end
-      @lineno = cursor.lineno || 1 # IMPORTANT lineno assignment must proceed prepare_lines call!
+      @lineno = cursor.lineno || 1
     end
     @lines = prepare_lines data, opts
     @source_lines = @lines.drop 0
@@ -718,7 +718,7 @@ class PreprocessorReader < Reader
     end
 
     # effectively fill the buffer
-    if (@lines = prepare_lines data, normalize: @process_lines || :chomp, condense: @process_lines, indent: attributes['indent']).empty?
+    if (@lines = prepare_lines data, normalize: @process_lines || :chomp, condense: false, indent: attributes['indent']).empty?
       pop_include
     else
       # FIXME we eventually want to handle leveloffset without affecting the lines
@@ -809,7 +809,6 @@ class PreprocessorReader < Reader
     end
 
     if opts.fetch :condense, true
-      result.shift && @lineno += 1 while (first = result[0]) && first.empty?
       result.pop while (last = result[-1]) && last.empty?
     end
 

--- a/test/document_test.rb
+++ b/test/document_test.rb
@@ -705,6 +705,41 @@ context 'Document' do
 
     test 'should recognize document title when preceded by blank lines' do
       input = <<~'EOS'
+
+      = Title
+
+      preamble
+
+      == Section 1
+
+      text
+      EOS
+      output = convert_string input, safe: Asciidoctor::SafeMode::SAFE
+      assert_css '#header h1', output, 1
+      assert_css '#content h1', output, 0
+    end
+
+    test 'should recognize document title when preceded by blank lines introduced by a preprocessor conditional' do
+      input = <<~'EOS'
+      ifdef::sectids[]
+
+      :foo: bar
+      endif::[]
+      = Title
+
+      preamble
+
+      == Section 1
+
+      text
+      EOS
+      output = convert_string input, safe: Asciidoctor::SafeMode::SAFE
+      assert_css '#header h1', output, 1
+      assert_css '#content h1', output, 0
+    end
+
+    test 'should recognize document title when preceded by blank lines after an attribute entry' do
+      input = <<~'EOS'
       :doctype: book
 
       = Title

--- a/test/reader_test.rb
+++ b/test/reader_test.rb
@@ -454,7 +454,7 @@ class ReaderTest < Minitest::Test
         data.push ''
         doc = Asciidoctor::Document.new data
         reader = doc.reader
-        assert_equal SAMPLE_DATA, reader.lines
+        assert_equal [''] + SAMPLE_DATA, reader.lines
       end
 
       test 'should prepare and normalize lines from String data' do
@@ -464,7 +464,14 @@ class ReaderTest < Minitest::Test
         data_as_string = data * ::Asciidoctor::LF
         doc = Asciidoctor::Document.new data_as_string
         reader = doc.reader
-        assert_equal SAMPLE_DATA, reader.lines
+        assert_equal [''] + SAMPLE_DATA, reader.lines
+      end
+
+      test 'should drop all lines if all lines are empty' do
+        data = ['', ' ', '', ' ']
+        doc = Asciidoctor::Document.new data
+        reader = doc.reader
+        assert reader.lines.empty?
       end
 
       test 'should clean CRLF from end of lines' do


### PR DESCRIPTION
* don't drop leading and trailing empty lines in AsciiDoc include file
* skip empty lines before processing document header
* don't drop leading empty lines in main AsciiDoc file (defer until processing the document header)