### PR TITLE
manpage: fix apostrophe portability

### DIFF
--- a/lib/asciidoctor/converter/manpage.rb
+++ b/lib/asciidoctor/converter/manpage.rb
@@ -743,7 +743,7 @@ allbox tab(:);'
       .gsub('&#8658;', '\(rA')  # rightwards double arrow
       .gsub('&#8203;', '\:')    # zero width space
       .gsub('&amp;', '&')       # literal ampersand (NOTE must take place after any other replacement that includes &)
-      .gsub('\'', '\(aq')       # apostrophe-quote
+      .gsub('\'', '\*(Aq')      # apostrophe-quote
       .gsub(MockMacroRx, '\1')  # mock boundary
       .gsub(ESC_BS, '\\')       # unescape troff backslash (NOTE update if more escapes are added)
       .gsub(ESC_FS, '.')        # unescape full stop in troff commands (NOTE must take place after gsub(LeadingPeriodRx))

--- a/test/manpage_test.rb
+++ b/test/manpage_test.rb
@@ -256,6 +256,16 @@ context 'Manpage' do
       assert_includes output, 'go\\(emto'
     end
 
+    test 'should replace quotes' do
+      input = <<~EOS.chop
+      #{SAMPLE_MANPAGE_HEADER}
+
+      'command'
+      EOS
+      output = Asciidoctor.convert input, backend: :manpage
+      assert_includes output, '\*(Aqcommand\*(Aq'
+    end
+
     test 'should escape lone period' do
       input = <<~EOS.chop
       #{SAMPLE_MANPAGE_HEADER}


### PR DESCRIPTION
As you can see from the bug referenced in the preamble, the point is to
not convert \' to \(aq directly, because that only works in groff. To
make it portable \*(Aq should be used instead, and that will be
converted to \(aq in groff and ' elsewhere.

[1] https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=507673