### PR TITLE
[Docs] Add command for generating default Gemfile

### DIFF
--- a/docs/modules/install/pages/ruby-packaging.adoc
+++ b/docs/modules/install/pages/ruby-packaging.adoc
@@ -40,7 +40,13 @@ Note that it's possible that the prerelease version is older than the latest sta
 
 == Bundler
 
-. Create a Gemfile in the root folder of your project (or the current directory)
+. Create a Gemfile in the root folder of your project (or the current directory):
++
+[,ruby,subs=attributes+]
+----
+bundle init
+----
+
 . Add the `asciidoctor` gem to your Gemfile as follows:
 +
 [,ruby,subs=attributes+]


### PR DESCRIPTION
To help new users, I thought the Bundler instructions could include the `bundle init` command. This generates a Gemfile with the default rubygems.org source [1].

[1] https://bundler.io/guides/gemfile.html#gemfiles