### PR TITLE
Add styling for table header and striping in docbook converter

### DIFF
--- a/lib/asciidoctor/converter/docbook5.rb
+++ b/lib/asciidoctor/converter/docbook5.rb
@@ -379,7 +379,11 @@ class Converter::DocBook5Converter < Converter::Base
     pgwide_attribute = (node.option? 'pgwide') ? ' pgwide="1"' : ''
     frame = 'topbot' if (frame = node.attr 'frame', 'all', 'table-frame') == 'ends'
     grid = node.attr 'grid', nil, 'table-grid'
-    result << %(<#{tag_name = node.title? ? 'table' : 'informaltable'}#{common_attributes node.id, node.role, node.reftext}#{pgwide_attribute} frame="#{frame}" rowsep="#{(%w(none cols).include? grid) ? 0 : 1}" colsep="#{(%w(none rows).include? grid) ? 0 : 1}"#{(node.attr? 'orientation', 'landscape', 'table-orientation') ? ' orient="land"' : ''}>)
+    stripes = node.attr 'stripes', nil, 'table-stripes'
+    stripe_style = ("striped-even" if stripes==='even') || ("striped-odd" if stripes==='odd') || nil
+    header_style = ('headerbg' if node.option? 'headerbg') || nil
+    tab_style = [stripe_style, header_style].compact.join(',');
+    result << %(<#{tag_name = node.title? ? 'table' : 'informaltable'}#{common_attributes node.id, node.role, node.reftext}#{pgwide_attribute} frame="#{frame}" rowsep="#{(%w(none cols).include? grid) ? 0 : 1}" colsep="#{(%w(none rows).include? grid) ? 0 : 1}"#{(node.attr? 'orientation', 'landscape', 'table-orientation') ? ' orient="land"' : ''} #{tab_style.empty? ? '' : 'tabstyle="' + "#{tab_style}" +'"'}>)
     if node.option? 'unbreakable'
       result << '<?dbfo keep-together="always"?>'
     elsif node.option? 'breakable'


### PR DESCRIPTION
Adds a tab style attribute with striping and header background value if they are present. The actual table striping is now handled downstream in docbook xsl. 

An example of the table.row.properties needed to use these features
```xml
<xsl:template name="table.row.properties">
    <xsl:choose>
        <xsl:when test="$bgcolor != ''">
            <xsl:attribute name="background-color">
                <xsl:value-of select="$bgcolor" />
            </xsl:attribute>
        </xsl:when>
        <xsl:when test="contains($tabstyle, 'striped-odd')">
            <xsl:if test="$rownum mod 2 != 0 and not(ancestor::thead)">
                <xsl:attribute name="background-color">
                    <xsl:value-of select="$table.row.background-color" />
                </xsl:attribute>
            </xsl:if>
        </xsl:when>
        <xsl:when test="contains($tabstyle, 'striped-even')">
            <xsl:if test="$rownum mod 2 = 0">
                <xsl:attribute name="background-color">
                    <xsl:value-of select="$table.row.background-color" />
                </xsl:attribute>
            </xsl:if>
        </xsl:when>
    </xsl:choose>
    <xsl:if test="ancestor::thead">
        <xsl:if test="contains($tabstyle, 'headerbg')">
            <xsl:attribute name="background-color">
                <xsl:value-of select="$table.heading.background-color" />
            </xsl:attribute>
        </xsl:if>
    </xsl:if>
</xsl:template>
```