### PR TITLE
resolves #4482 fix look of tables in man pages

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -65,6 +65,7 @@ Improvements::
 Bug Fixes::
 
   * Escape spaces in include target (using inline passthrough) when generating link from include directive (#4461)
+  * Tables in man pages no longer have a blank line at the top of each table cell
 
 == 2.0.20 (2023-05-18) - @mojavelinux
 

--- a/lib/asciidoctor/converter/manpage.rb
+++ b/lib/asciidoctor/converter/manpage.rb
@@ -425,7 +425,7 @@ allbox tab(:);'
           if row_header[row_index][cell_index] == ['^t']
             row_text[row_index] << %(T{#{LF}.sp#{LF}T}:)
           end
-          row_text[row_index] << %(T{#{LF}.sp#{LF})
+          row_text[row_index] << %(T{#{LF})
           cell_halign = (cell.attr 'halign', 'left').chr
           if tsec == :body
             if row_header[row_index].empty? || row_header[row_index][cell_index].empty?

--- a/test/manpage_test.rb
+++ b/test/manpage_test.rb
@@ -718,19 +718,15 @@ context 'Manpage' do
       allbox tab(:);
       lt.
       T{
-      .sp
       Header
       T}
       T{
-      .sp
       Body 1
       T}
       T{
-      .sp
       Body 2
       T}
       T{
-      .sp
       Footer
       T}
       .TE
@@ -778,23 +774,17 @@ context 'Manpage' do
       allbox tab(:);
       lt lt lt.
       T{
-      .sp
       Name
       T}:T{
-      .sp
       Description
       T}:T{
-      .sp
       Default
       T}
       T{
-      .sp
       dim
       T}:T{
-      .sp
       dimension of the object
       T}:T{
-      .sp
       3
       T}
       .TE
@@ -819,10 +809,8 @@ context 'Manpage' do
       allbox tab(:);
       lt lt.
       T{
-      .sp
       a
       T}:T{
-      .sp
       .nf
       b
       c    _d_


### PR DESCRIPTION
Tables in man pages have a blank line at the top of each table cell. For example:

    [cols="1,1"]
    |===
    |Cell in column 1, row 1
    |Cell in column 2, row 1

    |Cell in column 1, row 2
    |Cell in column 2, row 2

    |Cell in column 1, row 3
    |Cell in column 2, row 3
    |===

Man page output (using Linux's man command):

    ┌────────────────────────┬─────────────────────────┐
    │                        │                         │
    │Cell in column 1, row 1 │ Cell in column 2, row 1 │
    ├────────────────────────┼─────────────────────────┤
    │                        │                         │
    │Cell in column 1, row 2 │ Cell in column 2, row 2 │
    ├────────────────────────┼─────────────────────────┤
    │                        │                         │
    │Cell in column 1, row 3 │ Cell in column 2, row 3 │
    └────────────────────────┴─────────────────────────┘

Remove the blank lines to make the table more compact:

    ┌────────────────────────┬─────────────────────────┐
    │Cell in column 1, row 1 │ Cell in column 2, row 1 │
    ├────────────────────────┼─────────────────────────┤
    │Cell in column 1, row 2 │ Cell in column 2, row 2 │
    ├────────────────────────┼─────────────────────────┤
    │Cell in column 1, row 3 │ Cell in column 2, row 3 │
    └────────────────────────┴─────────────────────────┘