### PR TITLE
resolves #4013 increment counter even if attribute is locked

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -13,6 +13,13 @@ endif::[]
 This document provides a high-level view of the changes introduced in Asciidoctor by release.
 For a detailed view of what has changed, refer to the {uri-repo}/commits/master[commit history] on GitHub.
 
+== Unreleased
+
+Improvments::
+
+ * Increment counter (but not the corresponding attribute) if attribute is locked (#4013)
+ * Use attribute as seed value for counter even if not already registered as a counter (#4014)
+
 // tag::compact[]
 == 2.0.13 (2021-04-10) - @mojavelinux
 

--- a/lib/asciidoctor/document.rb
+++ b/lib/asciidoctor/document.rb
@@ -562,15 +562,17 @@ class Document < AbstractBlock
   # returns the next number in the sequence for the specified counter
   def counter name, seed = nil
     return @parent_document.counter name, seed if @parent_document
-    if attribute_locked? name
-      @attributes[name]
-    elsif (attr_seed = !(attr_val = @attributes[name]).nil_or_empty?) && (@counters.key? name)
-      @attributes[name] = @counters[name] = Helpers.nextval attr_val
+    if (locked = attribute_locked? name) && (curr_val = @counters[name])
+      next_val = @counters[name] = Helpers.nextval curr_val
+    elsif !(curr_val = @attributes[name]).nil_or_empty?
+      next_val = @counters[name] = Helpers.nextval curr_val
     elsif seed
-      @attributes[name] = @counters[name] = seed == seed.to_i.to_s ? seed.to_i : seed
+      next_val = @counters[name] = seed == seed.to_i.to_s ? seed.to_i : seed
     else
-      @attributes[name] = @counters[name] = Helpers.nextval attr_seed ? attr_val : 0
+      next_val = @counters[name] = 1
     end
+    @attributes[name] = next_val unless locked
+    next_val
   end
 
   # Public: Increment the specified counter and store it in the block's attributes

--- a/test/attributes_test.rb
+++ b/test/attributes_test.rb
@@ -1227,16 +1227,16 @@ context 'Attributes' do
 
     test 'should not allow counter to modify locked attribute' do
       input = <<~'EOS'
-      {counter:foo:baz} is still {foo}
+      {counter:foo:ignored} is not {foo}
       EOS
 
       output = convert_string_to_embedded input, :attributes => { 'foo' => 'bar' }
-      assert_xpath '//p[text()="bar is still bar"]', output, 1
+      assert_xpath '//p[text()="bas is not bar"]', output, 1
     end
 
     test 'should not allow counter2 to modify locked attribute' do
       input = <<~'EOS'
-      {counter2:foo:baz}{foo}
+      {counter2:foo:ignored}{foo}
       EOS
 
       output = convert_string_to_embedded input, :attributes => { 'foo' => 'bar' }
@@ -1245,12 +1245,12 @@ context 'Attributes' do
 
     test 'should not allow counter to modify built-in locked attribute' do
       input = <<~'EOS'
-      {counter:max-include-depth:128} is still {max-include-depth}
+      {counter:max-include-depth:128} is one more than {max-include-depth}
       EOS
 
       doc = document_from_string input, standalone: false
       output = doc.convert
-      assert_xpath '//p[text()="64 is still 64"]', output, 1
+      assert_xpath '//p[text()="65 is one more than 64"]', output, 1
       assert_equal 64, doc.attributes['max-include-depth']
     end
 

--- a/test/blocks_test.rb
+++ b/test/blocks_test.rb
@@ -804,6 +804,30 @@ context 'Blocks' do
       assert_equal 'B', doc.attributes['example-number']
     end
 
+    test 'should increment counter for example even when example-number is locked by the API' do
+      input = <<~'EOS'
+      .Writing Docs with AsciiDoc
+      ====
+      Here's how you write AsciiDoc.
+
+      You just write.
+      ====
+
+      .Writing Docs with DocBook
+      ====
+      Here's how you write DocBook.
+
+      You futz with XML.
+      ====
+      EOS
+
+      doc = document_from_string input, attributes: { 'example-number' => '`' }
+      output = doc.convert
+      assert_xpath '(//*[@class="exampleblock"])[1]/*[@class="title"][text()="Example a. Writing Docs with AsciiDoc"]', output, 1
+      assert_xpath '(//*[@class="exampleblock"])[2]/*[@class="title"][text()="Example b. Writing Docs with DocBook"]', output, 1
+      assert_equal 'b', doc.attributes['example-number']
+    end
+
     test "explicit caption is used if provided" do
       input = <<~'EOS'
       [caption="Look! "]

--- a/test/sections_test.rb
+++ b/test/sections_test.rb
@@ -1624,7 +1624,7 @@ context 'Sections' do
       :doctype: book
       :sectnums:
       :chapter-signifier: Chapter
-      :chapter-number: {counter:chapter-number:9}
+      :chapter-number: 9
 
       == Not the Beginning
 
@@ -2048,7 +2048,7 @@ context 'Sections' do
 
     test 'should allow appendix number to be controlled using appendix-number attribute' do
       input = <<~'EOS'
-      :appendix-number: {counter:appendix-number:α}
+      :appendix-number: α
 
       [appendix]
       == Attribute Options


### PR DESCRIPTION
resolves #4013 increment counter (but not the corresponding attribute) if attribute is locked

also resolves #4014 use attribute as seed value for counter even if not already registered as a counter