### PR TITLE
resolves #4406 fix test assertion for fallback Rouge stylesheet to be compatible with Rouge 4.1

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -42,6 +42,7 @@ Compliance::
   * Disallow the use of dot (`.`) in the name of a named element attribute (#4147)
   * Disallow the use of the left square bracket in an attribute list on formatted text (#4306)
   * Fix call order so use of an include file with invalid encoding continues to raise error when using Ruby >= 3.2.0
+  * Fix test assertion for fallback Rouge stylesheet to be compatible with Rouge 4.1 (#4406) (*@tmzullinger*)
   * Drop support for Ruby < 2.5 and JRuby < 9.2
   * Update latest Ruby to 3.2 in CI workflows
 

--- a/test/syntax_highlighter_test.rb
+++ b/test/syntax_highlighter_test.rb
@@ -1061,8 +1061,8 @@ context 'Syntax Highlighter' do
       EOS
       output = convert_string input, safe: :safe, linkcss_default: true
       assert_css 'pre.rouge', output, 1
-      assert_includes output, 'pre.rouge .no {'
-      assert_match %r/pre\.rouge \{\s*background-color: #f8f8f8;/m, output
+      expected_css = (Asciidoctor::SyntaxHighlighter.for 'rouge').read_stylesheet 'github'
+      assert_includes output, expected_css
     end
 
     test 'should restore isolated callout mark on last line of source' do


### PR DESCRIPTION
Adjust the pattern used by the `should gracefully fallback to default style if specified style not recognized` test to support rouge-4.1.0.

Upstream rouge commit 6f5aecd2 (Update GitHub theme, add dark mode (#1918), 2023-01-24) changed the CSS output.  Work with both old and new CSS.

resolves #4406