### PR TITLE
resolves #4024 suppress missing attribute warning when processing value for doctitle attribute

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -22,6 +22,7 @@ Bug Fixes::
   * Allow showtitle/notitle to be toggled in AsciiDoc table cell if set in parent document (#4018)
   * Ensure mtime of input file honors TZ environment variable on JRuby for Windows (affects value of docdatetime attribute) (#3550)
   * Honor caption attribute on blocks that support captioned title even if corresponding *-caption document attribute is not set (#4023)
+  * Suppress missing attribute warning when applying substitutions to implicit document title to assign to doctitle attribute (#4024)
 
 Improvements::
 

--- a/lib/asciidoctor/parser.rb
+++ b/lib/asciidoctor/parser.rb
@@ -144,7 +144,10 @@ class Parser
         l0_section_title = nil
       else
         document.title = l0_section_title
-        doc_attrs['doctitle'] = doctitle_attr_val = document.apply_header_subs l0_section_title
+        if (doc_attrs['doctitle'] = doctitle_attr_val = document.sub_specialchars l0_section_title).include? ATTR_REF_HEAD
+          # QUESTION should we defer substituting attributes until the end of the header? or should we substitute again if necessary?
+          doc_attrs['doctitle'] = doctitle_attr_val = document.sub_attributes doctitle_attr_val, attribute_missing: 'skip'
+        end
       end
       document.header.source_location = source_location if source_location
       # default to compat-mode if document has setext doctitle


### PR DESCRIPTION
suppress missing attribute warning when applying substitutions to implicit document title to assign to doctitle attribute

author should assume there's an implicit attribute entry for doctitle directly after the document title (level-0 section title)
