### PR TITLE
use document ID as linkend for self xref in DocBook output, generating one if necessary

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -23,8 +23,9 @@ Bug Fixes::
   * Don't assign nil value to named attribute mapped to absent positional attribute when parsing attrlist (#4033)
   * Remove leading and trailing spaces around role on inline phrase (#4035)
   * Ignore empty role on inline phrase defined using legacy syntax and followed by comma (#4035)
-  * Use xreftext of document as fallback link text for inter-document xref that resolves to current document when no link text is provided (#4032)
-  * Use xreftext of document as fallback link text for interal xref with empty fragment when no link text is provided (#4032)
+  * Use xreftext on document as fallback link text in HTML output for inter-document xref that resolves to current document when no link text is provided (#4032)
+  * Use xreftext on document as fallback link text in HTML output for internal xref with empty fragment when no link text is provided (#4032)
+  * Use document ID as linkend in DocBook output for internal xref with empty fragment; auto-generating one if necessary (#4032)
 
 Improvements::
 

--- a/test/links_test.rb
+++ b/test/links_test.rb
@@ -995,6 +995,31 @@ context 'Links' do
     assert_include '<a href="#">[^top]</a>', output
   end
 
+  test 'should use document id as linkend for self xref in DocBook backend' do
+    input = <<~'EOS'
+    [#docid]
+    = Document Title
+
+    See xref:test.adoc[]
+    EOS
+    output = convert_string_to_embedded input, backend: :docbook, attributes: { 'docname' => 'test' }
+    assert_include '<xref linkend="docid"/>', output
+  end
+
+  test 'should auto-generate document id to use as linkend for self xref in DocBook backend' do
+    input = <<~'EOS'
+    = Document Title
+
+    See xref:test.adoc[]
+    EOS
+    doc = document_from_string input, backend: :docbook, attributes: { 'docname' => 'test' }
+    assert_nil doc.id
+    output = doc.convert
+    assert_nil doc.id
+    assert_include ' xml:id="__article-root__"', output
+    assert_include '<xref linkend="__article-root__"/>', output
+  end
+
   test 'should produce an internal anchor for inter-document xref to file outside of base directory' do
     input = <<~'EOS'
     = Document Title


### PR DESCRIPTION
This is a follow-up to the fix for #4032, which also affected the DocBook output (though in a different way).