### PR TITLE
Hide autoload converter/template from Opal

### DIFF
--- a/lib/asciidoctor/converter.rb
+++ b/lib/asciidoctor/converter.rb
@@ -43,7 +43,7 @@ module Asciidoctor
 #   puts Asciidoctor.convert_file 'sample.adoc', safe: :safe
 module Converter
   autoload :CompositeConverter, %(#{__dir__}/converter/composite)
-  autoload :TemplateConverter, %(#{__dir__}/converter/template)
+  autoload :TemplateConverter, %(#{__dir__}/converter/template) unless RUBY_ENGINE == 'opal'
 
   # Public: The String backend name that this converter is handling.
   attr_reader :backend


### PR DESCRIPTION
The latest version of Opal will resolve `autoload` module/class at compile time.
However, the built-in template converter (`converter/template.rb`) relies on Ruby template engines and, as a result, cannot be compiled by Opal.

It's no use to try to create a JavaScript compatible version of the built-in template converter because Asciidoctor.js already provides a custom implementation when running in a Node.js environment: https://github.com/asciidoctor/asciidoctor.js/blob/master/packages/core/lib/asciidoctor/js/asciidoctor_ext/node/template.rb