### PR TITLE
Use recursive descent parser to implement ifeval

### DIFF
--- a/lib/asciidoctor.rb
+++ b/lib/asciidoctor.rb
@@ -570,6 +570,7 @@ require_relative 'asciidoctor/section'
 require_relative 'asciidoctor/stylesheets'
 require_relative 'asciidoctor/table'
 require_relative 'asciidoctor/writer'
+require_relative 'asciidoctor/ifeval_parser'
 
 # main API entry points
 require_relative 'asciidoctor/load'

--- a/lib/asciidoctor/ifeval_parser.rb
+++ b/lib/asciidoctor/ifeval_parser.rb
@@ -1,0 +1,197 @@
+module Asciidoctor
+
+
+# The recursive descent parser for asciidoctor-pdf's ifeval
+#
+# EBNF expression LL(*):
+#   expr := disjunction
+#   disjunction := conjunction ('or' conjunction)*
+#   conjunction := inversion ('and' inversion)*
+#   inversion := 'not' inversion
+#              | comparison
+#
+#   comparison := term "==" term
+#               | term "!=" term
+#               | term ">" term
+#               | term "<" term
+#               | term "<=" term
+#               | term ">=" term
+#   term := literal
+#       | '(' expr ')'
+#
+# reference:
+#   https://docs.python.org/3/reference/grammar.html
+
+class IfevalParser
+  include Logging
+
+  @str = ""
+  @pos = 0
+  @next_pos = 0
+  @document
+  
+  def initialize doc
+    @str = ""
+    @pos = 0
+    @next_pos = 0
+    @document = doc
+  end
+
+  def peek_token
+    @next_pos = @pos
+    str = @str[@pos..-1]
+    if str =~ /^\s*\d+/ ||                         # for number
+       str =~ /^\s*[+\-*\/()]/ ||            # for operator
+       str =~ /^\s*(==|!=|>=|<=|>|<)/ ||     # for equivalent
+       str =~ /^\s*"\S*"/ ||                 # for string
+       str =~ /^\s*{\S+}/ ||                 # for attribute
+       str =~ /^\s*(not|and|or|true|false)/  # for binary operator
+      token = $~[0]
+      @next_pos += token.length
+#      puts @str[@next_pos..-1]
+      return token.gsub(/\s*/, "")
+    end
+    
+    nil
+  end
+  
+  def commit_token
+    @pos = @next_pos
+  end
+
+  def solve str
+    initialize @document
+    @str = str
+    next_expr
+  end
+
+  def next_expr
+    next_disjunction
+  end
+
+  def next_disjunction
+    a = next_conjunction
+    token = peek_token
+    while token == "or"
+      commit_token
+      b = next_conjunction
+      token = peek_token
+      a = a | b
+    end
+    return a
+  end
+
+  def next_conjunction
+    a = next_inversion
+    token = peek_token
+    while token == "and"
+      commit_token
+      b = next_inversion
+      token = peek_token
+      a = a & b
+    end
+    return a
+  end
+
+  def next_inversion
+    token = peek_token
+    if token == "not"
+      commit_token
+      ret = next_inversion
+      return !ret
+    end
+    
+    return next_comparison
+  end
+
+  def next_comparison
+    a = next_term
+    token = peek_token
+    if token == "=="
+      commit_token
+      b = next_term
+      return a == b
+    elsif token == "!="
+      commit_token
+      b = next_term
+      return a != b
+    elsif token == ">="
+      commit_token
+      b = next_term
+      return a >= b
+    elsif token == "<="
+      commit_token
+      b = next_term
+      return a <= b
+    elsif token == ">"
+      commit_token
+      b = next_term
+      return a > b
+    elsif token == "<"
+      commit_token
+      b = next_term
+      return a < b
+    else
+      return a
+    end
+  end
+
+  def next_term
+    token = peek_token
+    commit_token
+    if token == "("
+      a = next_expr
+      token = peek_token
+      commit_token
+      if token != ")"
+        raise ArgumentError, "Expect ')', but is #{token}"
+      end
+      token = a
+    end
+
+    # literal
+    resolve_expr_val token
+#    if token.to_s =~ /(true|false)/ 
+#      return token.to_s == "true"
+#    elsif token.to_s =~ /"(\S+)"/
+#      return $1
+#    else
+#      return token
+#    end
+  end
+  
+  def resolve_expr_val val
+    if ((val.start_with? '"') && (val.end_with? '"')) ||
+        ((val.start_with? '\'') && (val.end_with? '\''))
+      quoted = true
+      val = val.gsub(/"(.+)"/, '\1')
+      val = val.gsub(/'(.+)'/, '\1')
+    else
+      quoted = false
+    end
+
+    # QUESTION should we substitute first?
+    # QUESTION should we also require string to be single quoted (like block attribute values?)
+    val = @document.sub_attributes val, attribute_missing: 'drop' if val.include? ATTR_REF_HEAD
+  
+    if quoted
+      val = val.gsub(/"(.+)"/, '\1')
+      val
+    elsif val.empty?
+      nil
+    elsif val == 'true'
+      true
+    elsif val == 'false'
+      false
+    elsif val.rstrip.empty?
+      ' '
+    elsif val.include? '.'
+      val.to_f
+    else
+      # fallback to coercing to integer, since we
+      # require string values to be explicitly quoted
+      val.to_i
+    end
+  end
+end
+end

