### PR TITLE
Add closing parenthesis to capture group to properly catch enclosed links

### DIFF
--- a/lib/asciidoctor/rx.rb
+++ b/lib/asciidoctor/rx.rb
@@ -517,7 +517,7 @@ module Asciidoctor
   #   "https://github.com[]"
   #
   # FIXME revisit! the main issue is we need different rules for implicit vs explicit
-  InlineLinkRx = %r((^|link:|#{CG_BLANK}|&lt;|[>\(\)\[\];"'])(\\?(?:https?|file|ftp|irc)://[^\s\[\]<]*([^\s.,\[\]<]))(?:\[(|#{CC_ALL}*?[^\\])\])?)m
+  InlineLinkRx = %r((^|link:|#{CG_BLANK}|&lt;|[>\(\)\[\];"'])(\\?(?:https?|file|ftp|irc)://[^\s\[\]<]*([^\s.,\[\]<\)]))(?:\[(|#{CC_ALL}*?[^\\])\])?)m
 
   # Match a link or e-mail inline macro.
   #


### PR DESCRIPTION
I am working on an extension that extracts more detailed info about documents. I was trying to get the links and their source code location. I noticed that some of the links would have broken match data and wouldn't work. After some digging I noticed that this only happens when you have links enclosed in parentheses.

The regex for `InlineLinkRx` incorrectly matches the closing parenthesis into the third capture group. This usually is not a problem because `sub_macros` will perform some additional sanitizing and correctly strip the parenthesis for the internal processing. However, if you try to just filter the unprocessed lines with the regex you'll end up with false matches.

```ruby
require 'asciidoctor'

include Asciidoctor

testlinks = [
  'ABCD https://www.google.com',
  'ABCD (https://www.google.com)',
  'link:https://www.google.com',
  '(link:https://www.google.com)',
  'link:https://www.google.com[]',
  '(link:https://www.google.com[])',
]

puts
puts 'InlineLinkRx'
puts InlineLinkRx

testlinks.each do |link|
  bar = link.match(InlineLinkRx)
  pp bar
end

puts
patched = %r((^|link:|#{CG_BLANK}|&lt;|[>\(\)\[\];"'])(\\?(?:https?|file|ftp|irc)://[^\s\[\]<]*([^\s.,\[\]<\)]))(?:\[(|#{CC_ALL}*?[^\\])\])?)m
puts 'Patched InlineLinkRx'
puts patched

testlinks.each do |link|
  bar = link.match(patched)
  pp bar
end
```

Note how MatchData result 2 the has these parentheses included in the current version. When you use an empty attriblist `[]` it matches correctly. This only occurs if you have a link without macro or macro without attriblist enclosed in parenthesis.

```
InlineLinkRx
(?m-ix:(^|link:|\p{Blank}|&lt;|[>\(\)\[\];"'])(\\?(?:https?|file|ftp|irc):\/\/[^\s\[\]<]*([^\s.,\[\]<]))(?:\[(|.*?[^\\])\])?)
#<MatchData " https://www.google.com" 1:" " 2:"https://www.google.com" 3:"m" 4:nil>
#<MatchData "(https://www.google.com)" 1:"(" 2:"https://www.google.com)" 3:")" 4:nil>
#<MatchData "link:https://www.google.com" 1:"link:" 2:"https://www.google.com" 3:"m" 4:nil>
#<MatchData "link:https://www.google.com)" 1:"link:" 2:"https://www.google.com)" 3:")" 4:nil>
#<MatchData "link:https://www.google.com[]" 1:"link:" 2:"https://www.google.com" 3:"m" 4:"">
#<MatchData "link:https://www.google.com[]" 1:"link:" 2:"https://www.google.com" 3:"m" 4:"">

Patched InlineLinkRx
(?m-ix:(^|link:|\p{Blank}|&lt;|[>\(\)\[\];"'])(\\?(?:https?|file|ftp|irc):\/\/[^\s\[\]<]*([^\s.,\[\]<\)]))(?:\[(|.*?[^\\])\])?)
#<MatchData " https://www.google.com" 1:" " 2:"https://www.google.com" 3:"m" 4:nil>
#<MatchData "(https://www.google.com" 1:"(" 2:"https://www.google.com" 3:"m" 4:nil>
#<MatchData "link:https://www.google.com" 1:"link:" 2:"https://www.google.com" 3:"m" 4:nil>
#<MatchData "link:https://www.google.com" 1:"link:" 2:"https://www.google.com" 3:"m" 4:nil>
#<MatchData "link:https://www.google.com[]" 1:"link:" 2:"https://www.google.com" 3:"m" 4:"">
#<MatchData "link:https://www.google.com[]" 1:"link:" 2:"https://www.google.com" 3:"m" 4:"">
```