### PR TITLE
resolves #4393 avoid matching numeric character references when searching for # in xref target

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -62,6 +62,7 @@ Improvements::
   * Set linenums option on source block when line numbering is enabled (#3313)
   * Warn if include target is remote and `allow-uri-read` attribute is not set (#2284)
   * Return empty string instead of nil if raw or verbatim block has no lines
+  * Avoid numeric character reference when looking for fragment in target of xref (#4393)
   * Don't split value of `-r` CLI option; treat as single path (#4425)
 
 Bug Fixes::

--- a/lib/asciidoctor/substitutors.rb
+++ b/lib/asciidoctor/substitutors.rb
@@ -756,7 +756,7 @@ module Substitutors
 
         if doc.compat_mode
           fragment = refid
-        elsif (hash_idx = refid.index '#')
+        elsif (hash_idx = refid.index '#') && refid[hash_idx - 1] != '&'
           if hash_idx > 0
             if (fragment_len = refid.length - 1 - hash_idx) > 0
               path, fragment = (refid.slice 0, hash_idx), (refid.slice hash_idx + 1, fragment_len)

--- a/test/links_test.rb
+++ b/test/links_test.rb
@@ -1212,6 +1212,25 @@ context 'Links' do
     assert_xpath '//a[@href="#s1"][text()="Section Title"]', output, 1
   end
 
+  test 'should not match numeric character references while searching for fragment in xref target' do
+    input = <<~'EOS'
+    see <<Cub => Tiger>>
+
+    == Cub => Tiger
+    EOS
+    output = convert_string_to_embedded input
+    assert_xpath '//a[@href="#_cub_tiger"]', output, 1
+    assert_xpath %(//a[@href="#_cub_tiger"][text()="Cub #{decode_char 8658} Tiger"]), output, 1
+  end
+
+  test 'should not match numeric character references in path of interdocument xref' do
+    input = <<~'EOS'
+    see xref:{cpp}[{cpp}].
+    EOS
+    output = convert_string_to_embedded input
+    assert_includes output, '<a href="#C&#43;&#43;">C&#43;&#43;</a>'
+  end
+
   test 'anchor creates reference' do
     doc = document_from_string '[[tigers]]Tigers roam here.'
     ref = doc.catalog[:refs]['tigers']


### PR DESCRIPTION
Test provided. 

As mentioned in #4393, the substitutor handles link with numeric character references incorrectly. This fixes it by avoiding matches of numeric character references with a regex. 