### PR TITLE
fix front matter in preprocessor.adoc

### DIFF
--- a/docs/modules/extensions/pages/preprocessor.adoc
+++ b/docs/modules/extensions/pages/preprocessor.adoc
@@ -37,6 +37,7 @@ Skim off front matter from the top of the document that gets used by site genera
 
 [source,asciidoc]
 ....
+---
 tags: [announcement, website]
 ---
 = Document Title


### PR DESCRIPTION
Front matter must start with `---`, see https://docs.asciidoctor.org/asciidoctor/latest/html-backend/skip-front-matter/.