### PR TITLE
Add MacPorts Documentation

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -154,7 +154,7 @@ Asciidoctor works best when you use UTF-8 everywhere.
 
 Asciidoctor is packaged and distributed to RubyGems.org as a RubyGem (aka gem) named {url-rubygem}[asciidoctor^].
 The asciidoctor gem can be installed on all major operating systems using Ruby packaging tools (gem or bundle).
-Asciidoctor is also distributed as a Docker image, as a package for numerous Linux distributions, and as a package for macOS (via Homebrew).
+Asciidoctor is also distributed as a Docker image, as a package for numerous Linux distributions, and as a package for macOS (via Homebrew and MacPorts).
 
 === Linux package managers
 
@@ -196,7 +196,9 @@ To install the package, open a terminal and type:
 
  $ sudo dnf install -y asciidoctor
 
-=== Homebrew (macOS)
+=== macOS
+
+==== Homebrew
 
 You can use Homebrew, the macOS package manager, to install Asciidoctor.
 If you don’t have Homebrew on your computer, complete the installation instructions at https://brew.sh/[brew.sh] first.
@@ -206,6 +208,12 @@ Open a terminal and type:
  $ brew install asciidoctor
 
 Homebrew installs the `asciidoctor` gem into an exclusive prefix that's independent of system gems.
+
+==== MacPorts
+
+Asciidoctor is also available on https://ports.macports.org/port/asciidoctor/[MacPorts]:
+
+ $ sudo port install asciidoctor
 
 === Windows
 
@@ -307,6 +315,13 @@ When you install a new version of the gem using `gem install`, you end up with m
 Use the following command to remove the old versions:
 
  $ gem cleanup asciidoctor
+ 
+=== MacPorts (macOS)
+
+To upgrade the gem, use:
+
+ $ sudo port selfupdate
+ $ sudo port upgrade asciidoctor
 
 == Usage
 

--- a/docs/modules/ROOT/pages/index.adoc
+++ b/docs/modules/ROOT/pages/index.adoc
@@ -16,7 +16,7 @@ When we say Asciidoctor in this section of the documentation, we're specifically
 
 To simplify installation, Asciidoctor is packaged and distributed to RubyGems.org as a {url-rubygem}/asciidoctor[RubyGem named asciidoctor^].
 The asciidoctor gem can be installed on all major operating systems using Ruby packaging tools (gem or bundle).
-Asciidoctor is also distributed as a Docker image, as a package for numerous Linux distributions, and as a package for macOS (via Homebrew).
+Asciidoctor is also distributed as a Docker image, as a package for numerous Linux distributions, and as a package for macOS (via Homebrew and MacPorts).
 
 Asciidoctor is open source software available under the terms of the MIT license and {url-org}[hosted on GitHub^].
 

--- a/docs/modules/install/pages/index.adoc
+++ b/docs/modules/install/pages/index.adoc
@@ -9,7 +9,7 @@ In addition to running on Ruby, Asciidoctor can be executed on a JVM using xref:
 Asciidoctor can be installed using:
 
 * package managers for popular Linux distributions,
-* Homebrew for macOS,
+* Homebrew or MacPorts for macOS,
 * the `gem install` command (recommended for Windows users or if you'll be installing additional gems),
 * the Asciidoctor Docker image, or
 * Bundler.

--- a/docs/modules/install/pages/macos.adoc
+++ b/docs/modules/install/pages/macos.adoc
@@ -1,7 +1,10 @@
 = Install on macOS
 :url-homebrew: https://brew.sh/
+:url-macports: https://ports.macports.org/port/asciidoctor/
 
-== Install with Homebrew
+== Homebrew
+
+=== Install
 
 You can use Homebrew, the macOS package manager, to install Asciidoctor.
 If you don't have Homebrew on your computer, complete the installation instructions at {url-homebrew}[brew.sh^] first.
@@ -15,9 +18,24 @@ Homebrew installs the `asciidoctor` gem into an exclusive prefix that's independ
 
 include::partial$success.adoc[]
 
-== Upgrade with Homebrew
+=== Upgrade
 
 To upgrade the gem, open a terminal and type:
 
  $ brew update
  $ brew upgrade asciidoctor
+
+== MacPorts
+
+Asciidoctor is also available on {url-macports}[MacPorts]:
+
+ $ sudo port install asciidoctor
+
+include::partial$success.adoc[]
+
+=== Upgrade
+
+To upgrade the gem, open a terminal and type:
+
+ $ sudo port selfupdate
+ $ sudo port upgrade asciidoctor


### PR DESCRIPTION
Hi there 👋

For the [last five years](https://github.com/macports/macports-ports/commits/master/textproc/asciidoctor/Portfile), asciidoctor has been available on [MacPorts](https://ports.macports.org/). It can be installed on macOS by running the following:

```
$ sudo port install asciidoctor
```

The project page can be found [here](https://ports.macports.org/port/asciidoctor/). Pre-built binaries and support is provided all the way from Big Sur to Snow Leopard from 12 years ago. I therefore thought that I'd add some documentation for this.

It goes without saying, but I also wanted to say thank you to the maintainers (particularly @mojavelinux) for providing bugfixes and updates for this amazing project all these years. Your work is greatly appreciated. 👍