### PR TITLE
RFC: Use YARD to document API

### DIFF
--- a/lib/asciidoctor/abstract_node.rb
+++ b/lib/asciidoctor/abstract_node.rb
@@ -1,31 +1,46 @@
 # frozen_string_literal: true
 
 module Asciidoctor
-# Public: An abstract base class that provides state and methods for managing a
+# An abstract base class that provides state and methods for managing a
 # node of AsciiDoc content. The state and methods on this class are common to
 # all content segments in an AsciiDoc document.
 class AbstractNode
   include Logging
   include Substitutors
 
-  # Public: Get the Hash of attributes for this node
+  # Get the Hash of attributes for this node
+  #
+  # @return [Hash<String, String>]
   attr_reader :attributes
 
-  # Public: Get the Symbol context for this node
+  # Get the Symbol context for this node
+  #
+  # @return [Symbol]
   attr_reader :context
 
-  # Public: Get the Asciidoctor::Document to which this node belongs
+  # Get the Asciidoctor::Document to which this node belongs
+  #
+  # @return [Asciidoctor::Document]
   attr_reader :document
 
-  # Public: Get/Set the String id of this node
+  # Get/Set the String id of this node
+  #
+  # @return [String]
   attr_accessor :id
 
-  # Public: Get the String name of this node
+  # Get the String name of this node
+  #
+  # @return [String]
   attr_reader :node_name
 
-  # Public: Get the AbstractBlock parent element of this node
+  # Get the AbstractBlock parent element of this node
+  #
+  # @return [Asciidoctor::AbstractBlock, nil]
   attr_reader :parent
 
+  # @param parent [Asciidoctor::AbstractBlock, nil]
+  # @param context [Symbol, nil]
+  # @param opts [Hash<Symbol, Object>]
   def initialize parent, context, opts = {}
     # document is a special case, should refer to itself
     if context == :document
@@ -39,57 +54,58 @@ class AbstractNode
     @passthroughs = []
   end
 
-  # Public: Returns whether this {AbstractNode} is an instance of {Block}
+  # Returns whether this {AbstractNode} is an instance of {Block}
   #
-  # Returns [Boolean]
+  # @return [Boolean]
   def block?
     # :nocov:
     raise ::NotImplementedError
     # :nocov:
   end
 
-  # Public: Returns whether this {AbstractNode} is an instance of {Inline}
+  # Returns whether this {AbstractNode} is an instance of {Inline}
   #
-  # Returns [Boolean]
+  # @return [Boolean]
   def inline?
     # :nocov:
     raise ::NotImplementedError
     # :nocov:
   end
 
-  # Public: Get the Asciidoctor::Converter instance being used to convert the
-  # current Asciidoctor::Document.
+  # Get the {Asciidoctor::Converter} instance being used to convert the current {Asciidoctor::Document}.
+  #
+  # @return [Asciidoctor::Converter]
   def converter
     @document.converter
   end
 
-  # Public: Associate this Block with a new parent Block
+  # Associate this Block with a new parent Block
   #
-  # parent - The Block to set as the parent of this Block
+  # @param parent [Asciidoctor::AbstractBlock] the block to set as the parent of this Block
   #
   # Returns the the specified Block parent
   def parent= parent
     @parent, @document = parent, parent.document
   end
 
-  # Public: Get the value of the specified attribute. If the attribute is not found on this node, fallback_name is set,
+  # Get the value of the specified attribute. If the attribute is not found on this node, fallback_name is set,
   # and this node is not the Document node, get the value of the specified attribute from the Document node.
   #
   # Look for the specified attribute in the attributes on this node and return the value of the attribute, if found.
   # Otherwise, if fallback_name is set (default: same as name) and this node is not the Document node, look for that
   # attribute on the Document node and return its value, if found. Otherwise, return the default value (default: nil).
   #
