### PR TITLE
fix broken google doc extention link in Update ms-word.adoc

### DIFF
--- a/docs/modules/migrate/pages/ms-word.adoc
+++ b/docs/modules/migrate/pages/ms-word.adoc
@@ -2,7 +2,7 @@
 :navtitle: Migrate from MS Word
 :description: This page presents various tools and strategies for migrating from MS Word to AsciiDoc.
 :url-pandoc: https://pandoc.org
-:url-google-asciidoc: https://chrome.google.com/webstore/detail/asciidoc-processor/eghlmnhjljbjodpeehjjcgfcjegcfbhk/
+:url-google-asciidoc: https://workspace.google.com/marketplace/app/asciidoc_processor/1023004302050
 :url-google-asciidoc-source:  https://github.com/Mogztter/asciidoc-googledocs-addon/
 
 == Pandoc


### PR DESCRIPTION
https://workspace.google.com/marketplace/app/asciidoc_processor/1023004302050 is the correct link, taken from the doc link for the extention, old one 404s