### PR TITLE
feat: semantic HTML 5 table generator

### DIFF
--- a/test/fixtures/semantic-html5-scenarios/table-basic.adoc
+++ b/test/fixtures/semantic-html5-scenarios/table-basic.adoc
@@ -1,0 +1,5 @@
+|===
+|Cell in column 1, row 1|Cell in column 2, row 1
+|Cell in column 1, row 2|Cell in column 2, row 2
+|Cell in column 1, row 3|Cell in column 2, row 3
+|===

--- a/test/fixtures/semantic-html5-scenarios/table-basic_implicit-header-row.adoc
+++ b/test/fixtures/semantic-html5-scenarios/table-basic_implicit-header-row.adoc
@@ -1,0 +1,7 @@
+|===
+|Cell in column 1, row 1|Cell in column 2, row 1
+
+|Cell in column 1, row 1|Cell in column 2, row 1
+|Cell in column 1, row 2|Cell in column 2, row 2
+|Cell in column 1, row 3|Cell in column 2, row 3
+|===

--- a/test/fixtures/semantic-html5-scenarios/table-basic_implicit-header-row_-title.adoc
+++ b/test/fixtures/semantic-html5-scenarios/table-basic_implicit-header-row_-title.adoc
@@ -1,0 +1,8 @@
+.A table with an header row and a title
+|===
+|Cell in column 1, row 1|Cell in column 2, row 1
+
+|Cell in column 1, row 1|Cell in column 2, row 1
+|Cell in column 1, row 2|Cell in column 2, row 2
+|Cell in column 1, row 3|Cell in column 2, row 3
+|===

--- a/test/fixtures/semantic-html5-scenarios/table-basic_implicit-header-row_title_caption-attribute.adoc
+++ b/test/fixtures/semantic-html5-scenarios/table-basic_implicit-header-row_title_caption-attribute.adoc
@@ -1,0 +1,9 @@
+[caption="Data Set A.: "]
+.A table with an header row, a title and its label prefix
+|===
+|Cell in column 1, row 1|Cell in column 2, row 1
+
+|Cell in column 1, row 1|Cell in column 2, row 1
+|Cell in column 1, row 2|Cell in column 2, row 2
+|Cell in column 1, row 3|Cell in column 2, row 3
+|===

--- a/test/fixtures/semantic-html5-scenarios/table-basic_implicit-header-row_title_no-title-label-via-caption-attribute.adoc
+++ b/test/fixtures/semantic-html5-scenarios/table-basic_implicit-header-row_title_no-title-label-via-caption-attribute.adoc
@@ -1,0 +1,9 @@
+[caption=]
+.A table with a header row and a title but no label
+|===
+|Cell in column 1, row 1|Cell in column 2, row 1
+
+|Cell in column 1, row 1|Cell in column 2, row 1
+|Cell in column 1, row 2|Cell in column 2, row 2
+|Cell in column 1, row 3|Cell in column 2, row 3
+|===

--- a/test/fixtures/semantic-html5-scenarios/table-basic_implicit-header-row_title_no-title-label-via-table-caption.adoc
+++ b/test/fixtures/semantic-html5-scenarios/table-basic_implicit-header-row_title_no-title-label-via-table-caption.adoc
@@ -1,0 +1,10 @@
+:table-caption!:
+
+.A table with a title but no label
+|===
+|Cell in column 1, row 1|Cell in column 2, row 1
+
+|Cell in column 1, row 1|Cell in column 2, row 1
+|Cell in column 1, row 2|Cell in column 2, row 2
+|Cell in column 1, row 3|Cell in column 2, row 3
+|===

--- a/test/fixtures/semantic-html5-scenarios/table-basic_implicit-header-row_title_table-caption.adoc
+++ b/test/fixtures/semantic-html5-scenarios/table-basic_implicit-header-row_title_table-caption.adoc
@@ -1,0 +1,19 @@
+:table-caption: Data Set
+
+.A table with an header row and a title
+|===
+|Cell in column 1, row 1|Cell in column 2, row 1
+
+|Cell in column 1, row 1|Cell in column 2, row 1
+|Cell in column 1, row 2|Cell in column 2, row 2
+|Cell in column 1, row 3|Cell in column 2, row 3
+|===
+
+.A table with an header row and a title
+|===
+|Cell in column 1, row 1|Cell in column 2, row 1
+
+|Cell in column 1, row 1|Cell in column 2, row 1
+|Cell in column 1, row 2|Cell in column 2, row 2
+|Cell in column 1, row 3|Cell in column 2, row 3
+|===


### PR DESCRIPTION
My contribution to a new modern semantic HTML 5 table generator for the Asciidoctor and the AsciiDoc community. This is my first time contributing to this project.

ToDos before marking this PR as ready:

* [ ] writing tests
* [ ] writing code for the new table generator
* [ ] testing code using the written tests
* [ ] tweaking it
* [ ] Optional: Putting an html attribute `data-header` to each non-header cell to make [Responsive Data Tables - CSS-Tricks](https://css-tricks.com/responsive-data-tables/) with their example [Responsive Data Tables Example](https://codepen.io/team/css-tricks/pen/wXgJww) possible. Only with some modifications to remove the need to insert row content via CSS. So instead of `content: "First Name";` it will be something like `content: attr(data-header);` for all CSS `td` blocks.