### PR TITLE
Add attribute "manvoldir"

### DIFF
--- a/docs/modules/manpage-backend/pages/index.adoc
+++ b/docs/modules/manpage-backend/pages/index.adoc
@@ -39,7 +39,8 @@ Refer to the <<document-attributes>> section.
 The NAME Section::
 The first section is mandatory, must be titled "`Name`" (or "`NAME`"), and must contain a single paragraph (usually a single line) consisting of a list of one or more comma-separated command name(s) separated from the command's purpose by a dash character (e.g., `progname - does stuff` or `name1, name2 - does stuff`).
 The dash must have at least one space character on either side.
-If multiple names are given, Asciidoctor will generate alias files for the secondary names that point to the primary name.
+If multiple names are given, Asciidoctor will generate alias files for the secondary names that point to the primary name. +
+If you would like to change the path for the alias file, you can use the `:manvoldir:` attribute (see <<document-attributes, document attributes>>).
 
 The SYNOPSIS Section::
 The second section is recommended and, if present, must be titled "`Synopsis`" (or "`SYNOPSIS`").
@@ -230,6 +231,10 @@ Must include both the man page name and volume number.
 |Can be set by overriding the `doctitle` attribute.
 Must include both the man page name and volume number.
 |ASCIIDOCTOR(1)
+
+|`manvoldir`
+|Set the directory for the `.so` directive in the alias file(s).
+|
 
 |`manname`
 |Alternative way to set the command name.

--- a/lib/asciidoctor/converter/manpage.rb
+++ b/lib/asciidoctor/converter/manpage.rb
@@ -42,6 +42,7 @@ class Converter::ManPageConverter < Converter::Base
     end
     mantitle = (node.attr 'mantitle').gsub InvalidSectionIdCharsRx, ''
     manvolnum = node.attr 'manvolnum', '1'
+    manvoldir = node.attr 'manvoldir', ''
     manname = node.attr 'manname', mantitle
     manmanual = node.attr 'manmanual'
     mansource = node.attr 'mansource'
@@ -656,13 +657,17 @@ r lw(\n(.lu*75u/100u).'
     end
   end
 
-  def self.write_alternate_pages mannames, manvolnum, target
+  def self.write_alternate_pages mannames, manvolnum, manvoldir, target
     return unless mannames && mannames.size > 1
     mannames.shift
     manvolext = %(.#{manvolnum})
+    manvoldir = manvoldir.strip
+    if not manvoldir.empty? then
+      manvoldir = manvoldir + "/"
+    end
     dir, basename = ::File.split target
     mannames.each do |manname|
-      ::File.write ::File.join(dir, %(#{manname}#{manvolext})), %(.so #{basename}), mode: FILE_WRITE_MODE
+      ::File.write ::File.join(dir, %(#{manname}#{manvolext})), %(.so #{manvoldir}#{basename}), mode: FILE_WRITE_MODE
     end
   end
 

--- a/lib/asciidoctor/document.rb
+++ b/lib/asciidoctor/document.rb
@@ -999,7 +999,7 @@ class Document < AbstractBlock
         ::File.write target, output, mode: FILE_WRITE_MODE
       end
       if @backend == 'manpage' && ::String === target && (@converter.class.respond_to? :write_alternate_pages)
-        @converter.class.write_alternate_pages @attributes['mannames'], @attributes['manvolnum'], target
+        @converter.class.write_alternate_pages @attributes['mannames'], @attributes['manvolnum'], @attributes['manvoldir'], target
       end
     end
     @timings.record :write if @timings

--- a/test/manpage_test.rb
+++ b/test/manpage_test.rb
@@ -28,6 +28,7 @@ context 'Manpage' do
       assert_equal 'man', doc.attributes['filetype']
       assert_equal '', doc.attributes['filetype-man']
       assert_equal '1', doc.attributes['manvolnum']
+      assert_equal '', doc.attributes['manvoldir']
       assert_equal '.1', doc.attributes['outfilesuffix']
       assert_equal 'command', doc.attributes['manname']
       assert_equal 'command', doc.attributes['mantitle']


### PR DESCRIPTION
This adds the attribute `manvoldir` to be used when generating man pages.

Currently if you have multiples names in the NAMES section, there will be generated alias files like
`.so manpage.1`

If you specify `manvoldir` they will look like:
`.so <manvoldir>/manpage.1`

This is especially helpful when migrating from a2x to asciidoctor.

See also https://asciidoctor.zulipchat.com/#narrow/channel/279642-users/topic/Man.20page.20generation.3A.20Setting.20base.20path.20for.20alias.20files

This is more a template as I don't really know what is all needed to add a new attribute.