### PR TITLE
Clarify that source_location is not tracked by default

### DIFF
--- a/docs/modules/api/pages/sourcemap.adoc
+++ b/docs/modules/api/pages/sourcemap.adoc
@@ -46,6 +46,26 @@ Here's an example of how to enable the sourcemap using the API:
 doc = Asciidoctor.load_file 'doc.adoc', safe: :safe, sourcemap: true
 ----
 
+Extensions can enable the sourcemap as such:
+
+[,ruby]
+----
+class Asciidoctor::Document
+  attr_writer :sourcemap unless method_defined? :sourcemap=
+end
+
+# A preprocessor that enables the sourcemap feature if not
+# already enabled via the API.
+Asciidoctor::Extensions.register do
+  preprocessor do
+    process do |doc, reader|
+      doc.sourcemap = true
+      nil
+    end
+  end
+end
+----
+
 Now that the sourcemap is enabled, you can access the source location of the block elements in the parsed document.
 
 == Use the sourcemap

--- a/lib/asciidoctor/abstract_block.rb
+++ b/lib/asciidoctor/abstract_block.rb
@@ -25,6 +25,7 @@ class AbstractBlock < AbstractNode
   attr_accessor :numeral
 
   # Public: Gets/Sets the location in the AsciiDoc source where this block begins.
+  # Tracking source location is not enabled by default, and is controlled by the sourcemap option.
   attr_accessor :source_location
 
   # Public: Get/Set the String style (block type qualifier) for this block.


### PR DESCRIPTION
... in the API documentation. The docs/ explain this, but a hint at the sourcemap option in the API docs would allow the reader to find that information.