### PR TITLE
fix FrontMatterPreprocessor extension example joining lines

### DIFF
--- a/docs/modules/extensions/pages/preprocessor.adoc
+++ b/docs/modules/extensions/pages/preprocessor.adoc
@@ -72,7 +72,7 @@ class FrontMatterPreprocessor < Asciidoctor::Extensions::Preprocessor
         lines = original_lines
       else
         lines.shift
-        document.attributes['front-matter'] = front_matter.join.chomp
+        document.attributes['front-matter'] = front_matter.join("\n").chomp
         # advance the reader by the number of lines taken
         (front_matter.length + 2).times { reader.advance }
       end


### PR DESCRIPTION
It joins multiple lines into one line which is presumably not what intended to be shown.