-  # name          - The String or Symbol name of the attribute to resolve.
-  # default_value - The Object value to return if the attribute is not found (default: nil).
-  # fallback_name - The String or Symbol of the attribute to resolve on the Document if the attribute is not found on
-  #                 this node (default: same as name).
+  # @param name [String, Symbol]               the name of the attribute to resolve.
+  # @param default_value [Object, nil]         the value to return if the attribute is not found.
+  # @param fallback_name [String, Symbol, nil] the name attribute to resolve on the Document if the attribute is not found on
+  #                                            this node (default: same as name).
   #
-  # Returns the [Object] value (typically a String) of the attribute or default_value if the attribute is not found.
+  # @return [Object, nil] the value (typically a String) of the attribute or default_value if the attribute is not found.
   def attr name, default_value = nil, fallback_name = nil
     @attributes[name.to_s] || (fallback_name && @parent && @document.attributes[(fallback_name == true ? name : fallback_name).to_s] || default_value)
   end
 
-  # Public: Check if the specified attribute is defined using the same logic as {#attr}, optionally performing a
+  # Check if the specified attribute is defined using the same logic as {#attr}, optionally performing a
   # comparison with the expected value if specified.
   #
   # Look for the specified attribute in the attributes on this node. If not found, fallback_name is specified (default:
@@ -97,13 +113,13 @@ class AbstractNode
   # if the attribute is found, and the comparison value is truthy, return whether the two values match. Otherwise,
   # return whether the attribute was found.
   #
-  # name           - The String or Symbol name of the attribute to resolve.
-  # expected_value - The expected Object value of the attribute (default: nil).
-  # fallback_name  - The String or Symbol of the attribute to resolve on the Document if the attribute is not found on
-  #                  this node (default: same as name).
+  # @param name [String, Symbol]          the name of the attribute to resolve.
+  # @param expected_value [Object, nil]   the expected value of the attribute.
+  # @param fallback_name [String, Symbol] the name attribute to resolve on the Document if the attribute is not found on
+  #                                       this node (default: same as name).
   #
-  # Returns a [Boolean] indicating whether the attribute exists and, if a truthy comparison value is specified, whether
-  # the value of the attribute matches the comparison value.
+  # @return [Boolean] indicating whether the attribute exists and, if a truthy comparison value is specified, whether
+  #                   the value of the attribute matches the comparison value.
   def attr? name, expected_value = nil, fallback_name = nil
     if expected_value
       expected_value == (@attributes[name.to_s] || (fallback_name && @parent ? @document.attributes[(fallback_name == true ? name : fallback_name).to_s] : nil))
@@ -112,14 +128,14 @@ class AbstractNode
     end
   end
 
-  # Public: Assign the value to the attribute name for the current node.
+  # Assign the value to the attribute name for the current node.
   #
-  # name      - The String attribute name to assign
-  # value     - The Object value to assign to the attribute (default: '')
-  # overwrite - A Boolean indicating whether to assign the attribute
-  #             if currently present in the attributes Hash (default: true)
+  # @param name [String]       attribute name to assign
+  # @param value [Object]      value to assign to the attribute
+  # @param overwrite [Boolean] a Boolean indicating whether to assign the attribute
+  #                            if currently present in the attributes Hash
   #
-  # Returns a [Boolean] indicating whether the assignment was performed
+  # @return [Boolean] indicating whether the assignment was performed
   def set_attr name, value = '', overwrite = true
     if overwrite == false && (@attributes.key? name)
       false
@@ -129,96 +145,96 @@ class AbstractNode
     end
   end
 
-  # Public: Remove the attribute from the current node.
+  # Remove the attribute from the current node.
   #
-  # name      - The String attribute name to remove
+  # @param name [String] attribute name to remove
   #
-  # Returns the previous [String] value, or nil if the attribute was not present.
+  # @return [String, nil] the previous value, or nil if the attribute was not present.
   def remove_attr name
     @attributes.delete name
   end
 
-  # Public: A convenience method to check if the specified option attribute is
+  # A convenience method to check if the specified option attribute is
   # enabled on the current node.
   #
   # Check if the option is enabled. This method simply checks to see if the
   # <name>-option attribute is defined on the current node.
   #
