### PR TITLE
resolves #4250 enhance Logger constructor to honor positional and keyword arguments

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -29,7 +29,10 @@ Enhancements::
   * Don't add empty line before block content if principal text of dlist item is not specified when converting to man page (#4182)
   * Add support for role on thematic break in HTML converter (#4101)
   * Add support for link=self on image macros (#3656)
-  * alias Inline#content to Inline#text so Inline node quacks like other nodes (#3220)
+  * Alias Inline#content to Inline#text so Inline node quacks like other nodes (#3220)
+  * Update signature of Logger constructor so both positional arguments and keyword arguments are passed to super constructor (#4250)
+  * Honor `level` and `formatter` keyword arguments passed to Logger constructor (#4250)
+  * Set logdev to $stderr if no arguments are passed to Logger constructor (#4250)
 
 Compliance::
 

--- a/lib/asciidoctor/logging.rb
+++ b/lib/asciidoctor/logging.rb
@@ -6,11 +6,12 @@ module Asciidoctor
 class Logger < ::Logger
   attr_reader :max_severity
 
-  def initialize *args
+  def initialize *args, **kwargs
+    args << $stderr if args.empty?
     super
     self.progname = 'asciidoctor'
-    self.formatter = BasicFormatter.new
-    self.level = WARN
+    self.formatter = kwargs[:formatter] || BasicFormatter.new
+    self.level = kwargs[:level] || WARN
   end
 
   def add severity, message = nil, progname = nil
@@ -41,7 +42,7 @@ class MemoryLogger < ::Logger
   attr_reader :messages
 
   def initialize
-    self.level = WARN
+    self.level = UNKNOWN
     @messages = []
   end
 
@@ -68,7 +69,7 @@ class NullLogger < ::Logger
   attr_reader :max_severity
 
   def initialize
-    self.level = WARN
+    self.level = UNKNOWN
   end
 
   def add severity, message = nil, progname = nil

--- a/test/logger_test.rb
+++ b/test/logger_test.rb
@@ -51,6 +51,36 @@ context 'Logger' do
   end
 
   context 'Logger' do
+    test 'should set logdev to $stderr by default' do
+      out_string, err_string = redirect_streams do |out, err|
+        logger = Asciidoctor::Logger.new
+        logger.warn 'this is a call'
+        [out.string, err.string]
+      end
+      assert_empty out_string
+      refute_empty err_string
+      assert_includes err_string, 'this is a call'
+    end
+
+    test 'should set level to value specified by level kwarg' do
+      out_string, err_string, log_level = redirect_streams do |out, err|
+        logger = Asciidoctor::Logger.new level: 'fatal'
+        logger.warn 'this is a call'
+        [out.string, err.string, logger.level]
+      end
+      assert_empty out_string
+      assert_empty err_string
+      assert_equal Logger::Severity::FATAL, log_level
+    end
+
+    test 'should configure logger with progname set to asciidoctor' do
+      assert_equal 'asciidoctor', Asciidoctor::Logger.new.progname
+    end
+
+    test 'should configure logger with level set to WARN by default' do
+      assert_equal Logger::Severity::WARN, Asciidoctor::Logger.new.level
+    end
+
     test 'configures default logger with progname set to asciidoctor' do
       assert_equal 'asciidoctor', Asciidoctor::LoggerManager.logger.progname
     end
@@ -82,7 +112,13 @@ context 'Logger' do
     test 'NullLogger level is not nil' do
       logger = Asciidoctor::NullLogger.new
       refute_nil logger.level
-      assert_equal Logger::WARN, logger.level
+      assert_equal Logger::UNKNOWN, logger.level
+    end
+
+    test 'MemoryLogger level is not nil' do
+      logger = Asciidoctor::MemoryLogger.new
+      refute_nil logger.level
+      assert_equal Logger::UNKNOWN, logger.level
     end
   end
 


### PR DESCRIPTION
* update signature of the Logger constructor so both positional arguments and keyword arguments are passed to super constructor
* honor level and formatter keyword arguments passed to Logger constructor (even for Ruby 2.3)
* set logdev to $stderr if no arguments are passed to Logger constructor