### PR TITLE
resolves #3545 warn if closing endif directive is not found

### DIFF
--- a/lib/asciidoctor/reader.rb
+++ b/lib/asciidoctor/reader.rb
@@ -805,7 +805,6 @@ class PreprocessorReader < Reader
 
   def process_line line
     return line unless @process_lines
-
     if line.empty?
       if @skipping
         shift
@@ -859,6 +858,15 @@ class PreprocessorReader < Reader
         line
       end
     elsif @skipping
+      # If we are skipping, and we can see that we will reach the end
+      # without an endif, then warn you've forgotten to close the
+      # conditional
+      if @lines.length == 1
+        next_line = @lines[-1]
+        if not next_line.include? 'endif'
+          logger.warn message_with_context %(Unclosed conditional at end of parsing), source_location: cursor
+        end
+      end
       shift
       nil
     else

--- a/test/reader_test.rb
+++ b/test/reader_test.rb
@@ -2902,6 +2902,27 @@ class ReaderTest < Minitest::Test
         assert_equal 'before', doc.blocks[0].source
         assert_equal 'after', doc.blocks[1].source
       end
+
+      test 'should warn if unclosed if' do
+        input = <<~EOS
+
+        ifdef::flag[]
+        closed ifdef
+        endif::[]
+
+        ifdef::flag[]
+        unclosed ifdef
+
+        EOS
+
+        using_memory_logger do |logger|
+          doc = Asciidoctor::Document.new input, attribues: {'flag' => 'true'}
+          reader = doc.reader
+          lines = []
+          lines << reader.read_line while reader.has_more_lines?
+          assert_message logger, :WARN, '<stdin>: line 7: Unclosed conditional at end of parsing', Hash
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
It's quite easy to leave out an endif and then have the rest of the document accidentally be skipped.  This implements a small check when skipping lines in the pre-processor; if we are currently in skipping mode, and we can see the end of the line stack, and it doesn't include an endif, give the user a warning that they've forgotten to close their conditional.

Closes: https://github.com/asciidoctor/asciidoctor/issues/3545