### PR TITLE
resolves #4212 invert FR "caution" &  "warning" translations

### DIFF
--- a/data/locale/attributes-fr.adoc
+++ b/data/locale/attributes-fr.adoc
@@ -1,7 +1,7 @@
 // French translation, courtesy of Nicolas Comet <nicolas.comet@gmail.com> with updates from Maheva Bagard Laursen <mblaursen@gbif.org>
 :appendix-caption: Annexe
 :appendix-refsig: {appendix-caption}
-:caution-caption: Avertissement
+:caution-caption: Attention
 :chapter-signifier: Chapitre
 :chapter-refsig: {chapter-signifier}
 :example-caption: Exemple
@@ -20,4 +20,4 @@ ifdef::preface-title[:preface-title: Préface]
 :toc-title: Table des matières
 :untitled-label: Sans titre
 :version-label: Version
-:warning-caption: Attention
+:warning-caption: Avertissement


### PR DESCRIPTION
This is just a suggestion for consistency across languages.

I'm a detail-oriented native French speaker and I'm available for exchanging on this topic if need be.
This is by no mean an urgent request and I'm sorry of how insignificant a contribution it is.

Thanks for the great tools and work!