### PR TITLE
resolves #4176 allow hash to be specified for Vimeo video

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -44,6 +44,7 @@ Improvements::
   * Consolidate styles applied to primary containers (`#header`, `#content`, `#footnotes`, `#footer`) in default stylesheet (#4169)
   * Constrain width of `<svg>` element to container in default stylesheet
   * Target `<object>` element with image more accurately in default stylesheet
+  * Allow hash to be specified for Vimeo video either in video ID or using `hash` attribute (#4176)
 
 == Documentation
 

--- a/lib/asciidoctor/converter/html5.rb
+++ b/lib/asciidoctor/converter/html5.rb
@@ -1035,12 +1035,14 @@ Your browser does not support the audio tag.
       end
       start_anchor = (node.attr? 'start') ? %(#at=#{node.attr 'start'}) : ''
       delimiter = ['?']
+      target, hash = (node.attr 'target').split '/', 2
+      hash_param = (hash ||= node.attr 'hash') ? %(#{delimiter.pop || '&amp;'}h=#{hash}) : ''
       autoplay_param = (node.option? 'autoplay') ? %(#{delimiter.pop || '&amp;'}autoplay=1) : ''
       loop_param = (node.option? 'loop') ? %(#{delimiter.pop || '&amp;'}loop=1) : ''
       muted_param = (node.option? 'muted') ? %(#{delimiter.pop || '&amp;'}muted=1) : ''
       %(<div#{id_attribute}#{class_attribute}>#{title_element}
 <div class="content">
-<iframe#{width_attribute}#{height_attribute} src="#{asset_uri_scheme}//player.vimeo.com/video/#{node.attr 'target'}#{autoplay_param}#{loop_param}#{muted_param}#{start_anchor}" frameborder="0"#{(node.option? 'nofullscreen') ? '' : (append_boolean_attribute 'allowfullscreen', xml)}></iframe>
+<iframe#{width_attribute}#{height_attribute} src="#{asset_uri_scheme}//player.vimeo.com/video/#{target}#{hash_param}#{autoplay_param}#{loop_param}#{muted_param}#{start_anchor}" frameborder="0"#{(node.option? 'nofullscreen') ? '' : (append_boolean_attribute 'allowfullscreen', xml)}></iframe>
 </div>
 </div>)
     when 'youtube'

--- a/test/blocks_test.rb
+++ b/test/blocks_test.rb
@@ -3061,6 +3061,26 @@ context 'Blocks' do
       assert_css 'iframe[height="300"]', output, 1
     end
 
+    test 'video macro should allow hash for vimeo video to be specified in video ID' do
+      input = 'video::67480300/123456789[vimeo, 400, 300, options=loop]'
+      output = convert_string_to_embedded input
+      assert_css 'video', output, 0
+      assert_css 'iframe', output, 1
+      assert_css 'iframe[src="https://player.vimeo.com/video/67480300?h=123456789&loop=1"]', output, 1
+      assert_css 'iframe[width="400"]', output, 1
+      assert_css 'iframe[height="300"]', output, 1
+    end
+
+    test 'video macro should allow hash for vimeo video to be specified using hash attribute' do
+      input = 'video::67480300[vimeo, 400, 300, options=loop, hash=123456789]'
+      output = convert_string_to_embedded input
+      assert_css 'video', output, 0
+      assert_css 'iframe', output, 1
+      assert_css 'iframe[src="https://player.vimeo.com/video/67480300?h=123456789&loop=1"]', output, 1
+      assert_css 'iframe[width="400"]', output, 1
+      assert_css 'iframe[height="300"]', output, 1
+    end
+
     test 'video macro should output custom HTML with iframe for youtube service' do
       input = 'video::U8GBXvdmHT4/PLg7s6cbtAD15Das5LK9mXt_g59DLWxKUe[youtube, 640, 360, start=60, options="autoplay,muted,modest", theme=light]'
       output = convert_string_to_embedded input


### PR DESCRIPTION
* hash can be set using the hash attribute
* alternately, hash can be set in video ID following a forward slash