### PR TITLE
Convert `nil_or_empty?` core_ext to a refinement

### DIFF
--- a/lib/asciidoctor/abstract_block.rb
+++ b/lib/asciidoctor/abstract_block.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 module Asciidoctor
+using NilOrEmptyRefinement
 class AbstractBlock < AbstractNode
   # Public: Get the Array of {AbstractBlock} child blocks for this block. Only applies if content model is :compound.
   attr_reader :blocks

--- a/lib/asciidoctor/block.rb
+++ b/lib/asciidoctor/block.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 module Asciidoctor
+using NilOrEmptyRefinement
 # Public: Methods for managing AsciiDoc content blocks.
 #
 # Examples

--- a/lib/asciidoctor/converter/docbook5.rb
+++ b/lib/asciidoctor/converter/docbook5.rb
@@ -3,6 +3,7 @@
 module Asciidoctor
 # A built-in {Converter} implementation that generates DocBook 5 output. The output is inspired by the output produced
 # by the docbook45 backend from AsciiDoc.py, except it has been migrated to the DocBook 5 specification.
+using NilOrEmptyRefinement
 class Converter::DocBook5Converter < Converter::Base
   register_for 'docbook5'
 

--- a/lib/asciidoctor/converter/html5.rb
+++ b/lib/asciidoctor/converter/html5.rb
@@ -3,6 +3,7 @@
 module Asciidoctor
 # A built-in {Converter} implementation that generates HTML 5 output
 # consistent with the html5 backend from AsciiDoc.py.
+using NilOrEmptyRefinement
 class Converter::Html5Converter < Converter::Base
   register_for 'html5'
 

--- a/lib/asciidoctor/core_ext/nil_or_empty.rb
+++ b/lib/asciidoctor/core_ext/nil_or_empty.rb
@@ -4,22 +4,24 @@
 # optimize checks for nil? or empty? on common object types such as NilClass,
 # String, Array, Hash, and Numeric.
 
-class NilClass
-  alias nil_or_empty? nil? unless method_defined? :nil_or_empty?
-end
+module NilOrEmptyRefinement
+  refine NilClass do
+    alias nil_or_empty? nil? unless method_defined? :nil_or_empty?
+  end
 
-class String
-  alias nil_or_empty? empty? unless method_defined? :nil_or_empty?
-end
+  refine String do
+    alias nil_or_empty? empty? unless method_defined? :nil_or_empty?
+  end
 
-class Array
-  alias nil_or_empty? empty? unless method_defined? :nil_or_empty?
-end
+  refine Array do
+    alias nil_or_empty? empty? unless method_defined? :nil_or_empty?
+  end
 
-class Hash
-  alias nil_or_empty? empty? unless method_defined? :nil_or_empty?
-end
+  refine Hash do
+    alias nil_or_empty? empty? unless method_defined? :nil_or_empty?
+  end
 
-class Numeric
-  alias nil_or_empty? nil? unless method_defined? :nil_or_empty?
+  refine  Numeric do
+    alias nil_or_empty? nil? unless method_defined? :nil_or_empty?
+  end
 end

--- a/lib/asciidoctor/document.rb
+++ b/lib/asciidoctor/document.rb
@@ -81,6 +81,7 @@ module Asciidoctor
 #
 # Loading a document object is the first step in the conversion process. You
 # can take the process to completion by calling the {Document#convert} method.
+using NilOrEmptyRefinement
 class Document < AbstractBlock
   ImageReference = ::Struct.new :target, :imagesdir do
     alias to_s target # rubocop:disable Style/Alias

--- a/lib/asciidoctor/extensions.rb
+++ b/lib/asciidoctor/extensions.rb
@@ -1,4 +1,4 @@
-# frozen_string_literal: true
+# frozen_string_literal: tArue
 
 (require 'asciidoctor' unless defined? Asciidoctor.load) unless RUBY_ENGINE == 'opal'
 
@@ -23,6 +23,7 @@ module Asciidoctor
 # Extensions may be registered globally using the {Extensions.register} method
 # or added to a custom {Registry} instance and passed as an option to a single
 # Asciidoctor processor.
+using NilOrEmptyRefinement
 module Extensions
   # Public: An abstract base class for document and syntax processors.
   #

--- a/lib/asciidoctor/helpers.rb
+++ b/lib/asciidoctor/helpers.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 module Asciidoctor
+using NilOrEmptyRefinement
 # Internal: Except where noted, a module that contains internal helper functions.
 module Helpers
   module_function

--- a/lib/asciidoctor/list.rb
+++ b/lib/asciidoctor/list.rb
@@ -2,6 +2,7 @@
 
 module Asciidoctor
 # Public: Methods for managing AsciiDoc lists (ordered, unordered and description lists)
+using NilOrEmptyRefinement
 class List < AbstractBlock
   # Public: Create alias for blocks
   alias items blocks

--- a/lib/asciidoctor/parser.rb
+++ b/lib/asciidoctor/parser.rb
@@ -23,6 +23,7 @@ module Asciidoctor
 #   block = Parser.next_block reader, doc
 #   block.class
 #   # => Asciidoctor::Block
+using NilOrEmptyRefinement
 class Parser
   include Logging
 

--- a/lib/asciidoctor/path_resolver.rb
+++ b/lib/asciidoctor/path_resolver.rb
@@ -101,6 +101,7 @@ module Asciidoctor
 #     end
 #     => start path /etc is outside of jail: /path/to/docs'
 #
+using NilOrEmptyRefinement
 class PathResolver
   include Logging
 

--- a/lib/asciidoctor/reader.rb
+++ b/lib/asciidoctor/reader.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 module Asciidoctor
+using NilOrEmptyRefinement
 # Public: Methods for retrieving lines from AsciiDoc source files
 class Reader
   include Logging

--- a/lib/asciidoctor/substitutors.rb
+++ b/lib/asciidoctor/substitutors.rb
@@ -4,6 +4,7 @@ module Asciidoctor
 # Public: Methods to perform substitutions on lines of AsciiDoc text. This module
 # is intended to be mixed-in to Section and Block to provide operations for performing
 # the necessary substitutions.
+using NilOrEmptyRefinement
 module Substitutors
   SpecialCharsRx = /[<&>]/
   SpecialCharsTr = { '>' => '&gt;', '<' => '&lt;', '&' => '&amp;' }

--- a/lib/asciidoctor/table.rb
+++ b/lib/asciidoctor/table.rb
@@ -3,6 +3,7 @@
 module Asciidoctor
 # Public: Methods and constants for managing AsciiDoc table content in a document.
 # It supports all three of AsciiDoc's table formats: psv, dsv and csv.
+using NilOrEmptyRefinement
 class Table < AbstractBlock
   # precision of column widths
   DEFAULT_PRECISION = 4

--- a/test/extensions_test.rb
+++ b/test/extensions_test.rb
@@ -2,6 +2,7 @@
 
 require_relative 'test_helper'
 
+using NilOrEmptyRefinement
 class ExtensionsInitTest < Minitest::Test
   def test_autoload
     doc = empty_document


### PR DESCRIPTION
This limits the scope of the method addition to this gem preventing it effecting code outside of the gem. This is hopefully less suprising for gem adopters. Refinements are available since ruby 2.7 which is the minimum required Ruby version.