### PR TITLE
Add `logger` as a runtime dependency

### DIFF
--- a/asciidoctor.gemspec
+++ b/asciidoctor.gemspec
@@ -34,6 +34,8 @@ Gem::Specification.new do |s|
   s.require_paths = ['lib']
   #s.test_files = files.grep %r/^(?:features|test)\/.+$/
 
+  s.add_dependency "logger"
+
   # concurrent-ruby, haml, slim, and tilt are needed for testing custom templates
   s.add_development_dependency 'concurrent-ruby', '~> 1.1.0'
   s.add_development_dependency 'cucumber', '~> 3.1.0'


### PR DESCRIPTION
On Ruby 3.4, requiring `logger` without it being in the bundle shows the following warning:

```rb
require "asciidoctor"
/home/earlopain/Documents/asciidoctor/lib/asciidoctor/logging.rb:3: warning: logger was loaded from the standard library, but will no longer be part of the default gems starting from Ruby 3.5.0.
You can add logger to your Gemfile or gemspec to silence this warning.
=> true
irb(main):002> RUBY_VERSION
=> "3.4.1"
```