### PR TITLE
Fix mantitle parsing (fixes #4445)

### DIFF
--- a/lib/asciidoctor/parser.rb
+++ b/lib/asciidoctor/parser.rb
@@ -206,7 +206,7 @@ class Parser
   def self.parse_manpage_header reader, document, block_attributes, header_only = false
     if ManpageTitleVolnumRx =~ (doc_attrs = document.attributes)['doctitle']
       doc_attrs['manvolnum'] = manvolnum = $2
-      doc_attrs['mantitle'] = (((mantitle = $1).include? ATTR_REF_HEAD) ? (document.sub_attributes mantitle) : mantitle).downcase
+      doc_attrs['mantitle'] = (document.sub_replacements (((mantitle = $1).include? ATTR_REF_HEAD) ? (document.sub_attributes mantitle) : mantitle)).downcase
     else
       logger.error message_with_context 'non-conforming manpage title', source_location: (reader.cursor_at_line 1)
       # provide sensible fallbacks


### PR DESCRIPTION
If the document title is unescaped for `<title>`, it should be unescaped for `<refentrytitle>` as well.

    = foo\--bar\--roo(1)
    <title>foo--bar--roo(1)</title>
    <refentrytitle>foo--bar--roo</refentrytitle>