--- a/lib/asciidoctor/reader.rb
+++ b/lib/asciidoctor/reader.rb
@@ -853,6 +853,11 @@ class PreprocessorReader < Reader
     elsif @skipping
       shift
       nil
+    elsif (line.start_with? ':') && AttributeEntryRx =~ line
+      attributes = {}
+      Parser.process_attribute_entry self, @document, attributes, $~
+      shift
+      nil
     else
       # NOTE optimization to inline super
       @look_ahead += 1
@@ -935,18 +940,7 @@ class PreprocessorReader < Reader
         end
       when 'ifeval'
         if no_target
-          # the text in brackets must match a conditional expression
-          if text && EvalExpressionRx =~ text.strip
-            # NOTE assignments must happen before call to resolve_expr_val for compatibility with Opal
-            lhs = $1
-            # regex enforces a restricted set of math-related operations (==, !=, <=, >=, <, >)
-            op = $2
-            rhs = $3
-            skip = ((resolve_expr_val lhs).send op, (resolve_expr_val rhs)) ? false : true rescue true
-          else
-            logger.error message_with_context %(malformed preprocessor directive - #{text ? 'invalid expression' : 'missing expression'}: ifeval::[#{text}]), source_location: cursor
-            return true
-          end
+            skip = !(conditional_ifeval text)
         else
           logger.error message_with_context %(malformed preprocessor directive - target not permitted: ifeval::#{target}[#{text}]), source_location: cursor
           return true
@@ -971,6 +965,17 @@ class PreprocessorReader < Reader
     end
 
     true
+  end
+
+  def conditional_ifeval text
+    # the text in brackets must match a conditional expression
+    if text && EvalExpressionRx =~ text.strip
+      parser = IfevalParser.new @document
+      return parser.solve text
+    else
+      logger.error message_with_context %(malformed preprocessor directive - #{text ? 'invalid expression' : 'missing expression'}: ifeval::[#{text}]), source_location: cursor
+      return true
+    end
   end
 
   # Internal: Preprocess the directive to include lines from another document.
@@ -1325,7 +1330,8 @@ class PreprocessorReader < Reader
     if ((val.start_with? '"') && (val.end_with? '"')) ||
         ((val.start_with? '\'') && (val.end_with? '\''))
       quoted = true
-      val = val.slice 1, (val.length - 1)
+      val = val.gsub(/"(.+)"/, '\1')
+      val = val.gsub(/'(.+)'/, '\1')
     else
       quoted = false
     end
@@ -1335,6 +1341,7 @@ class PreprocessorReader < Reader
     val = @document.sub_attributes val, attribute_missing: 'drop' if val.include? ATTR_REF_HEAD
 
     if quoted
+      val = val.gsub(/"(.+)"/, '\1')
       val
     elsif val.empty?
       nil


### PR DESCRIPTION
Hi, i found that your ifeval have some issue when i use plugin to build document, it will shift all the attributes at the phase preprocesser is parsing document, which makes the function Parser.parse() can't get correct attributes for ifevals to compare. So, i call Parser.process_attribute_entry() in Reader.process_line() to set attributes.
And I notice that your implement of ifeval seems incomplete, so i reference recursive descent parser of Python 3 to implement ifeval_parser.rb to support "and" "or" operator.