### PR TITLE
upgrade Nokogiri to latest version and add overrides for older Ruby versions

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -16,8 +16,10 @@ group :development do
   gem 'pygments.rb', ENV['PYGMENTS_VERSION'] if ENV.key? 'PYGMENTS_VERSION'
   # rouge is needed for testing source highlighting; Asciidoctor supports rouge >= 2
   gem 'rouge', (ENV.fetch 'ROUGE_VERSION', '~> 3.0')
-  if Gem.win_platform? && (Gem::Version.new RUBY_VERSION) >= (Gem::Version.new '2.6.0')
-    gem 'nokogiri', '~> 1.13.0'
+  if RUBY_ENGINE == 'truffleruby' || (Gem::Version.new RUBY_VERSION) < (Gem::Version.new '2.5.0')
+    gem 'nokogiri', '~> 1.10.0'
+  elsif (Gem::Version.new RUBY_VERSION) < (Gem::Version.new '2.6.0')
+    gem 'nokogiri', '~> 1.12.0'
   end
 end
 

--- a/asciidoctor.gemspec
+++ b/asciidoctor.gemspec
@@ -40,7 +40,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'erubi', '~> 1.10.0'
   s.add_development_dependency 'haml', '~> 5.2.0'
   s.add_development_dependency 'minitest', '~> 5.14.0'
-  s.add_development_dependency 'nokogiri', '~> 1.10.0'
+  s.add_development_dependency 'nokogiri', '~> 1.13.0'
   s.add_development_dependency 'rake', '~> 12.3.0'
   s.add_development_dependency 'slim', '~> 4.1.0'
   s.add_development_dependency 'tilt', '~> 2.0.0'


### PR DESCRIPTION
AsciiDoctor currently requires Nokogiri `~> 1.10.0`, but Nokogiri v1.10 has been out of support since January 2021, and this requirement may [prevent AsciiDoctor tests from running on Ruby 3.1](https://github.com/flavorjones/mini_portile/issues/101#issuecomment-1223072639).

This PR updates the gemspec to allow for modern versions of Nokogiri.

A side benefit is that Nokogiri >= 1.11 ships [precompiled native gems](https://nokogiri.org/index.html#native-gems-faster-more-reliable-installation) for most platforms.
