### PR TITLE
Added example of pointing Pygments adapter to one's own stylesheet

### DIFF
--- a/docs/modules/syntax-highlighting/examples/custom-theme-pygments-syntax-highlighter.rb
+++ b/docs/modules/syntax-highlighting/examples/custom-theme-pygments-syntax-highlighter.rb
@@ -1,0 +1,12 @@
+class MyPygmentsAdapter < (Asciidoctor::SyntaxHighlighter.for 'pygments')
+	register_for :pygments
+
+	def write_stylesheet? doc
+		false
+	end
+
+	def docinfo location, doc, opts
+		slash = opts[:self_closing_tag_slash]
+		%(<link rel="stylesheet" href="/styles/syntax-theme.css"#{slash}>)
+	end
+end

--- a/docs/modules/syntax-highlighting/pages/custom.adoc
+++ b/docs/modules/syntax-highlighting/pages/custom.adoc
@@ -51,6 +51,13 @@ Then, require this file when invoking Asciidoctor, setting `source-highlighter=p
 
  $ asciidoctor -r ./extended-pygments-syntax-highlighter.rb -a source-highlighter=pygments document.adoc
 
+ If you wanted to override the adapter to link to your own stylesheet and disable creation of the default stylesheet (`pygments-default.css`), you could use the following.
+
+ [,ruby]
+----
+include::example$custom-theme-pygments-syntax-highlighter.rb[]
+----
+
 If you want to decorate built-in behavior, you can invoke the `super` method anywhere inside the method to delegate to the behavior provided by the built-in adapter.
 
 Let's say you always want lines to be numbered, regardless of the setting in the document.


### PR DESCRIPTION
I think that in the future, a family of attributes like `:pygments-stylesheet:` would make sense. But for now, updating the docs on how to achieve this seems "the long way" seems best.