### PR TITLE
Expose unwrapped Rouge HTML formatter

### DIFF
--- a/docs/modules/syntax-highlighting/examples/autolink-urls-in-comments.rb
+++ b/docs/modules/syntax-highlighting/examples/autolink-urls-in-comments.rb
@@ -1,7 +1,7 @@
 class ExtendedRougeSyntaxHighlighter < (Asciidoctor::SyntaxHighlighter.for 'rouge')
   register_for 'rouge'
 
-  def create_formatter node, source, lang, opts
+  def create_html_formatter opts
     formatter = super
     formatter.singleton_class.prepend (Module.new do
       def safe_span tok, safe_val

--- a/lib/asciidoctor/syntax_highlighter/rouge.rb
+++ b/lib/asciidoctor/syntax_highlighter/rouge.rb
@@ -72,10 +72,14 @@ class SyntaxHighlighter::RougeAdapter < SyntaxHighlighter::Base
     lexer || ::Rouge::Lexers::PlainText.new
   end
 
-  def create_formatter node, source, lang, opts
-    formatter = opts[:css_mode] == :class ?
+  def create_html_formatter opts
+    opts[:css_mode] == :class ?
       (::Rouge::Formatters::HTML.new inline_theme: @style) :
       (::Rouge::Formatters::HTMLInline.new (::Rouge::Theme.find @style).new)
+  end
+
+  def create_formatter node, source, lang, opts
+    formatter = create_html_formatter opts
     if (number_lines = opts[:number_lines])
       formatter = RougeExt::Formatters::HTMLLineHighlighter.new formatter, lines: opts[:highlight_lines]
       number_lines == :table ?


### PR DESCRIPTION
This exposes the Rouge HTML formatter prior to any extension wrapping in order to allow further customizations when overriding the `Asciidoctor::SyntaxHighlighter::RougeAdapter` class.

This is a similar fix to an older issue reported at https://github.com/asciidoctor/asciidoctor/issues/3953.

Prior to these changes, executing for example this code ([autolink-urls-in-comments.rb]):

```ruby
class ExtendedRougeSyntaxHighlighter < (Asciidoctor::SyntaxHighlighter.for 'rouge')
  register_for 'rouge'

  def create_formatter node, source, lang, opts
    formatter = super
    formatter.singleton_class.prepend (Module.new do
      def safe_span tok, safe_val
        if tok.token_chain[0].matches? ::Rouge::Token::Tokens::Comment
          safe_val = safe_val.gsub(/https?:\/\/\S+/, '<a href="\&">\&</a>')
        end
        super
      end
    end)
    formatter
  end
end
```

Could potentially cause to override classes that do not implement `safe_span()`, for example `RougeExt::Formatters::HTMLTableLineNumberer` as we expect `Rouge::Formatters::HTML` instead.

Those other classes (`RougeExt::Formatters::*`) may be useful for extensions to keep enabled but currently need to be disabled as they are shadowing `Rouge::Formatters::HTML`.

The [autolink-urls-in-comments.rb] example would only work when not passing the attributes `%linenums`, and `highlight`:

```adoc
:source-highlighter: rouge

== This works

[,ruby]
----
get {
  render "Hello, World!"   # https://example.com
}
----

== This doesn't work

[%linenums,ruby]
----
get {
  render "Hello, World!"   # https://example.com
}
----

== This doesn't work

[,ruby,highlight=2]
----
get {
  render "Hello, World!"   # https://example.com
}
----
```



<details>

<summary>HTML Output (look for <code>&lt;a</code> presence):</summary>

```html
<div class="sect1">
    <h2 id="_this_works">This works</h2>
    <div class="sectionbody">
        <div class="listingblock">
            <div class="content">
<pre class="rouge highlight"><code data-lang="ruby"><span class="n">get</span> <span class="p">{</span>
  <span class="n">render</span> <span class="s2">"Hello, World!"</span>   <span class="c1"># <a
            href="https://example.com">https://example.com</a></span>
<span class="p">}</span></code></pre>
            </div>
        </div>
    </div>
</div>
<div class="sect1">
    <h2 id="_this_doesnt_work">This doesn&#8217;t work</h2>
    <div class="sectionbody">
        <div class="listingblock">
            <div class="content">
<pre class="rouge highlight"><code data-lang="ruby"><table class="linenotable"><tbody><tr><td class="linenos"><pre>1</pre></td><td
        class="code"><pre><span class="n">get</span> <span class="p">{</span>
</pre></td></tr><tr><td class="linenos"><pre>2</pre></td><td class="code"><pre>  <span class="n">render</span> <span
        class="s2">"Hello, World!"</span>   <span class="c1"># https://example.com</span>
</pre></td></tr><tr><td class="linenos"><pre>3</pre></td><td class="code"><pre><span class="p">}</span>
</pre></td></tr></tbody></table></code></pre>
            </div>
        </div>
    </div>
</div>
<div class="sect1">
    <h2 id="_this_doesnt_work_2">This doesn&#8217;t work</h2>
    <div class="sectionbody">
        <div class="listingblock">
            <div class="content">
<pre class="rouge highlight"><code data-lang="ruby"><span class="n">get</span> <span class="p">{</span>
<span class="hll">  <span class="n">render</span> <span class="s2">"Hello, World!"</span>   <span class="c1"># https://example.com</span>
</span><span class="p">}</span></code></pre>
            </div>
        </div>
    </div>
</div>
```

</details>


<details>

<summary>HTML Output after the fix (this PR):</summary>


```html
<div class="sect1">
    <h2 id="_this_works">This works</h2>
    <div class="sectionbody">
        <div class="listingblock">
            <div class="content">
<pre class="rouge highlight"><code data-lang="ruby"><span class="n">get</span> <span class="p">{</span>
  <span class="n">render</span> <span class="s2">"Hello, World!"</span>   <span class="c1"># <a href="https://example.com">https://example.com</a></span>
<span class="p">}</span></code></pre>
            </div>
        </div>
    </div>
</div>
<div class="sect1">
    <h2 id="_this_doesnt_work">This doesn&#8217;t work</h2>
    <div class="sectionbody">
        <div class="listingblock">
            <div class="content">
<pre class="rouge highlight"><code data-lang="ruby"><table class="linenotable"><tbody><tr><td class="linenos"><pre>1</pre></td><td class="code"><pre><span class="n">get</span> <span class="p">{</span>
</pre></td></tr><tr><td class="linenos"><pre>2</pre></td><td class="code"><pre>  <span class="n">render</span> <span class="s2">"Hello, World!"</span>   <span class="c1"># <a href="https://example.com">https://example.com</a></span>
</pre></td></tr><tr><td class="linenos"><pre>3</pre></td><td class="code"><pre><span class="p">}</span>
</pre></td></tr></tbody></table></code></pre>
            </div>
        </div>
    </div>
</div>
<div class="sect1">
    <h2 id="_this_doesnt_work_2">This doesn&#8217;t work</h2>
    <div class="sectionbody">
        <div class="listingblock">
            <div class="content">
<pre class="rouge highlight"><code data-lang="ruby"><span class="n">get</span> <span class="p">{</span>
<span class="hll">  <span class="n">render</span> <span class="s2">"Hello, World!"</span>   <span class="c1"># <a href="https://example.com">https://example.com</a></span>
</span><span class="p">}</span></code></pre>
            </div>
        </div>
    </div>
</div>
```


</details>


[autolink-urls-in-comments.rb]: https://github.com/asciidoctor/asciidoctor/blob/f3800cc9c92faf8370041b2b27a61124318ed289/docs/modules/syntax-highlighting/examples/autolink-urls-in-comments.rb