### PR TITLE
Block quotes for the semantic HTML 5 Converter

### DIFF
--- a/lib/asciidoctor/converter/semantic_html5.rb
+++ b/lib/asciidoctor/converter/semantic_html5.rb
@@ -92,6 +92,31 @@ class Converter::SemanticHtml5Converter < Converter::Base
 </figure>)
   end
 
+  def convert_quote node
+    attributes = common_html_attributes node.id, node.role
+    title = node.title ? %(<header><strong class="title">#{node.title}</strong></header>) : nil
+    attribution = (node.attr? 'attribution') ? (node.attr 'attribution') : nil
+    citation = (node.attr? 'citetitle') ? (node.attr 'citetitle') : nil
+    ret = []
+    ret << "<blockquote>"
+    if title
+      ret << title
+    end
+    ret << node.content
+    if attribution or citation
+      ret << "<footer>"
+      if attribution
+        ret << %(<span class="blockquote-attribution">#{attribution}</span>)
+      end
+      if citation
+        ret << %(<cite class="blockquote-citation">#{citation}</cite>)
+      end
+      ret << "<footer>"
+    end
+    ret << "</blockquote>"
+    ret.join LF
+  end
+
   def convert_thematic_break node
     '<hr>'
   end

--- a/test/fixtures/semantic-html5-scenarios/blockquote-1.adoc
+++ b/test/fixtures/semantic-html5-scenarios/blockquote-1.adoc
@@ -1,0 +1,4 @@
+The blockquote example 1 from https://docs.asciidoctor.org/asciidoc/latest/blocks/blockquotes/[here].
+
+[quote,attribution,citation title and information]
+Quote or excerpt text

--- a/test/fixtures/semantic-html5-scenarios/blockquote-1.html
+++ b/test/fixtures/semantic-html5-scenarios/blockquote-1.html
@@ -1,0 +1,10 @@
+<p>
+The blockquote example 1 from <a href="https://docs.asciidoctor.org/asciidoc/latest/blocks/blockquotes/">here</a>.
+</p>
+<blockquote>
+Quote or excerpt text
+<footer>
+<span class="blockquote-attribution">attribution</span>
+<cite class="blockquote-citation">citation title and information</cite>
+<footer>
+</blockquote>

--- a/test/fixtures/semantic-html5-scenarios/blockquote-2.adoc
+++ b/test/fixtures/semantic-html5-scenarios/blockquote-2.adoc
@@ -1,0 +1,5 @@
+The blockquote example 2 from https://docs.asciidoctor.org/asciidoc/latest/blocks/blockquotes/[here].
+
+.After landing the cloaked Klingon bird of prey in Golden Gate park:
+[quote,Captain James T. Kirk,Star Trek IV: The Voyage Home]
+Everybody remember where we parked.

--- a/test/fixtures/semantic-html5-scenarios/blockquote-2.html
+++ b/test/fixtures/semantic-html5-scenarios/blockquote-2.html
@@ -1,0 +1,11 @@
+<p>
+The blockquote example 2 from <a href="https://docs.asciidoctor.org/asciidoc/latest/blocks/blockquotes/">here</a>.
+</p>
+<blockquote>
+<header><strong class="title">After landing the cloaked Klingon bird of prey in Golden Gate park:</strong></header>
+Everybody remember where we parked.
+<footer>
+<span class="blockquote-attribution">Captain James T. Kirk</span>
+<cite class="blockquote-citation">Star Trek IV: The Voyage Home</cite>
+<footer>
+</blockquote>

--- a/test/fixtures/semantic-html5-scenarios/blockquote-3.adoc
+++ b/test/fixtures/semantic-html5-scenarios/blockquote-3.adoc
@@ -1,0 +1,10 @@
+The blockquote example 3 from https://docs.asciidoctor.org/asciidoc/latest/blocks/blockquotes/[here].
+
+[quote,Monty Python and the Holy Grail]
+____
+Dennis: Come and see the violence inherent in the system. Help! Help! I'm being repressed!
+
+King Arthur: Bloody peasant!
+
+Dennis: Oh, what a giveaway! Did you hear that? Did you hear that, eh? That's what I'm on about! Did you see him repressing me? You saw him, Didn't you?
+____

--- a/test/fixtures/semantic-html5-scenarios/blockquote-3.html
+++ b/test/fixtures/semantic-html5-scenarios/blockquote-3.html
@@ -1,0 +1,17 @@
+<p>
+The blockquote example 3 from <a href="https://docs.asciidoctor.org/asciidoc/latest/blocks/blockquotes/">here</a>.
+</p>
+<blockquote>
+<p>
+Dennis: Come and see the violence inherent in the system. Help! Help! I&#8217;m being repressed!
+</p>
+<p>
+King Arthur: Bloody peasant!
+</p>
+<p>
+Dennis: Oh, what a giveaway! Did you hear that? Did you hear that, eh? That&#8217;s what I&#8217;m on about! Did you see him repressing me? You saw him, Didn&#8217;t you?
+</p>
+<footer>
+<span class="blockquote-attribution">Monty Python and the Holy Grail</span>
+<footer>
+</blockquote>

--- a/test/fixtures/semantic-html5-scenarios/blockquote-4.adoc
+++ b/test/fixtures/semantic-html5-scenarios/blockquote-4.adoc
@@ -1,0 +1,5 @@
+The blockquote example 4 from https://docs.asciidoctor.org/asciidoc/latest/blocks/blockquotes/[here].
+
+"I hold it that a little rebellion now and then is a good thing,
+and as necessary in the political world as storms in the physical."
+-- Thomas Jefferson, Papers of Thomas Jefferson: Volume 11

--- a/test/fixtures/semantic-html5-scenarios/blockquote-4.html
+++ b/test/fixtures/semantic-html5-scenarios/blockquote-4.html
@@ -1,0 +1,11 @@
+<p>
+The blockquote example 4 from <a href="https://docs.asciidoctor.org/asciidoc/latest/blocks/blockquotes/">here</a>.
+</p>
+<blockquote>
+I hold it that a little rebellion now and then is a good thing,
+and as necessary in the political world as storms in the physical.
+<footer>
+<span class="blockquote-attribution">Thomas Jefferson</span>
+<cite class="blockquote-citation">Papers of Thomas Jefferson: Volume 11</cite>
+<footer>
+</blockquote>

--- a/test/fixtures/semantic-html5-scenarios/blockquote-5.adoc
+++ b/test/fixtures/semantic-html5-scenarios/blockquote-5.adoc
@@ -1,0 +1,5 @@
+The blockquote example 6 from https://docs.asciidoctor.org/asciidoc/latest/blocks/blockquotes/[here].
+
+> I hold it that a little rebellion now and then is a good thing,
+> and as necessary in the political world as storms in the physical.
+> -- Thomas Jefferson, Papers of Thomas Jefferson: Volume 11

--- a/test/fixtures/semantic-html5-scenarios/blockquote-5.html
+++ b/test/fixtures/semantic-html5-scenarios/blockquote-5.html
@@ -1,0 +1,13 @@
+<p>
+The blockquote example 6 from <a href="https://docs.asciidoctor.org/asciidoc/latest/blocks/blockquotes/">here</a>.
+</p>
+<blockquote>
+<p>
+I hold it that a little rebellion now and then is a good thing,
+and as necessary in the political world as storms in the physical.
+</p>
+<footer>
+<span class="blockquote-attribution">Thomas Jefferson</span>
+<cite class="blockquote-citation">Papers of Thomas Jefferson: Volume 11</cite>
+<footer>
+</blockquote>

--- a/test/fixtures/semantic-html5-scenarios/blockquote-6.adoc
+++ b/test/fixtures/semantic-html5-scenarios/blockquote-6.adoc
@@ -1,0 +1,15 @@
+The blockquote example 6 from https://docs.asciidoctor.org/asciidoc/latest/blocks/blockquotes/[here].
+
+> > What's new?
+>
+> I've got Markdown in my AsciiDoc!
+>
+> > Like what?
+>
+> * Blockquotes
+> * Headings
+> * Fenced code blocks
+>
+> > Is there more?
+>
+> Yep. AsciiDoc and Markdown share a lot of common syntax already.


### PR DESCRIPTION
This MR adds functionality to convert block-quotes in AsciiDoctor for the semantic-html5 converter/backend. I've added the examples from [the asciidoctor](https://docs.asciidoctor.org/asciidoc/latest/blocks/blockquotes/) manual as tests. The `blockquotes-6` test requires unordered lists, which is blocked by MR #4321.

This is an example of the old and new output.

OLD:

```
<div class="quoteblock">
<div class="title">After landing the cloaked Klingon bird of prey in Golden Gate park:</div>
<blockquote>
Everybody remember where we parked.
</blockquote>
<div class="attribution">
&#8212; Captain James T. Kirk<br>
<cite>Star Trek IV: The Voyage Home</cite>
</div>
</div>
```

NEW:

```
<blockquote>
<header><strong class="title">After landing the cloaked Klingon bird of prey in Golden Gate park:</strong></header>
Everybody remember where we parked.
<footer>
<span class="blockquote-attribution">Captain James T. Kirk</span>
<cite class="blockquote-citation">Star Trek IV: The Voyage Home</cite>
<footer>
</blockquote>
```

The use of `<header>` for the title matches my latest [suggestions for admonitions]. The use of `<footer>` matches MDNs examples https://developer.mozilla.org/en-US/docs/Web/HTML/Element/blockquote.