### PR TITLE
resolves #4492 add Wistia support to the video macro

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -35,6 +35,7 @@ Enhancements::
   * Honor `level` and `formatter` keyword arguments passed to Logger constructor (#4250)
   * Set logdev to $stderr if no arguments are passed to Logger constructor (#4250)
   * Add support for skipping TOML front matter (Hugo) when `skip-front-matter` attribute is set (#4300) (*@abhinav*)
+  * Add support for Wistia using the video macro
 
 Compliance::
 

--- a/data/reference/syntax.adoc
+++ b/data/reference/syntax.adoc
@@ -287,6 +287,8 @@ video::aHjpOzsQ9YI[youtube]
 
 video::300817511[vimeo]
 
+video::e4a27b971d[wistia]
+
 == Breaks
 
 // thematic break (aka horizontal rule)

--- a/lib/asciidoctor/converter/html5.rb
+++ b/lib/asciidoctor/converter/html5.rb
@@ -1095,6 +1095,21 @@ Your browser does not support the audio tag.
 <iframe#{width_attribute}#{height_attribute} src="#{asset_uri_scheme}//www.youtube.com/embed/#{target}?rel=#{rel_param_val}#{start_param}#{end_param}#{autoplay_param}#{loop_param}#{mute_param}#{controls_param}#{list_param}#{fs_param}#{modest_param}#{theme_param}#{hl_param}" frameborder="0"#{fs_attribute}></iframe>
 </div>
 </div>)
+    when 'wistia'
+      unless (asset_uri_scheme = node.document.attr 'asset-uri-scheme', 'https').empty?
+        asset_uri_scheme = %(#{asset_uri_scheme}:)
+      end
+      delimiter = ['?']
+      start_anchor = (node.attr? 'start') ? %(#{delimiter.pop || '&amp;'}time=#{node.attr 'start'}) : ''
+      loop_param = (node.attr? 'loopBehavior') ? %(#{delimiter.pop || '&amp;'}endVideoBehavior=#{node.attr 'loopBehavior'}) : ''
+      target = (node.attr 'target')
+      autoplay_param = (node.option? 'autoplay') ? %(#{delimiter.pop || '&amp;'}autoPlay=true) : ''
+      muted_param = (node.option? 'muted') ? %(#{delimiter.pop || '&amp;'}muted=true) : ''
+      %(<div#{id_attribute}#{class_attribute}>#{title_element}
+<div class="content">
+<iframe#{width_attribute}#{height_attribute} src="#{asset_uri_scheme}//fast.wistia.com/embed/iframe/#{target}#{start_anchor}#{autoplay_param}#{loop_param}#{muted_param}" frameborder="0"#{(node.option? 'nofullscreen') ? '' : (append_boolean_attribute 'allowfullscreen', xml)} class="wistia_embed" name="wistia_embed"></iframe>
+</div>
+</div>)
     else
       poster_attribute = (val = node.attr 'poster').nil_or_empty? ? '' : %( poster="#{node.media_uri val}")
       preload_attribute = (val = node.attr 'preload').nil_or_empty? ? '' : %( preload="#{val}")

--- a/test/blocks_test.rb
+++ b/test/blocks_test.rb
@@ -3260,6 +3260,26 @@ context 'Blocks' do
       assert_css 'iframe[height="360"]', output, 1
     end
 
+    test 'video macro should output custom HTML with iframe for wistia service' do
+      input = 'video::e4a27b971d[wistia, 640, 360, start=60, options="autoplay,muted"]'
+      output = convert_string_to_embedded input
+      assert_css 'video', output, 0
+      assert_css 'iframe', output, 1
+      assert_css 'iframe[src="https://fast.wistia.com/embed/iframe/e4a27b971d?time=60&autoPlay=true&muted=true"]', output, 1
+      assert_css 'iframe[width="640"]', output, 1
+      assert_css 'iframe[height="360"]', output, 1
+    end
+
+    test 'video macro should output custom HTML with iframe for wistia service with loop behavior set' do
+      input = 'video::e4a27b971d[wistia, 640, 360, start=60, loopBehavior="reset" options="autoplay,muted"]'
+      output = convert_string_to_embedded input
+      assert_css 'video', output, 0
+      assert_css 'iframe', output, 1
+      assert_css 'iframe[src="https://fast.wistia.com/embed/iframe/e4a27b971d?time=60&autoPlay=true&endVideoBehavior=reset&muted=true"]', output, 1
+      assert_css 'iframe[width="640"]', output, 1
+      assert_css 'iframe[height="360"]', output, 1
+    end
+
     test 'should detect and convert audio macro' do
       input = 'audio::podcast.mp3[]'
       output = convert_string_to_embedded input


### PR DESCRIPTION
This PR adds basic support for Wistia to the `video::` macro, following a similar approach to how Youtube and Vimeo are currently supported. It supports some basic options (controlling looping behavior, autoplay, start time, dimensions, and muting), and uses an `iframe` embedding method.

It does include referencing an external script they recommend including with their embeds - while recommended, we don't strictly have to for things to work, so your call on whether you'd prefer we remove it.