### PR TITLE
Fix `:templates_dir` API option typo

### DIFF
--- a/docs/modules/convert/pages/templates.adoc
+++ b/docs/modules/convert/pages/templates.adoc
@@ -601,7 +601,7 @@ To load templates from multiple directories when using the CLI, you can pass eac
 
  $ asciidoctor -T /path/to/common-templates -T /path/to/specialized-templates -E slim doc.adoc
 
-When using the API, you add all the template directories to the array value of the `:templates_dir` option:
+When using the API, you add all the template directories to the array value of the `:template_dirs` option:
 
 [,ruby]
 ----


### PR DESCRIPTION
It's inconsistent with what's below and should be `:template_dirs`.