### PR TITLE
resolves #4458 process constrained inline passthrough inside monospace span

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -73,6 +73,7 @@ Improvements::
 
 Bug Fixes::
 
+  * Process constrained inline passthrough inside monospace span (#4458)
   * Catalog inline ref defined using anchor macro even when resolved reftext is empty
   * Use while loop rather than recursion to locate next line to process; prevents stack limit error (#4368)
   * Avoid numeric character reference when looking for fragment in target of xref (#4393, #3642)

--- a/lib/asciidoctor/rx.rb
+++ b/lib/asciidoctor/rx.rb
@@ -569,22 +569,16 @@ module Asciidoctor
   # Examples
   #
   #   +text+
-  #   `text` (compat)
+  #   [x-]+text+
+  #   [x-]`text`
+  #   `text` (compat only)
+  #   [role]`text` (compat only)
   #
   # NOTE we always capture the attributes so we know when to use compatible (i.e., legacy) behavior
   InlinePassRx = {
-    false => ['+', '`', /(^|[^#{CC_WORD};:])(?:#{QuoteAttributeListRxt})?(\\?(\+|`)(\S|\S#{CC_ALL}*?\S)\4)(?!#{CG_WORD})/m],
-    true => ['`', nil, /(^|[^`#{CC_WORD}])(?:#{QuoteAttributeListRxt})?(\\?(`)([^`\s]|[^`\s]#{CC_ALL}*?\S)\4)(?![`#{CC_WORD}])/m],
+    false => ['+', '-]', /((?:^|[^#{CC_WORD};:\\])(?=(\[)|\+)|\\(?=\[)|(?=\\\+))(?:\2(x-|[^\[\]]+ x-)\]|(?:#{QuoteAttributeListRxt})?(?=(\\)?\+))(\5?(\+|`)(\S|\S#{CC_ALL}*?\S)\7)(?!#{CG_WORD})/m],
+    true => ['`', nil, /(^|[^`#{CC_WORD}])(?:(\Z)()|#{QuoteAttributeListRxt}(?=(\\))?)?(\5?(`)([^`\s]|[^`\s]#{CC_ALL}*?\S)\7)(?![`#{CC_WORD}])/m],
   }
-
-  # Matches an inline plus passthrough spanning multiple lines, but only when it occurs directly
-  # inside constrained monospaced formatting in non-compat mode.
-  #
-  # Examples
-  #
-  #   +text+
-  #
-  SinglePlusInlinePassRx = /^(\\)?\+(\S|\S#{CC_ALL}*?\S)\+$/m
 
   # Matches several variants of the passthrough inline macro, which may span multiple lines.
   #

--- a/test/substitutions_test.rb
+++ b/test/substitutions_test.rb
@@ -2154,6 +2154,42 @@ context 'Substitutions' do
         assert_equal 'the text <code>asciimath:[x = y]</code> should be passed through as <code>literal</code> text', para.content
       end
 
+      test 'should support constrained passthrough in middle of monospace span' do
+        input = 'a `foo +bar+ baz` kind of thing'
+        para = block_from_string input
+        assert_equal 'a <code>foo bar baz</code> kind of thing', para.content
+      end
+
+      test 'should support constrained passthrough in monospace span preceded by escaped boxed attrlist with transitional role' do
+        input = %(#{BACKSLASH}[x-]`foo +bar+ baz`)
+        para = block_from_string input
+        assert_equal '[x-]<code>foo bar baz</code>', para.content
+      end
+
+      test 'should treat monospace phrase with escaped boxed attrlist with transitional role as monospace' do
+        input = %(#{BACKSLASH}[x-]`*foo* +bar+ baz`)
+        para = block_from_string input
+        assert_equal '[x-]<code><strong>foo</strong> bar baz</code>', para.content
+      end
+
+      test 'should ignore escaped attrlist with transitional role on monospace phrase if not proceeded by [' do
+        input = %(#{BACKSLASH}x-]`*foo* +bar+ baz`)
+        para = block_from_string input
+        assert_equal %(#{BACKSLASH}x-]<code><strong>foo</strong> bar baz</code>), para.content
+      end
+
+      test 'should not process passthrough inside transitional literal monospace span' do
+        input = 'a [x-]`foo +bar+ baz` kind of thing'
+        para = block_from_string input
+        assert_equal 'a <code>foo +bar+ baz</code> kind of thing', para.content
+      end
+
+      test 'should support constrained passthrough in monospace phrase with attrlist' do
+        input = '[.role]`foo +bar+ baz`'
+        para = block_from_string input
+        assert_equal '<code class="role">foo bar baz</code>', para.content
+      end
+
       test 'should support attrlist on a literal monospace phrase' do
         input = '[.baz]`+foo--bar+`'
         para = block_from_string input


### PR DESCRIPTION
this change also fixes some incorrectly matched constrained passthrough and monospace cases, now covered by tests