### PR TITLE
Update the link name in readme

### DIFF
--- a/README-de.adoc
+++ b/README-de.adoc
@@ -64,7 +64,7 @@ Das Asciidoctor-Projekt wird {uri-repo}[auf GitHub] gehostet.
 
 ifndef::env-site[]
 Dieses Dokument ist auch in folgenden Sprachen erhältlich: +
-{uri-rel-file-base}README-zh_CN.adoc[汉语]
+{uri-rel-file-base}README-zh_CN.adoc[简体中文]
 |
 {uri-rel-file-base}README.adoc[English]
 |

--- a/README-jp.adoc
+++ b/README-jp.adoc
@@ -72,7 +72,7 @@ ifndef::env-site,env-yard[]
 このドキュメントには以下の言語版が存在します: +
 {uri-rel-file-base}README.adoc[English]
 |
-{uri-rel-file-base}README-zh_CN.adoc[汉语]
+{uri-rel-file-base}README-zh_CN.adoc[简体中文]
 |
 {uri-rel-file-base}README-de.adoc[Deutsch]
 |

--- a/README.adoc
+++ b/README.adoc
@@ -60,7 +60,7 @@ In addition to running on Ruby, Asciidoctor can be executed on a JVM using {url-
 
 ifndef::env-site,env-yard[]
 This document is also available in the following languages: +
-{url-rel-file-base}README-zh_CN.adoc[汉语]
+{url-rel-file-base}README-zh_CN.adoc[简体中文]
 |
 {url-rel-file-base}README-de.adoc[Deutsch]
 |


### PR DESCRIPTION
supplement for #4278. I found that in [README-fr.adoc](https://github.com/asciidoctor/asciidoctor/blob/main/README-fr.adoc), It does not display language names in the local language like other readme documents, but only in French. Is this a French convention or document style?