-  # name    - the String or Symbol name of the option
+  # @param name [String, Symbol] the name of the option
   #
-  # return a Boolean indicating whether the option has been specified
+  # @return [Boolean] indicating whether the option has been specified
   def option? name
     @attributes[%(#{name}-option)] ? true : false
   end
 
-  # Public: Set the specified option on this node.
+  # Set the specified option on this node.
   #
   # This method sets the specified option on this node by setting the <name>-option attribute.
   #
-  # name - the String name of the option
+  # @param name [String] name of the option
   #
-  # Returns nothing
+  # @return [void]
   def set_option name # rubocop:disable Naming/AccessorMethodName
     @attributes[%(#{name}-option)] = ''
     nil
   end
 
-  # Public: Retrieve the Set of option names that are enabled on this node
+  # Retrieve the Set of option names that are enabled on this node
   #
-  # Returns a [Set] of option names
+  # @return [Set<String>]
   def enabled_options
     ::Set.new.tap {|accum| @attributes.each_key {|k| accum << (k.slice 0, k.length - 7) if k.to_s.end_with? '-option' } }
   end
 
-  # Public: Update the attributes of this node with the new values in
+  # Update the attributes of this node with the new values in
   # the attributes argument.
   #
   # If an attribute already exists with the same key, it's value will
   # be overwritten.
   #
-  # new_attributes - A Hash of additional attributes to assign to this node.
+  # @param new_attributes [Hash<String, Object>] additional attributes to assign to this node.
   #
   # Returns the updated attributes [Hash] on this node.
   def update_attributes new_attributes
     @attributes.update new_attributes
   end
 
-  # Public: Retrieves the space-separated String role for this node.
+  # Retrieves the space-separated String role for this node.
   #
-  # Returns the role as a space-separated [String].
+  # @return [String, nil]
   def role
     @attributes['role']
   end
 
-  # Public: Retrieves the String role names for this node as an Array.
+  # Retrieves the String role names for this node as an Array.
   #
-  # Returns the role names as a String [Array], which is empty if the role attribute is absent on this node.
+  # @return [Array<String>] the role names array, which is empty if the role attribute is absent on this node.
   def roles
     (val = @attributes['role']) ? val.split : []
   end
 
-  # Public: Checks if the role attribute is set on this node and, if an expected value is given, whether the
+  # Checks if the role attribute is set on this node and, if an expected value is given, whether the
   # space-separated role matches that value.
   #
   # expected_value - The expected String value of the role (optional, default: nil)
   #
-  # Returns a [Boolean] indicating whether the role attribute is set on this node and, if an expected value is given,
-  # whether the space-separated role matches that value.
+  # @return [Boolean] indicating whether the role attribute is set on this node and, if an expected value is given,
+  #                   whether the space-separated role matches that value.
   def role? expected_value = nil
     expected_value ? expected_value == @attributes['role'] : (@attributes.key? 'role')
   end
 
-  # Public: Checks if the specified role is present in the list of roles for this node.
+  # Checks if the specified role is present in the list of roles for this node.
   #
-  # name - The String name of the role to find.
+  # @param name [String] The name of the role to find.
   #
-  # Returns a [Boolean] indicating whether this node has the specified role.
+  # @return [Boolean] indicating whether this node has the specified role.
   def has_role? name
     # NOTE center + include? is faster than split + include?
     (val = @attributes['role']) ? (%( #{val} ).include? %( #{name} )) : false
   end
 
-  # Public: Sets the value of the role attribute on this node.
+  # Sets the value of the role attribute on this node.
   #
   # names - A single role name, a space-separated String of role names, or an Array of role names
   #
@@ -227,9 +243,10 @@ class AbstractNode
     @attributes['role'] = (::Array === names) ? (names.join ' ') : names
   end
 
-  # Public: Adds the given role directly to this node.
+  # Adds the given role directly to this node.
+  # @param name [String]
   #
-  # Returns a [Boolean] indicating whether the role was added.
+  # @return [Boolean] indicating whether the role was added.
   def add_role name
     if (val = @attributes['role'])
       # NOTE center + include? is faster than split + include?
@@ -245,9 +262,10 @@ class AbstractNode
     end
   end
 
-  # Public: Removes the given role directly from this node.
+  # Removes the given role directly from this node.
+  # @param name [String]
   #
-  # Returns a [Boolean] indicating whether the role was removed.
+  # @return [Boolean] indicating whether the role was removed.
   def remove_role name
     if (val = @attributes['role']) && ((val = val.split).delete name)
       if val.empty?
@@ -261,17 +279,21 @@ class AbstractNode
     end
   end
 
-  # Public: A convenience method that returns the value of the reftext attribute with substitutions applied.
+  # A convenience method that returns the value of the reftext attribute with substitutions applied.
+  #
+  # @return [String, nil]
   def reftext
     (val = @attributes['reftext']) ? (apply_reftext_subs val) : nil
   end
 
-  # Public: A convenience method that checks if the reftext attribute is defined.
+  # A convenience method that checks if the reftext attribute is defined.
+  #
+  # @return [Boolean]
   def reftext?
     @attributes.key? 'reftext'
   end
 
-  # Public: Construct a reference or data URI to an icon image for the
+  # Construct a reference or data URI to an icon image for the
   # specified icon name.
   #
   # If the 'icon' attribute is set on this block, the name is ignored and the
@@ -286,9 +308,9 @@ class AbstractNode
   #
   # The return value of this method can be safely used in an image tag.
   #
-  # name - The String name of the icon
+  # @param name [String] the name of the icon
   #
-  # Returns A String reference or data URI for an icon image
+  # @return [String, nil] a reference or data URI for an icon image
   def icon_uri name
     if attr? 'icon'
       icon = attr 'icon'
@@ -300,7 +322,7 @@ class AbstractNode
     image_uri icon, 'iconsdir'
   end
 
-  # Public: Construct a URI reference or data URI to the target image.
+  # Construct a URI reference or data URI to the target image.
   #
   # If the target image is a URI reference, then leave it untouched.
   #
@@ -314,11 +336,10 @@ class AbstractNode
   #
   # The return value of this method can be safely used in an image tag.
   #
-  # target_image - A String path to the target image
-  # asset_dir_key - The String attribute key used to lookup the directory where
-  #                the image is located (default: 'imagesdir')
+  # @param target_image [String]       path to the target image
+  # @param asset_dir_key [String, nil] attribute key used to lookup the directory where the image is located
   #
-  # Returns A String reference or data URI for the target image
+  # @return [String] a reference or data URI for the target image
   def image_uri target_image, asset_dir_key = 'imagesdir'
     if (doc = @document).safe < SafeMode::SECURE && (doc.attr? 'data-uri')
       if ((Helpers.uriish? target_image) && (target_image = Helpers.encode_spaces_in_uri target_image)) ||
@@ -333,7 +354,7 @@ class AbstractNode
     end
   end
 
-  # Public: Construct a URI reference to the target media.
+  # Construct a URI reference to the target media.
   #
   # If the target media is a URI reference, then leave it untouched.
   #
@@ -342,27 +363,25 @@ class AbstractNode
   #
   # The return value can be safely used in a media tag (img, audio, video).
   #
-  # target        - A String reference to the target media
-  # asset_dir_key - The String attribute key used to lookup the directory where
-  #                 the media is located (default: 'imagesdir')
+  # @param target [String]             reference to the target media
+  # @param asset_dir_key [String, nil] attribute key used to lookup the directory where the media is located
   #
-  # Returns A String reference for the target media
+  # @return [String] String reference for the target media
   def media_uri target, asset_dir_key = 'imagesdir'
     normalize_web_path target, (asset_dir_key ? (@document.attr asset_dir_key) : nil)
   end
 
-  # Public: Generate a data URI that can be used to embed an image in the output document
+  # Generate a data URI that can be used to embed an image in the output document
   #
   # First, and foremost, the target image path is cleaned if the document safe mode level
   # is set to at least SafeMode::SAFE (a condition which is true by default) to prevent access
   # to ancestor paths in the filesystem. The image data is then read and converted to
   # Base64. Finally, a data URI is built which can be used in an image tag.
   #
-  # target_image - A String path to the target image
-  # asset_dir_key - The String attribute key used to lookup the directory where
-  #                the image is located (default: nil)
+  # @param target_image [String]  path to the target image
+  # @param asset_dir_key [String] attribute key used to lookup the directory where the image is located
   #
-  # Returns A String data URI containing the content of the target image
+  # @return [String] a data URI containing the content of the target image
   def generate_data_uri target_image, asset_dir_key = nil
     if (ext = Helpers.extname target_image, nil)
       mimetype = ext == '.svg' ? 'image/svg+xml' : %(image/#{ext.slice 1, ext.length})
@@ -387,17 +406,17 @@ class AbstractNode
     end
   end
 
-  # Public: Read the image data from the specified URI and generate a data URI
+  # Read the image data from the specified URI and generate a data URI
   #
   # The image data is read from the URI and converted to Base64. A data URI is
   # constructed from the content_type header and Base64 data and returned,
   # which can then be used in an image tag.
   #
   # image_uri  - The URI from which to read the image data. Can be http://, https:// or ftp://
-  # cache_uri  - A Boolean to control caching. When true, the open-uri-cached library
-  #              is used to cache the image for subsequent reads. (default: false)
+  # @param cache_uri [Boolean] A Boolean to control caching. When true, the open-uri-cached library
+  #              is used to cache the image for subsequent reads.
   #
-  # Returns A data URI string built from Base64 encoded data read from the URI
+  # @return [String] A data URI string built from Base64 encoded data read from the URI
   # and the mime type specified in the Content Type header.
   def generate_data_uri_from_uri image_uri, cache_uri = false
     if cache_uri
@@ -423,15 +442,17 @@ class AbstractNode
     end
   end
 
-  # Public: Normalize the asset file or directory to a concrete and rinsed path
+  # Normalize the asset file or directory to a concrete and rinsed path
   #
-  # Delegates to normalize_system_path, with the start path set to the value of
+  # Delegates to {#normalize_system_path}, with the start path set to the value of
   # the base_dir instance variable on the Document object.
+  #
+  # @return [String]
   def normalize_asset_path asset_ref, asset_name = 'path', autocorrect = true
     normalize_system_path asset_ref, @document.base_dir, nil, target_name: asset_name, recover: autocorrect
   end
 
-  # Public: Resolve and normalize a secure path from the target and start paths
+  # Resolve and normalize a secure path from the target and start paths
   # using the PathResolver.
   #
   # See {PathResolver#system_path} for details.
@@ -442,10 +463,10 @@ class AbstractNode
   # safe level is set to SafeMode::SAFE or greater (a condition which is true
   # by default).
   #
-  # target - the String target path
-  # start  - the String start (i.e., parent) path
-  # jail   - the String jail path to confine the resolved path
-  # opts   - an optional Hash of options to control processing (default: {}):
+  # @param target [String]     target path
+  # @param start [String, nil] start (i.e., parent) path
+  # @param jail [String, nil]  jail path to confine the resolved path
+  # @param opts [Hash<String, Object>] an optional Hash of options to control processing:
   #          * :recover is used to control whether the processor should
   #            automatically recover when an illegal path is encountered
   #          * :target_name is used in messages to refer to the path being resolved
@@ -453,7 +474,7 @@ class AbstractNode
   # raises a SecurityError if a jail is specified and the resolved path is
   # outside the jail.
   #
-  # Returns the [String] path resolved from the start and target paths, with any
+  # @return [String] the path resolved from the start and target paths, with any
   # parent references resolved and self references removed. If a jail is provided,
   # this path will be guaranteed to be contained within the jail.
   def normalize_system_path target, start = nil, jail = nil, opts = {}
@@ -470,15 +491,15 @@ class AbstractNode
     doc.path_resolver.system_path target, start, jail, opts
   end
 
-  # Public: Normalize the web path using the PathResolver.
+  # Normalize the web path using the PathResolver.
   #
   # See {PathResolver#web_path} for details about path resolution and encoding.
   #
-  # target              - the String target path
-  # start               - the String start (i.e, parent) path (optional, default: nil)
-  # preserve_uri_target - a Boolean indicating whether target should be preserved if contains a URI (default: true)
+  # @param target [String]               target path
+  # @param start [String, nil]           optional start (i.e, parent) path
+  # @param preserve_uri_target [Boolean] a Boolean indicating whether target should be preserved if contains a URI
   #
-  # Returns the resolved [String] path
+  # @return [String] the resolved path
   def normalize_web_path target, start = nil, preserve_uri_target = true
     if preserve_uri_target && (Helpers.uriish? target)
       Helpers.encode_spaces_in_uri target
@@ -487,18 +508,18 @@ class AbstractNode
     end
   end
 
-  # Public: Read the contents of the file at the specified path.
+  # Read the contents of the file at the specified path.
   # This method assumes that the path is safe to read. It checks
   # that the file is readable before attempting to read it.
   #
   # path - the String path from which to read the contents
-  # opts - a Hash of options to control processing (default: {})
+  # opts - a Hash of options to control processing
   #        * :warn_on_failure a Boolean that controls whether a warning
   #          is issued if the file cannot be read (default: false)
   #        * :normalize a Boolean that controls whether the lines
   #          are normalized and coerced to UTF-8 (default: false)
   #
-  # Returns the [String] content of the file at the specified path, or nil
+  # @return [String, nil] the content of the file at the specified path, or nil
   # if the file does not exist.
   def read_asset path, opts = {}
     # remap opts for backwards compatibility
@@ -512,7 +533,7 @@ class AbstractNode
     end
   end
 
-  # Public: Resolve the URI or system path to the specified target, then read and return its contents
+  # Resolve the URI or system path to the specified target, then read and return its contents
   #
   # The URI or system path of the target is first resolved. If the resolved path is a URI, read the
   # contents from the URI if the allow-uri-read attribute is set, enabling caching if the cache-uri
@@ -520,13 +541,13 @@ class AbstractNode
   # file system. If the normalize option is set, the data will be normalized.
   #
   # target - The URI or local path from which to read the data.
-  # opts   - a Hash of options to control processing (default: {})
+  # opts   - a Hash of options to control processing
   #          * :label the String label of the target to use in warning messages (default: 'asset')
   #          * :normalize a Boolean that indicates whether the data should be normalized (default: false)
   #          * :start the String relative base path to use when resolving the target (default: nil)
   #          * :warn_on_failure a Boolean that indicates whether warnings are issued if the target cannot be read (default: true)
   #          * :warn_if_empty a Boolean that indicates whether a warning is issued if contents of target is empty (default: false)
-  # Returns the contents of the resolved target or nil if the resolved target cannot be read
+  # @return [String, nil] the contents of the resolved target or nil if the resolved target cannot be read
   # --
   # TODO refactor other methods in this class to use this method were possible (repurposing if necessary)
   def read_contents target, opts = {}
@@ -560,6 +581,7 @@ class AbstractNode
   #
   # In use by Asciidoctor PDF
   #
+  # @return [Boolean]
   # @deprecated Use Helpers.uriish? instead
   def is_uri? str
     Helpers.uriish? str


### PR DESCRIPTION
Motivation:

1. While rubydoc.org understands some of the current documentation format, there are other tools that do not. Most notable example is RubyMine.
2. Tools (including rubydoc.org) cannot infer nullability from current documentation (should I say "nillability" in Ruby?).
3. Tools (including rubydoc.org) do not properly understand variant types.
4. Things like visibility are already described by code itself and feel redundant.