### PR TITLE
Fix documentation about shared-header

### DIFF
--- a/docs/modules/ROOT/pages/docinfo.adoc
+++ b/docs/modules/ROOT/pages/docinfo.adoc
@@ -162,6 +162,7 @@ To specify which file(s) you want to apply, set the `docinfo` attribute to any c
 * `private-footer`
 * `private` (alias for `private-head,private-header,private-footer`)
 * `shared-head`
+* `shared-header`
 * `shared-footer`
 * `shared` (alias for `shared-head,shared-header,shared-footer`)
 


### PR DESCRIPTION
Added the missing `shared-header` in the docinfo list ([Asciidoctor Docs > Docinfo Files > Enabling docinfo](https://docs.asciidoctor.org/asciidoctor/latest/docinfo/#enable)).