### PR TITLE
Implemented :<context>-caption-punctuator: attribute.

### DIFF
--- a/lib/asciidoctor.rb
+++ b/lib/asciidoctor.rb
@@ -295,6 +295,7 @@ module Asciidoctor
 
   # NOTE the 'figure' key as a string is historical and used by image blocks
   CAPTION_ATTRIBUTE_NAMES = { example: 'example-caption', 'figure' => 'figure-caption', listing: 'listing-caption', table: 'table-caption' }
+  CAPTION_PUNCTUATOR_ATTRIBUTE_NAMES = { example: 'example-caption-punctuator', 'figure' => 'figure-caption-punctuator', listing: 'listing-caption-punctuator', table: 'table-caption-punctuator' }
 
   LAYOUT_BREAK_CHARS = {
     '\'' => :thematic_break,

--- a/lib/asciidoctor/abstract_block.rb
+++ b/lib/asciidoctor/abstract_block.rb
@@ -377,7 +377,7 @@ class AbstractBlock < AbstractNode
   #
   # If a caption has already been assigned to this block, do nothing.
   #
-  # The parts of a complete caption are: <prefix> <number>. <title>
+  # The parts of a complete caption are: <prefix> <number><punctuator> <title>
   # This partial caption represents the part the precedes the title.
   #
   # value           - The String caption to assign to this block or nil to use document attribute.
@@ -388,8 +388,12 @@ class AbstractBlock < AbstractNode
   # Returns nothing.
   def assign_caption value, caption_context = @context
     unless @caption || !@title || (@caption = value || @document.attributes['caption']) # rubocop:disable Style/GuardClause
+      punctuator = '.'
+      if (attr_name = CAPTION_PUNCTUATOR_ATTRIBUTE_NAMES[caption_context]) && document.attributes[attr_name]
+        punctuator = @document.attributes[attr_name]
+      end
       if (attr_name = CAPTION_ATTRIBUTE_NAMES[caption_context]) && (prefix = @document.attributes[attr_name])
-        @caption = %(#{prefix} #{@numeral = @document.increment_and_store_counter %(#{caption_context}-number), self}. )
+        @caption = %(#{prefix} #{@numeral = @document.increment_and_store_counter %(#{caption_context}-number), self}#{punctuator} )
         nil
       end
     end

--- a/test/blocks_test.rb
+++ b/test/blocks_test.rb
@@ -887,6 +887,27 @@ context 'Blocks' do
       assert_xpath '(/*[@class="exampleblock"])[3]/*[@class="title"][starts-with(text(), "Exhibit ")]', output, 1
     end
 
+    test 'caption punctuator can be modified and defaults to period' do
+      input = <<~'EOS'
+      .first example
+      ====
+      an example
+      ====
+
+      :example-caption-punctuator: :
+
+      .second example
+      ====
+      another example
+      ====
+      EOS
+
+      output = convert_string_to_embedded input
+      assert_xpath '/*[@class="exampleblock"]', output, 2
+      assert_xpath '(/*[@class="exampleblock"])[1]/*[@class="title"][starts-with(text(), "Example 1.")]', output, 1
+      assert_xpath '(/*[@class="exampleblock"])[2]/*[@class="title"][starts-with(text(), "Example 2:")]', output, 1
+    end
+
     test 'should use explicit caption if specified even if block-specific global caption is disabled' do
       input = <<~'EOS'
       :!example-caption:


### PR DESCRIPTION
This allows customisation of the caption punctuation mark, which was previously hard-coded to be a period and which remains the default if unset.