### PR TITLE
resolves #4530 by underlining active footnote link in footnotes list

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -67,6 +67,7 @@ Improvements::
   * Remove empty line at top of table cells in manpage output (#4482) (*@strager*)
   * Return `nil` if name passed to `Asciidoctor::SafeMode.value_for_name` is not recognized (#3526)
   * Modify default stylesheet to honor text-* roles on quote blocks
+  * Modify default stylesheet to add text decoration to active footnote number link in footnotes list (#4530) (@Larhzu)
 
 Bug Fixes::
 

--- a/data/stylesheets/asciidoctor-default.css
+++ b/data/stylesheets/asciidoctor-default.css
@@ -288,7 +288,7 @@ a.image{text-decoration:none;display:inline-block}
 a.image object{pointer-events:none}
 sup.footnote,sup.footnoteref{font-size:.875em;position:static;vertical-align:super}
 sup.footnote a,sup.footnoteref a{text-decoration:none}
-sup.footnote a:active,sup.footnoteref a:active{text-decoration:underline}
+sup.footnote a:active,sup.footnoteref a:active,#footnotes .footnote a:first-of-type:active{text-decoration:underline}
 #footnotes{padding-top:.75em;padding-bottom:.75em;margin-bottom:.625em}
 #footnotes hr{width:20%;min-width:6.25em;margin:-.25em 0 .75em;border-width:1px 0 0}
 #footnotes .footnote{padding:0 .375em 0 .225em;line-height:1.3334;font-size:.875em;margin-left:1.2em;margin-bottom:.2em}

--- a/src/stylesheets/asciidoctor.css
+++ b/src/stylesheets/asciidoctor.css
@@ -1748,7 +1748,8 @@ sup.footnoteref a {
 }
 
 sup.footnote a:active,
-sup.footnoteref a:active {
+sup.footnoteref a:active,
+#footnotes .footnote a:first-of-type:active {
   text-decoration: underline;
 }
 


### PR DESCRIPTION
Consider the following document:

    = Title

    Foo.footnote:[Bar]

The link after Foo is underlined in active state but the link before Bar wasn't before this commit.

Note that the related

    #footnotes .footnote a:first-of-type {
      ...
      text-decoration: none;
      ...
    }

is later in the stylesheet but this way the code is slightly smaller.

Fixes: https://github.com/asciidoctor/asciidoctor/issues/4530