### PR TITLE
resolves #4493 support ruby3.3 Logger by properly initialize super class

### DIFF
--- a/lib/asciidoctor/logging.rb
+++ b/lib/asciidoctor/logging.rb
@@ -42,6 +42,7 @@ class MemoryLogger < ::Logger
   attr_reader :messages
 
   def initialize
+    super nil
     self.level = UNKNOWN
     @messages = []
   end
@@ -69,6 +70,7 @@ class NullLogger < ::Logger
   attr_reader :max_severity
 
   def initialize
+    super nil
     self.level = UNKNOWN
   end
 


### PR DESCRIPTION
Upcoming ruby3.3 will have enhanced Logger class:
https://github.com/ruby/ruby/commit/194520f80e1cdb71faa055d731450855a1ddb8d1 which initializes newly added instance variables.
Without initializing such variables (in super class), now using subclass of Logger will cause exception.

To avoid this, first call super, then execute additional subclass initialization.

Closes #4493 .