### PR TITLE
html-converter-next images

### DIFF
--- a/lib/asciidoctor/converter/semantic_html5.rb
+++ b/lib/asciidoctor/converter/semantic_html5.rb
@@ -72,7 +72,12 @@ class Converter::SemanticHtml5Converter < Converter::Base
   end
 
   def convert_image node
-    attributes = common_html_attributes node.id, node.role
+    roles = []
+    roles << node.role if node.role
+    roles << %(text-#{node.attr 'align'}) if node.attr? 'align'
+    roles << %(#{node.attr 'float'}) if node.attr? 'float'
+    role = roles.join " "
+    attributes = common_html_attributes node.id, role.empty? ? nil : role
     size = []
     size << %( width="#{node.attr "width"}") if node.attr? "width"
     size << %( height="#{node.attr "height"}") if node.attr? "height"
@@ -89,6 +94,22 @@ class Converter::SemanticHtml5Converter < Converter::Base
     else
       %(#{link_start}<img src="#{target}" alt="#{encode_attribute_value node.alt}"#{attributes}#{size} />#{link_end})
     end
+  end
+
+  def convert_inline_image node
+    roles = []
+    roles << node.role if node.role
+    roles << %(text-#{node.attr 'align'}) if node.attr? 'align'
+    roles << %(#{node.attr 'float'}) if node.attr? 'float'
+    role = roles.join " "
+    attributes = common_html_attributes node.id, role.empty? ? nil : role
+    size = []
+    size << %( width="#{node.attr "width"}") if node.attr? "width"
+    size << %( height="#{node.attr "height"}") if node.attr? "height"
+    size = size.join
+    target = node.target
+    title = %( title="#{node.attr "title"}") if node.attr? "title"
+    %(<img src="#{target}" alt="#{encode_attribute_value node.alt}"#{title}#{attributes}#{size} />)
   end
 
   def convert_inline_anchor node

--- a/lib/asciidoctor/converter/semantic_html5.rb
+++ b/lib/asciidoctor/converter/semantic_html5.rb
@@ -75,16 +75,16 @@ class Converter::SemanticHtml5Converter < Converter::Base
     roles = []
     roles << node.role if node.role
     roles << %(text-#{node.attr 'align'}) if node.attr? 'align'
-    roles << %(#{node.attr 'float'}) if node.attr? 'float'
-    role = roles.join " "
+    roles << (node.attr 'float').to_s if node.attr? 'float'
+    role = roles.join ' '
     attributes = common_html_attributes node.id, role.empty? ? nil : role
     size = []
-    size << %( width="#{node.attr "width"}") if node.attr? "width"
-    size << %( height="#{node.attr "height"}") if node.attr? "height"
+    size << %( width="#{node.attr 'width'}") if node.attr? 'width'
+    size << %( height="#{node.attr 'height'}") if node.attr? 'height'
     size = size.join
-    target = node.attr "target"
-    link_start = %(<a href="#{node.attr "link"}">) if node.attr? "link"
-    link_end = %(</a>) if node.attr? "link"
+    target = node.attr 'target'
+    link_start = %(<a href="#{node.attr 'link'}">) if node.attr? 'link'
+    link_end = %(</a>) if node.attr? 'link'
 
     if node.title?
       %(<figure#{attributes}>
@@ -100,15 +100,15 @@ class Converter::SemanticHtml5Converter < Converter::Base
     roles = []
     roles << node.role if node.role
     roles << %(text-#{node.attr 'align'}) if node.attr? 'align'
-    roles << %(#{node.attr 'float'}) if node.attr? 'float'
-    role = roles.join " "
+    roles << (node.attr 'float').to_s if node.attr? 'float'
+    role = roles.join ' '
     attributes = common_html_attributes node.id, role.empty? ? nil : role
     size = []
-    size << %( width="#{node.attr "width"}") if node.attr? "width"
-    size << %( height="#{node.attr "height"}") if node.attr? "height"
+    size << %( width="#{node.attr 'width'}") if node.attr? 'width'
+    size << %( height="#{node.attr 'height'}") if node.attr? 'height'
     size = size.join
     target = node.target
-    title = %( title="#{node.attr "title"}") if node.attr? "title"
+    title = %( title="#{node.attr 'title'}") if node.attr? 'title'
     %(<img src="#{target}" alt="#{encode_attribute_value node.alt}"#{title}#{attributes}#{size} />)
   end
 

--- a/lib/asciidoctor/converter/semantic_html5.rb
+++ b/lib/asciidoctor/converter/semantic_html5.rb
@@ -71,6 +71,26 @@ class Converter::SemanticHtml5Converter < Converter::Base
     '<hr>'
   end
 
+  def convert_image node
+    attributes = common_html_attributes node.id, node.role
+    size = []
+    size << %( width="#{node.attr "width"}") if node.attr? "width"
+    size << %( height="#{node.attr "height"}") if node.attr? "height"
+    size = size.join
+    target = node.attr "target"
+    link_start = %(<a href="#{node.attr "link"}">) if node.attr? "link"
+    link_end = %(</a>) if node.attr? "link"
+
+    if node.title?
+      %(<figure#{attributes}>
+#{link_start}<img src="#{target}" alt="#{encode_attribute_value node.alt}"#{size} />#{link_end}
+<figcaption>#{node.captioned_title}</figcaption>
+</figure>)
+    else
+      %(#{link_start}<img src="#{target}" alt="#{encode_attribute_value node.alt}"#{attributes}#{size} />#{link_end})
+    end
+  end
+
   def convert_inline_anchor node
     case node.type
     when :link
@@ -218,6 +238,10 @@ class Converter::SemanticHtml5Converter < Converter::Base
     end
     attrs << %( rel="#{link_types.join ' '}") unless link_types.empty?
     attrs
+  end
+
+  def encode_attribute_value val
+    (val.include? '"') ? (val.gsub '"', '&quot;') : val
   end
 end
 end

--- a/test/fixtures/semantic-html5-scenarios/image-block-caption-link-with-id-role.adoc
+++ b/test/fixtures/semantic-html5-scenarios/image-block-caption-link-with-id-role.adoc
@@ -1,0 +1,6 @@
+This is a block image link with a caption.
+
+[#the_image.role_1.role_2]
+.Image of a dot.
+[link=https://docs.asciidoctor.org]
+image::../dot.gif[A dot image, 100, 100]

--- a/test/fixtures/semantic-html5-scenarios/image-block-caption-link-with-id-role.html
+++ b/test/fixtures/semantic-html5-scenarios/image-block-caption-link-with-id-role.html
@@ -1,0 +1,7 @@
+<p>
+This is a block image link with a caption.
+</p>
+<figure id="the_image" class="role_1 role_2">
+<a href="https://docs.asciidoctor.org"><img src="../dot.gif" alt="A dot image" width="100" height="100" /></a>
+<figcaption>Figure 1. Image of a dot.</figcaption>
+</figure>

--- a/test/fixtures/semantic-html5-scenarios/image-block-caption-with-align.adoc
+++ b/test/fixtures/semantic-html5-scenarios/image-block-caption-with-align.adoc
@@ -1,0 +1,4 @@
+This is a block image with a caption.
+
+.Image of a dot.
+image::../dot.gif[A dot image, align="center"]

--- a/test/fixtures/semantic-html5-scenarios/image-block-caption-with-align.html
+++ b/test/fixtures/semantic-html5-scenarios/image-block-caption-with-align.html
@@ -1,0 +1,7 @@
+<p>
+This is a block image with a caption.
+</p>
+<figure class="text-center">
+<img src="../dot.gif" alt="A dot image" />
+<figcaption>Figure 1. Image of a dot.</figcaption>
+</figure>

--- a/test/fixtures/semantic-html5-scenarios/image-block-caption-with-float.adoc
+++ b/test/fixtures/semantic-html5-scenarios/image-block-caption-with-float.adoc
@@ -1,0 +1,4 @@
+This is a block image with a caption.
+
+.Image of a dot.
+image::../dot.gif[A dot image, float="right"]

--- a/test/fixtures/semantic-html5-scenarios/image-block-caption-with-float.html
+++ b/test/fixtures/semantic-html5-scenarios/image-block-caption-with-float.html
@@ -1,0 +1,7 @@
+<p>
+This is a block image with a caption.
+</p>
+<figure class="right">
+<img src="../dot.gif" alt="A dot image" />
+<figcaption>Figure 1. Image of a dot.</figcaption>
+</figure>

--- a/test/fixtures/semantic-html5-scenarios/image-block-caption-with-id-role.adoc
+++ b/test/fixtures/semantic-html5-scenarios/image-block-caption-with-id-role.adoc
@@ -1,0 +1,5 @@
+This is a block image with a caption.
+
+[#the_image.role_1.role_2]
+.Image of a dot.
+image::../dot.gif[A dot image]

--- a/test/fixtures/semantic-html5-scenarios/image-block-caption-with-id-role.html
+++ b/test/fixtures/semantic-html5-scenarios/image-block-caption-with-id-role.html
@@ -1,0 +1,7 @@
+<p>
+This is a block image with a caption.
+</p>
+<figure id="the_image" class="role_1 role_2">
+<img src="../dot.gif" alt="A dot image" />
+<figcaption>Figure 1. Image of a dot.</figcaption>
+</figure>

--- a/test/fixtures/semantic-html5-scenarios/image-block-caption-with-id.adoc
+++ b/test/fixtures/semantic-html5-scenarios/image-block-caption-with-id.adoc
@@ -1,0 +1,5 @@
+This is a block image with a caption.
+
+[#the_image]
+.Image of a dot.
+image::../dot.gif[A dot image]

--- a/test/fixtures/semantic-html5-scenarios/image-block-caption-with-id.html
+++ b/test/fixtures/semantic-html5-scenarios/image-block-caption-with-id.html
@@ -1,0 +1,7 @@
+<p>
+This is a block image with a caption.
+</p>
+<figure id="the_image">
+<img src="../dot.gif" alt="A dot image" />
+<figcaption>Figure 1. Image of a dot.</figcaption>
+</figure>

--- a/test/fixtures/semantic-html5-scenarios/image-block-caption-with-role.adoc
+++ b/test/fixtures/semantic-html5-scenarios/image-block-caption-with-role.adoc
@@ -1,0 +1,5 @@
+This is a block image with a caption.
+
+[.role_1.role_2]
+.Image of a dot.
+image::../dot.gif[A dot image]

--- a/test/fixtures/semantic-html5-scenarios/image-block-caption-with-role.html
+++ b/test/fixtures/semantic-html5-scenarios/image-block-caption-with-role.html
@@ -1,0 +1,7 @@
+<p>
+This is a block image with a caption.
+</p>
+<figure class="role_1 role_2">
+<img src="../dot.gif" alt="A dot image" />
+<figcaption>Figure 1. Image of a dot.</figcaption>
+</figure>

--- a/test/fixtures/semantic-html5-scenarios/image-block-caption.adoc
+++ b/test/fixtures/semantic-html5-scenarios/image-block-caption.adoc
@@ -1,0 +1,4 @@
+This is a block image with a caption.
+
+.Image of a dot.
+image::../dot.gif[A dot image]

--- a/test/fixtures/semantic-html5-scenarios/image-block-caption.html
+++ b/test/fixtures/semantic-html5-scenarios/image-block-caption.html
@@ -1,0 +1,7 @@
+<p>
+This is a block image with a caption.
+</p>
+<figure>
+<img src="../dot.gif" alt="A dot image" />
+<figcaption>Figure 1. Image of a dot.</figcaption>
+</figure>

--- a/test/fixtures/semantic-html5-scenarios/image-block-empty-alt.adoc
+++ b/test/fixtures/semantic-html5-scenarios/image-block-empty-alt.adoc
@@ -1,0 +1,3 @@
+This is a block image with intentionally empty alt. Asciidoctor leaves an `alt=""` attribute indicating to browsers that it is presentational.
+
+image::../dot.gif[""]

--- a/test/fixtures/semantic-html5-scenarios/image-block-empty-alt.adoc
+++ b/test/fixtures/semantic-html5-scenarios/image-block-empty-alt.adoc
@@ -1,3 +1,4 @@
-This is a block image with intentionally empty alt. Asciidoctor leaves an `alt=""` attribute indicating to browsers that it is presentational.
+This is a block image with intentionally empty alt.
+Asciidoctor leaves an alt="" attribute indicating to browsers that it is presentational.
 
 image::../dot.gif[""]

--- a/test/fixtures/semantic-html5-scenarios/image-block-empty-alt.html
+++ b/test/fixtures/semantic-html5-scenarios/image-block-empty-alt.html
@@ -1,0 +1,4 @@
+<p>
+This is a block image with intentionally empty alt. Asciidoctor leaves an <code>alt=""</code> attribute indicating to browsers that it is presentational.
+</p>
+<img src="../dot.gif" alt="" />

--- a/test/fixtures/semantic-html5-scenarios/image-block-empty-alt.html
+++ b/test/fixtures/semantic-html5-scenarios/image-block-empty-alt.html
@@ -1,4 +1,5 @@
 <p>
-This is a block image with intentionally empty alt. Asciidoctor leaves an <code>alt=""</code> attribute indicating to browsers that it is presentational.
+This is a block image with intentionally empty alt.
+Asciidoctor leaves an alt="" attribute indicating to browsers that it is presentational.
 </p>
 <img src="../dot.gif" alt="" />

--- a/test/fixtures/semantic-html5-scenarios/image-block-no-alt.adoc
+++ b/test/fixtures/semantic-html5-scenarios/image-block-no-alt.adoc
@@ -1,0 +1,3 @@
+This is a block image with no stated alt. AsciiDoctor replaces the alt with unpathified filename.
+
+image::../dot.gif[]

--- a/test/fixtures/semantic-html5-scenarios/image-block-no-alt.html
+++ b/test/fixtures/semantic-html5-scenarios/image-block-no-alt.html
@@ -1,0 +1,4 @@
+<p>
+This is a block image with no stated alt. AsciiDoctor replaces the alt with unpathified filename.
+</p>
+<img src="../dot.gif" alt="dot" />

--- a/test/fixtures/semantic-html5-scenarios/image-block-size.adoc
+++ b/test/fixtures/semantic-html5-scenarios/image-block-size.adoc
@@ -1,0 +1,3 @@
+This is a block image.
+
+image::../dot.gif[A dot image, 100, 200]

--- a/test/fixtures/semantic-html5-scenarios/image-block-size.html
+++ b/test/fixtures/semantic-html5-scenarios/image-block-size.html
@@ -1,0 +1,4 @@
+<p>
+This is a block image.
+</p>
+<img src="../dot.gif" alt="A dot image" width="100" height="200" />

--- a/test/fixtures/semantic-html5-scenarios/image-block-with-align.adoc
+++ b/test/fixtures/semantic-html5-scenarios/image-block-with-align.adoc
@@ -1,0 +1,3 @@
+This is a block image.
+
+image::../dot.gif[A dot image, align="center"]

--- a/test/fixtures/semantic-html5-scenarios/image-block-with-align.html
+++ b/test/fixtures/semantic-html5-scenarios/image-block-with-align.html
@@ -1,0 +1,4 @@
+<p>
+This is a block image.
+</p>
+<img src="../dot.gif" alt="A dot image" class="text-center" />

--- a/test/fixtures/semantic-html5-scenarios/image-block-with-float.adoc
+++ b/test/fixtures/semantic-html5-scenarios/image-block-with-float.adoc
@@ -1,0 +1,3 @@
+This is a block image.
+
+image::../dot.gif[A dot image, float="right"]

--- a/test/fixtures/semantic-html5-scenarios/image-block-with-float.html
+++ b/test/fixtures/semantic-html5-scenarios/image-block-with-float.html
@@ -1,0 +1,4 @@
+<p>
+This is a block image.
+</p>
+<img src="../dot.gif" alt="A dot image" class="right" />

--- a/test/fixtures/semantic-html5-scenarios/image-block-with-id-role.adoc
+++ b/test/fixtures/semantic-html5-scenarios/image-block-with-id-role.adoc
@@ -1,0 +1,4 @@
+This is a block image.
+
+[#the_image.role_1.role_2]
+image::../dot.gif[A dot image]

--- a/test/fixtures/semantic-html5-scenarios/image-block-with-id-role.html
+++ b/test/fixtures/semantic-html5-scenarios/image-block-with-id-role.html
@@ -1,0 +1,4 @@
+<p>
+This is a block image.
+</p>
+<img src="../dot.gif" alt="A dot image" id="the_image" class="role_1 role_2" />

--- a/test/fixtures/semantic-html5-scenarios/image-block-with-id.adoc
+++ b/test/fixtures/semantic-html5-scenarios/image-block-with-id.adoc
@@ -1,0 +1,4 @@
+This is a block image.
+
+[#the_image]
+image::../dot.gif[A dot image]

--- a/test/fixtures/semantic-html5-scenarios/image-block-with-id.html
+++ b/test/fixtures/semantic-html5-scenarios/image-block-with-id.html
@@ -1,0 +1,4 @@
+<p>
+This is a block image.
+</p>
+<img src="../dot.gif" alt="A dot image" id="the_image" />

--- a/test/fixtures/semantic-html5-scenarios/image-block-with-link.adoc
+++ b/test/fixtures/semantic-html5-scenarios/image-block-with-link.adoc
@@ -1,0 +1,4 @@
+This is a block image with link.
+
+[link=https://docs.asciidoctor.org]
+image::../dot.gif[A dot image, 100, 100]

--- a/test/fixtures/semantic-html5-scenarios/image-block-with-link.html
+++ b/test/fixtures/semantic-html5-scenarios/image-block-with-link.html
@@ -1,0 +1,4 @@
+<p>
+This is a block image with link.
+</p>
+<a href="https://docs.asciidoctor.org"><img src="../dot.gif" alt="A dot image" width="100" height="100" /></a>

--- a/test/fixtures/semantic-html5-scenarios/image-block-with-role.adoc
+++ b/test/fixtures/semantic-html5-scenarios/image-block-with-role.adoc
@@ -1,0 +1,4 @@
+This is a block image.
+
+[.role_1.role_2]
+image::../dot.gif[A dot image]

--- a/test/fixtures/semantic-html5-scenarios/image-block-with-role.html
+++ b/test/fixtures/semantic-html5-scenarios/image-block-with-role.html
@@ -1,0 +1,4 @@
+<p>
+This is a block image.
+</p>
+<img src="../dot.gif" alt="A dot image" class="role_1 role_2" />

--- a/test/fixtures/semantic-html5-scenarios/image-block.adoc
+++ b/test/fixtures/semantic-html5-scenarios/image-block.adoc
@@ -1,0 +1,3 @@
+This is a block image.
+
+image::../dot.gif[A dot image]

--- a/test/fixtures/semantic-html5-scenarios/image-block.html
+++ b/test/fixtures/semantic-html5-scenarios/image-block.html
@@ -1,0 +1,4 @@
+<p>
+This is a block image.
+</p>
+<img src="../dot.gif" alt="A dot image" />

--- a/test/fixtures/semantic-html5-scenarios/image-inline-with-align.adoc
+++ b/test/fixtures/semantic-html5-scenarios/image-inline-with-align.adoc
@@ -1,0 +1,1 @@
+This is an inline image. image:../dot.gif[inline dot, align="right"] Did you see it?

--- a/test/fixtures/semantic-html5-scenarios/image-inline-with-align.html
+++ b/test/fixtures/semantic-html5-scenarios/image-inline-with-align.html
@@ -1,0 +1,3 @@
+<p>
+This is an inline image. <img src="../dot.gif" alt="inline dot" class="text-right" /> Did you see it?
+</p>

--- a/test/fixtures/semantic-html5-scenarios/image-inline-with-float.adoc
+++ b/test/fixtures/semantic-html5-scenarios/image-inline-with-float.adoc
@@ -1,0 +1,1 @@
+This is an inline image. image:../dot.gif[inline dot, float="left"] Did you see it?

--- a/test/fixtures/semantic-html5-scenarios/image-inline-with-float.html
+++ b/test/fixtures/semantic-html5-scenarios/image-inline-with-float.html
@@ -1,0 +1,3 @@
+<p>
+This is an inline image. <img src="../dot.gif" alt="inline dot" class="left" /> Did you see it?
+</p>

--- a/test/fixtures/semantic-html5-scenarios/image-inline-with-role.adoc
+++ b/test/fixtures/semantic-html5-scenarios/image-inline-with-role.adoc
@@ -1,0 +1,1 @@
+This is an inline image. image:../dot.gif[inline dot, role="role_1 role_2"] Did you see it?

--- a/test/fixtures/semantic-html5-scenarios/image-inline-with-role.html
+++ b/test/fixtures/semantic-html5-scenarios/image-inline-with-role.html
@@ -1,0 +1,3 @@
+<p>
+This is an inline image. <img src="../dot.gif" alt="inline dot" class="role_1 role_2" /> Did you see it?
+</p>

--- a/test/fixtures/semantic-html5-scenarios/image-inline-with-size.adoc
+++ b/test/fixtures/semantic-html5-scenarios/image-inline-with-size.adoc
@@ -1,0 +1,1 @@
+This is an inline image. image:../dot.gif[inline dot, 30, 40] Did you see it?

--- a/test/fixtures/semantic-html5-scenarios/image-inline-with-size.html
+++ b/test/fixtures/semantic-html5-scenarios/image-inline-with-size.html
@@ -1,0 +1,3 @@
+<p>
+This is an inline image. <img src="../dot.gif" alt="inline dot" width="30" height="40" /> Did you see it?
+</p>

--- a/test/fixtures/semantic-html5-scenarios/image-inline-with-title.adoc
+++ b/test/fixtures/semantic-html5-scenarios/image-inline-with-title.adoc
@@ -1,0 +1,1 @@
+This is an inline image. image:../dot.gif[title="inline dot"] Did you see it?

--- a/test/fixtures/semantic-html5-scenarios/image-inline-with-title.html
+++ b/test/fixtures/semantic-html5-scenarios/image-inline-with-title.html
@@ -1,0 +1,3 @@
+<p>
+This is an inline image. <img src="../dot.gif" alt="dot" title="inline dot" /> Did you see it?
+</p>

--- a/test/fixtures/semantic-html5-scenarios/image-inline.adoc
+++ b/test/fixtures/semantic-html5-scenarios/image-inline.adoc
@@ -1,0 +1,1 @@
+This is an inline image. image:../dot.gif[inline dot] Did you see it?

--- a/test/fixtures/semantic-html5-scenarios/image-inline.html
+++ b/test/fixtures/semantic-html5-scenarios/image-inline.html
@@ -1,0 +1,3 @@
+<p>
+This is an inline image. <img src="../dot.gif" alt="inline dot" /> Did you see it?
+</p>


### PR DESCRIPTION
This has code for the following
 - block images
 - inline images
 - image alignment

Unfortunately, it needed to rebase off branch `feature/html-converter-next-convert_inline_quotes` (#4285), because the tests failed without the `convert_inline_quotes` method.