### PR TITLE
asset uri configuration for webfont/mathjax/highlightjs

### DIFF
--- a/lib/asciidoctor.rb
+++ b/lib/asciidoctor.rb
@@ -359,6 +359,8 @@ module Asciidoctor
 
   MATHJAX_VERSION = '2.7.9'
 
+  CDN_URI_AUTHORITY = "cdnjs.cloudflare.com"
+
   DEFAULT_ATTRIBUTES = {
     'appendix-caption' => 'Appendix',
     'appendix-refsig' => 'Appendix',

--- a/lib/asciidoctor/syntax_highlighter/highlightjs.rb
+++ b/lib/asciidoctor/syntax_highlighter/highlightjs.rb
@@ -18,12 +18,16 @@ class SyntaxHighlighter::HighlightJsAdapter < SyntaxHighlighter::Base
   end
 
   def docinfo location, doc, opts
-    base_url = doc.attr 'highlightjsdir', %(#{opts[:cdn_base_url]}/highlight.js/#{HIGHLIGHT_JS_VERSION})
+    asset_uri = opts[:asset_uri]
+    base_uri = asset_uri[:highlightjs_uri].rpartition('/')[0]
+    style_uri = "#{base_uri}/styles/#{doc.attr 'highlightjs-theme', 'github'}.min.css"
+    languages_uri_path = "#{base_uri}/languages"
+
     if location == :head
-      %(<link rel="stylesheet" href="#{base_url}/styles/#{doc.attr 'highlightjs-theme', 'github'}.min.css"#{opts[:self_closing_tag_slash]}>)
+      %(<link rel="stylesheet" href="#{style_uri}"#{opts[:self_closing_tag_slash]}>)
     else # :footer
-      %(<script src="#{base_url}/highlight.min.js"></script>
-#{(doc.attr? 'highlightjs-languages') ? ((doc.attr 'highlightjs-languages').split ',').map {|lang| %(<script src="#{base_url}/languages/#{lang.lstrip}.min.js"></script>\n) }.join : ''}<script>
+      %(<script src="#{asset_uri[:highlightjs_uri]}"></script>
+#{(doc.attr? 'highlightjs-languages') ? ((doc.attr 'highlightjs-languages').split ',').map {|lang| %(<script src="#{languages_uri_path}/#{lang.lstrip}.min.js"></script>\n) }.join : ''}<script>
 if (!hljs.initHighlighting.called) {
   hljs.initHighlighting.called = true
   ;[].slice.call(document.querySelectorAll('pre.highlight > code[data-lang]')).forEach(function (el) { hljs.highlightBlock(el) })


### PR DESCRIPTION
# overview

This changeset updates html5 renderer use of URI's for remote loaded content:
- mathjax
- webfonts
- highlightjs
- fontawesome

Features:
- consolidate URI strings into one place (```Asciidoctor::Converter::Html5Converter::@asset_uri```)
- provide run-time configuration of each URI component (scheme, authority, path, query) via attributes
- provide an override

# examples

## cdn server

To change MathJax's run-time script src server:
- use the document attribute ```:mathjax-uri-authority: my.cdn.internal```
- or, command line ```-a mathjax-uri-authority=my.cdn.internal```

similiarly, ```mathjax-uri-scheme```, ```mathjax-uri-path```, ```mathjax-uri-query``` may be changed from their default

## override

Adjusting the full URI by component may not offer enough flexibility, so there is a complete override available as ```product-uri```.  For example with MathJax: ```:mathjax-uri: ./local/MathJax.js```