### PR TITLE
Added IMPORTANT: Atom is being sunset

### DIFF
--- a/docs/modules/tooling/pages/index.adoc
+++ b/docs/modules/tooling/pages/index.adoc
@@ -58,6 +58,13 @@ See its documentation for {url-asciidocfx-docs}[download and installation instru
 
 === Atom
 
+[IMPORTANT]
+====
+The Atom editor's official site has announced that Atom is being sunset at the end of 2022.
+
+See link:https://github.blog/2022-06-08-sunsetting-atom/[Sunsetting Atom]
+====
+
 Install https://atom.io/[Atom^].
 Then from the Atom editor menus, navigate to menu:Atom[Preferences].
 From there, open the menu:Packages[] tab and install:


### PR DESCRIPTION
This PR addresses issue #4362.

Added to the section on text editors:

```
[IMPORTANT]
====
The Atom editor's official site has announced that Atom is being sunset at the end of 2022.

See link:https://github.blog/2022-06-08-sunsetting-atom/[Sunsetting Atom] 
===
```