### PR TITLE
Change default CSS to support RTL languages

### DIFF
--- a/data/stylesheets/asciidoctor-default.css
+++ b/data/stylesheets/asciidoctor-default.css
@@ -19,7 +19,7 @@ pre{color:rgba(0,0,0,.9);line-height:1.45;text-rendering:optimizeSpeed;white-spa
 dfn{font-style:italic}
 em,i{font-style:italic;line-height:inherit}
 em em{font-style:normal}
-hr{border:solid #dddddf;border-width:1px 0 0;clear:both;height:0;margin:1.25em 0 1.1875em}
+hr{border:solid #dddddf;border-width:1px 0 0;clear:both;height:0;margin-block:1.25em 1.1875em}
 mark{background:#ff0;color:#000}
 p{line-height:1.6;margin-bottom:1.25rem;text-rendering:optimizeLegibility}
 q{quotes:"\201C" "\201D" "\2018" "\2019"}
@@ -34,10 +34,10 @@ svg:not(:root){overflow:hidden}
 figure{margin:0}
 audio,video{display:inline-block}
 audio:not([controls]){display:none;height:0}
-.left{float:left!important}
-.right{float:right!important}
-.text-left,div.text-left>*{text-align:left!important}
-.text-right,div.text-right>*{text-align:right!important}
+.left{float:inline-start!important}
+.right{float:inline-end!important}
+.text-left,div.text-left>*{text-align:start!important}
+.text-right,div.text-right>*{text-align:end!important}
 .text-center,div.text-center>*{text-align:center!important}
 .text-justify,div.text-justify>*{text-align:justify!important}
 .hide{display:none}
@@ -51,16 +51,16 @@ h3,#toctitle,.sidebarblock>.content>.title{font-size:1.375em}
 h4,h5{font-size:1.125em}
 h6{font-size:1em}
 ul,ol,dl{line-height:1.6;margin-bottom:1.25em;list-style-position:outside;font-family:inherit}
-ul,ol{margin-left:1.5em}
-ul li ul,ul li ol{margin-left:1.25em;margin-bottom:0}
+ul,ol{margin-inline-start:1.5em}
+ul li ul,ul li ol{margin-inline-start:1.25em;margin-bottom:0}
 ul.circle{list-style-type:circle}
 ul.disc{list-style-type:disc}
 ul.square{list-style-type:square}
 ul.circle ul:not([class]),ul.disc ul:not([class]),ul.square ul:not([class]){list-style:inherit}
-ol li ul,ol li ol{margin-left:1.25em;margin-bottom:0}
+ol li ul,ol li ol{margin-inline-start:1.25em;margin-bottom:0}
 dl dt{margin-bottom:.3125em;font-weight:bold}
-dl dd{margin-bottom:1.25em;margin-left:1.125em}
-blockquote{margin:0 0 1.25em;padding:.5625em 1.25em 0 1.1875em;border-left:1px solid #ddd}
+dl dd{margin-bottom:1.25em;margin-inline-start:1.125em}
+blockquote{margin:0 0 1.25em;padding-block:.5625em 0;padding-inline:1.25em 1.1875em;border-inline-start:1px solid #ddd}
 blockquote,blockquote p{line-height:1.6;color:rgba(0,0,0,.85)}
 @media screen and (min-width:768px){h1{font-size:2.75em}
 h2{font-size:2.3125em}
@@ -68,12 +68,12 @@ h3,#toctitle,.sidebarblock>.content>.title{font-size:1.6875em}
 h4{font-size:1.4375em}}
 table{background:#fff;border:1px solid #dedede;border-collapse:collapse;border-spacing:0;margin-bottom:1.25em;word-wrap:normal}
 table thead,table tfoot{background:#f7f8f7}
-table thead tr th,table thead tr td,table tfoot tr th,table tfoot tr td{padding:.5em .625em .625em;font-size:inherit;color:rgba(0,0,0,.8);text-align:left}
+table thead tr th,table thead tr td,table tfoot tr th,table tfoot tr td{padding-block:.5em .625em;padding-inline:.625em;font-size:inherit;color:rgba(0,0,0,.8);text-align:inline-start}
 table tr th,table tr td{padding:.5625em .625em;font-size:inherit;color:rgba(0,0,0,.8)}
 table tr.even,table tr.alt{background:#f8f8f7}
 table thead tr th,table tfoot tr th,table tbody tr td,table tr td,table tfoot tr td{line-height:1.6}
 h1 strong,h2 strong,h3 strong,#toctitle strong,.sidebarblock>.content>.title strong,h4 strong,h5 strong,h6 strong{font-weight:400}
-.center{margin-left:auto;margin-right:auto}
+.center{margin-inline:auto}
 .stretch{width:100%}
 .clearfix::before,.clearfix::after,.float-group::before,.float-group::after{content:"";display:table}
 .clearfix::after,.float-group::after{clear:both}
@@ -85,26 +85,26 @@ pre code,pre pre{color:inherit;font-size:inherit;line-height:inherit}
 pre.nowrap,pre.nowrap pre{white-space:pre;word-wrap:normal}
 .keyseq{color:rgba(51,51,51,.8)}
 kbd{display:inline-block;color:rgba(0,0,0,.8);font-size:.65em;line-height:1.45;background:#f7f7f7;border:1px solid #ccc;border-radius:3px;box-shadow:0 1px 0 rgba(0,0,0,.2),inset 0 0 0 .1em #fff;margin:0 .15em;padding:.2em .5em;vertical-align:middle;position:relative;top:-.1em;white-space:nowrap}
-.keyseq kbd:first-child{margin-left:0}
-.keyseq kbd:last-child{margin-right:0}
+.keyseq kbd:first-child{margin-inline-start:0}
+.keyseq kbd:last-child{margin-inline-end:0}
 .menuseq,.menuref{color:#000}
 .menuseq b:not(.caret),.menuref{font-weight:inherit}
 .menuseq{word-spacing:-.02em}
 .menuseq b.caret{font-size:1.25em;line-height:.8}
 .menuseq i.caret{font-weight:bold;text-align:center;width:.45em}
 b.button::before,b.button::after{position:relative;top:-1px;font-weight:400}
-b.button::before{content:"[";padding:0 3px 0 2px}
-b.button::after{content:"]";padding:0 2px 0 3px}
+b.button::before{content:"[";padding-inline:3px 2px}
+b.button::after{content:"]";padding-inline:2px 3px}
 p a>code:hover{color:rgba(0,0,0,.9)}
-body>div[id]{margin:0 auto;max-width:62.5em;position:relative;padding-left:.9375em;padding-right:.9375em;width:100%}
+body>div[id]{margin:0 auto;max-width:62.5em;position:relative;padding-inline:.9375em;width:100%}
 body>div[id]::before,body>div[id]::after,#content #footnotes::before{content:"";display:table;clear:both}
 #content{margin-top:1.25em;margin-bottom:.625em}
 #content::before{content:none}
 #header>h1:first-child{color:rgba(0,0,0,.85);margin-top:2.25rem;margin-bottom:0}
 #header>h1:first-child+#toc{margin-top:8px;border-top:1px solid #dddddf}
 #header>h1:only-child{border-bottom:1px solid #dddddf;padding-bottom:8px}
-#header .details{border-bottom:1px solid #dddddf;line-height:1.45;padding-top:.25em;padding-bottom:.25em;padding-left:.25em;color:rgba(0,0,0,.6);display:flex;flex-flow:row wrap}
-#header .details span:first-child{margin-left:-.125em}
+#header .details{border-bottom:1px solid #dddddf;line-height:1.45;padding-top:.25em;padding-bottom:.25em;padding-inline-start:.25em;color:rgba(0,0,0,.6);display:flex;flex-flow:row wrap}
+#header .details span:first-child{margin-inline-start:-.125em}
 #header .details span.email a{color:rgba(0,0,0,.85)}
 #header .details br{display:none}
 #header .details br+span::before{content:"\00a0\2013\00a0"}
@@ -114,7 +114,7 @@ body>div[id]::before,body>div[id]::after,#content #footnotes::before{content:"";
 #header #revnumber::after{content:"\00a0"}
 #content>h1:first-child:not([class]){color:rgba(0,0,0,.85);border-bottom:1px solid #dddddf;padding-bottom:8px;margin-top:0;padding-top:1rem;margin-bottom:1.25rem}
 #toc{border-bottom:1px solid #e7e7e9;padding-bottom:.5em}
-#toc>ul{margin-left:.125em}
+#toc>ul{margin-inline-start:.125em}
 #toc ul.sectlevel0>li>a{font-style:italic}
 #toc ul.sectlevel0 ul.sectlevel1{margin:.5em 0}
 #toc ul{font-family:"Open Sans","DejaVu Sans",sans-serif;list-style-type:none}
@@ -123,21 +123,21 @@ body>div[id]::before,body>div[id]::after,#content #footnotes::before{content:"";
 #toc a:active{text-decoration:underline}
 #toctitle{color:#7a2518;font-size:1.2em}
 @media screen and (min-width:768px){#toctitle{font-size:1.375em}
-body.toc2{padding-left:15em;padding-right:0}
+body.toc2{padding-inline-start:15em;padding-inline-end:0}
 body.toc2 #header>h1:nth-last-child(2){border-bottom:1px solid #dddddf;padding-bottom:8px}
-#toc.toc2{margin-top:0!important;background:#f8f8f7;position:fixed;width:15em;left:0;top:0;border-right:1px solid #e7e7e9;border-top-width:0!important;border-bottom-width:0!important;z-index:1000;padding:1.25em 1em;height:100%;overflow:auto}
+#toc.toc2{margin-top:0!important;background:#f8f8f7;position:fixed;width:15em;inset-inline-start:0;top:0;border-inline-end:1px solid #e7e7e9;border-top-width:0!important;border-bottom-width:0!important;z-index:1000;padding:1.25em 1em;height:100%;overflow:auto}
 #toc.toc2 #toctitle{margin-top:0;margin-bottom:.8rem;font-size:1.2em}
 #toc.toc2>ul{font-size:.9em;margin-bottom:0}
-#toc.toc2 ul ul{margin-left:0;padding-left:1em}
-#toc.toc2 ul.sectlevel0 ul.sectlevel1{padding-left:0;margin-top:.5em;margin-bottom:.5em}
-body.toc2.toc-right{padding-left:0;padding-right:15em}
-body.toc2.toc-right #toc.toc2{border-right-width:0;border-left:1px solid #e7e7e9;left:auto;right:0}}
-@media screen and (min-width:1280px){body.toc2{padding-left:20em;padding-right:0}
+#toc.toc2 ul ul{margin-inline-start:0;padding-inline-start:1em}
+#toc.toc2 ul.sectlevel0 ul.sectlevel1{padding-inline-start:0;margin-top:.5em;margin-bottom:.5em}
+body.toc2.toc-right{padding-inline-start:0;padding-inline-end:15em}
+body.toc2.toc-right #toc.toc2{border-inline-end-width:0;border-inline-start:1px solid #e7e7e9;inset-inline-start:auto;inset-inline-end:0}}
+@media screen and (min-width:1280px){body.toc2{padding-inline-start:20em;padding-inline-end:0}
 #toc.toc2{width:20em}
 #toc.toc2 #toctitle{font-size:1.375em}
 #toc.toc2>ul{font-size:.95em}
-#toc.toc2 ul ul{padding-left:1.25em}
-body.toc2.toc-right{padding-left:0;padding-right:20em}}
+#toc.toc2 ul ul{padding-inline-start:1.25em}
+body.toc2.toc-right{padding-inline-start:0;padding-inline-end:20em}}
 #content #toc{border:1px solid #e0e0dc;margin-bottom:1.25em;padding:1.25em;background:#f8f8f7;border-radius:4px}
 #footer{max-width:none;background:rgba(0,0,0,.8);padding:1.25em}
 #footer-text{color:hsla(0,0%,100%,.8);line-height:1.44}
@@ -146,26 +146,26 @@ body.toc2.toc-right{padding-left:0;padding-right:20em}}
 .sect1{padding-bottom:1.25em}}
 .sect1:last-child{padding-bottom:0}
 .sect1+.sect1{border-top:1px solid #e7e7e9}
-#content h1>a.anchor,h2>a.anchor,h3>a.anchor,#toctitle>a.anchor,.sidebarblock>.content>.title>a.anchor,h4>a.anchor,h5>a.anchor,h6>a.anchor{position:absolute;z-index:1001;width:1.5ex;margin-left:-1.5ex;display:block;text-decoration:none!important;visibility:hidden;text-align:center;font-weight:400}
+#content h1>a.anchor,h2>a.anchor,h3>a.anchor,#toctitle>a.anchor,.sidebarblock>.content>.title>a.anchor,h4>a.anchor,h5>a.anchor,h6>a.anchor{position:absolute;z-index:1001;width:1.5ex;margin-inline-start:-1.5ex;display:block;text-decoration:none!important;visibility:hidden;text-align:center;font-weight:400}
 #content h1>a.anchor::before,h2>a.anchor::before,h3>a.anchor::before,#toctitle>a.anchor::before,.sidebarblock>.content>.title>a.anchor::before,h4>a.anchor::before,h5>a.anchor::before,h6>a.anchor::before{content:"\00A7";font-size:.85em;display:block;padding-top:.1em}
 #content h1:hover>a.anchor,#content h1>a.anchor:hover,h2:hover>a.anchor,h2>a.anchor:hover,h3:hover>a.anchor,#toctitle:hover>a.anchor,.sidebarblock>.content>.title:hover>a.anchor,h3>a.anchor:hover,#toctitle>a.anchor:hover,.sidebarblock>.content>.title>a.anchor:hover,h4:hover>a.anchor,h4>a.anchor:hover,h5:hover>a.anchor,h5>a.anchor:hover,h6:hover>a.anchor,h6>a.anchor:hover{visibility:visible}
 #content h1>a.link,h2>a.link,h3>a.link,#toctitle>a.link,.sidebarblock>.content>.title>a.link,h4>a.link,h5>a.link,h6>a.link{color:#ba3925;text-decoration:none}
 #content h1>a.link:hover,h2>a.link:hover,h3>a.link:hover,#toctitle>a.link:hover,.sidebarblock>.content>.title>a.link:hover,h4>a.link:hover,h5>a.link:hover,h6>a.link:hover{color:#a53221}
 details,.audioblock,.imageblock,.literalblock,.listingblock,.stemblock,.videoblock{margin-bottom:1.25em}
-details{margin-left:1.25rem}
+details{margin-inline-start:1.25rem}
 details>summary{cursor:pointer;display:block;position:relative;line-height:1.6;margin-bottom:.625rem;outline:none;-webkit-tap-highlight-color:transparent}
 details>summary::-webkit-details-marker{display:none}
-details>summary::before{content:"";border:solid transparent;border-left:solid;border-width:.3em 0 .3em .5em;position:absolute;top:.5em;left:-1.25rem;transform:translateX(15%)}
+details>summary::before{content:"";border-inline-start-color:currentColor;border:solid transparent;border-width:.3em 0 .3em .5em;position:absolute;top:.5em;inset-inline-start:-1.25rem;transform:translateX(15%)}
 details[open]>summary::before{border:solid transparent;border-top:solid;border-width:.5em .3em 0;transform:translateY(15%)}
-details>summary::after{content:"";width:1.25rem;height:1em;position:absolute;top:.3em;left:-1.25rem}
-.admonitionblock td.content>.title,.audioblock>.title,.exampleblock>.title,.imageblock>.title,.listingblock>.title,.literalblock>.title,.stemblock>.title,.openblock>.title,.paragraph>.title,.quoteblock>.title,table.tableblock>.title,.verseblock>.title,.videoblock>.title,.dlist>.title,.olist>.title,.ulist>.title,.qlist>.title,.hdlist>.title{text-rendering:optimizeLegibility;text-align:left;font-family:"Noto Serif","DejaVu Serif",serif;font-size:1rem;font-style:italic}
+details>summary::after{content:"";width:1.25rem;height:1em;position:absolute;top:.3em;inset-inline-start:-1.25rem}
+.admonitionblock td.content>.title,.audioblock>.title,.exampleblock>.title,.imageblock>.title,.listingblock>.title,.literalblock>.title,.stemblock>.title,.openblock>.title,.paragraph>.title,.quoteblock>.title,table.tableblock>.title,.verseblock>.title,.videoblock>.title,.dlist>.title,.olist>.title,.ulist>.title,.qlist>.title,.hdlist>.title{text-rendering:optimizeLegibility;text-align:start;font-family:"Noto Serif","DejaVu Serif",serif;font-size:1rem;font-style:italic}
 table.tableblock.fit-content>caption.title{white-space:nowrap;width:0}
 .paragraph.lead>p,#preamble>.sectionbody>[class=paragraph]:first-of-type p{font-size:1.21875em;line-height:1.6;color:rgba(0,0,0,.85)}
 .admonitionblock>table{border-collapse:separate;border:0;background:none;width:100%}
 .admonitionblock>table td.icon{text-align:center;width:80px}
 .admonitionblock>table td.icon img{max-width:none}
 .admonitionblock>table td.icon .title{font-weight:bold;font-family:"Open Sans","DejaVu Sans",sans-serif;text-transform:uppercase}
-.admonitionblock>table td.content{padding-left:1.125em;padding-right:1.25em;border-left:1px solid #dddddf;color:rgba(0,0,0,.6);word-wrap:anywhere}
+.admonitionblock>table td.content{padding-inline-start:1.125em;padding-inline-end:1.25em;border-inline-start:1px solid #dddddf;color:rgba(0,0,0,.6);word-wrap:anywhere}
 .admonitionblock>table td.content>:last-child>:last-child{margin-bottom:0}
 .exampleblock>.content{border:1px solid #e0e0dc;margin-bottom:1.25em;padding:1.25em;background:#fffef7;border-radius:4px;box-shadow:0 1px 4px #e0e0dc}
 .sidebarblock{border:1px solid #dbdbd6;margin-bottom:1.25em;padding:1.25em;background:#f3f3f2;border-radius:4px}
@@ -179,46 +179,47 @@ table.tableblock.fit-content>caption.title{white-space:nowrap;width:0}
 .literalblock.output pre{color:#f7f7f8;background:rgba(0,0,0,.9)}
 .listingblock>.content{position:relative}
 .listingblock pre>code{display:block}
-.listingblock code[data-lang]::before{display:none;content:attr(data-lang);position:absolute;font-size:.75em;top:.425rem;right:.5rem;line-height:1;text-transform:uppercase;color:inherit;opacity:.5}
+.listingblock code[data-lang]::before{display:none;content:attr(data-lang);position:absolute;font-size:.75em;top:.425rem;inset-inline-end:.5rem;line-height:1;text-transform:uppercase;color:inherit;opacity:.5}
 .listingblock:hover code[data-lang]::before{display:block}
-.listingblock.terminal pre .command::before{content:attr(data-prompt);padding-right:.5em;color:inherit;opacity:.5}
+.listingblock.terminal pre .command::before{content:attr(data-prompt);padding-inline-end:.5em;color:inherit;opacity:.5}
 .listingblock.terminal pre .command:not([data-prompt])::before{content:"$"}
 .listingblock pre.highlightjs{padding:0}
 .listingblock pre.highlightjs>code{padding:1em;border-radius:4px}
 .listingblock pre.prettyprint{border-width:0}
 .prettyprint{background:#f7f7f8}
-pre.prettyprint .linenums{line-height:1.45;margin-left:2em}
-pre.prettyprint li{background:none;list-style-type:inherit;padding-left:0}
+pre.prettyprint .linenums{line-height:1.45;margin-inline-start:2em}
+pre.prettyprint li{background:none;list-style-type:inherit;padding-inline-start:0}
 pre.prettyprint li code[data-lang]::before{opacity:1}
 pre.prettyprint li:not(:first-child) code[data-lang]::before{display:none}
 table.linenotable{border-collapse:separate;border:0;margin-bottom:0;background:none}
 table.linenotable td[class]{color:inherit;vertical-align:top;padding:0;line-height:inherit;white-space:normal}
-table.linenotable td.code{padding-left:.75em}
+table.linenotable td.code{padding-inline-start:.75em}
 table.linenotable td.linenos{width:.01%}
-table.linenotable td.linenos,pre.pygments .linenos,pre.rouge .linenos{border-right:1px solid;opacity:.35;padding-right:.5em;-webkit-user-select:none;-moz-user-select:none;user-select:none}
-pre.pygments span.linenos,pre.rouge span.linenos{display:inline-block;margin-right:.75em}
-.quoteblock{margin:0 1em 1.25em 1.5em;display:table}
-.quoteblock:not(.excerpt)>.title{margin-left:-1.5em;margin-bottom:.75em}
+table.linenotable td.linenos,pre.pygments .linenos,pre.rouge .linenos{border-inline-end:1px solid;opacity:.35;padding-inline-end:.5em;-webkit-user-select:none;-moz-user-select:none;user-select:none}
+pre.pygments span.linenos,pre.rouge span.linenos{display:inline-block;margin-inline-end:.75em}
+.quoteblock{margin-block:0 1.25em;margin-inline:1em 1.5em;display:table}
+.quoteblock:not(.excerpt)>.title{margin-inline-start:-1.5em;margin-bottom:.75em}
 .quoteblock blockquote,.quoteblock p{color:rgba(0,0,0,.85);font-size:1.15rem;line-height:1.75;word-spacing:.1em;letter-spacing:0;font-style:italic;text-align:justify}
 .quoteblock blockquote{margin:0;padding:0;border:0}
-.quoteblock blockquote::before{content:"\201c";float:left;font-size:2.75em;font-weight:bold;line-height:.6em;margin-left:-.6em;color:#7a2518;text-shadow:0 1px 2px rgba(0,0,0,.1)}
+.quoteblock blockquote::before{content:"\201c";float:inline-start;font-size:2.75em;font-weight:bold;line-height:.6em;margin-inline-start:-.6em;color:#7a2518;text-shadow:0 1px 2px rgba(0,0,0,.1)}
+.quoteblock blockquote:dir(rtl)::before{content:"\201d"}
 .quoteblock blockquote>.paragraph:last-child p{margin-bottom:0}
-.quoteblock .attribution{margin-top:.75em;margin-right:.5ex;text-align:right}
-.verseblock{margin:0 1em 1.25em}
+.quoteblock .attribution{margin-top:.75em;margin-inline-end:.5ex;text-align:end}
+.verseblock{margin-block:0 1.25em;margin-inline:1em}
 .verseblock pre{font-family:"Open Sans","DejaVu Sans",sans-serif;font-size:1.15rem;color:rgba(0,0,0,.85);font-weight:300;text-rendering:optimizeLegibility}
 .verseblock pre strong{font-weight:400}
-.verseblock .attribution{margin-top:1.25rem;margin-left:.5ex}
+.verseblock .attribution{margin-top:1.25rem;margin-inline-start:.5ex}
 .quoteblock .attribution,.verseblock .attribution{font-size:.9375em;line-height:1.45;font-style:italic}
 .quoteblock .attribution br,.verseblock .attribution br{display:none}
 .quoteblock .attribution cite,.verseblock .attribution cite{display:block;letter-spacing:-.025em;color:rgba(0,0,0,.6)}
 .quoteblock.abstract blockquote::before,.quoteblock.excerpt blockquote::before,.quoteblock .quoteblock blockquote::before{display:none}
 .quoteblock.abstract blockquote,.quoteblock.abstract p,.quoteblock.excerpt blockquote,.quoteblock.excerpt p,.quoteblock .quoteblock blockquote,.quoteblock .quoteblock p{line-height:1.6;word-spacing:0}
-.quoteblock.abstract{margin:0 1em 1.25em;display:block}
-.quoteblock.abstract>.title{margin:0 0 .375em;font-size:1.15em;text-align:center}
-.quoteblock.excerpt>blockquote,.quoteblock .quoteblock{padding:0 0 .25em 1em;border-left:.25em solid #dddddf}
-.quoteblock.excerpt,.quoteblock .quoteblock{margin-left:0}
+.quoteblock.abstract{margin-block:0 1.25em;margin-inline:1em;display:block}
+.quoteblock.abstract>.title{margin-block:0 .375em;font-size:1.15em;text-align:center}
+.quoteblock.excerpt>blockquote,.quoteblock .quoteblock{padding-block:0 .25em;padding-inline:0 1em;border-inline-start:.25em solid #dddddf}
+.quoteblock.excerpt,.quoteblock .quoteblock{margin-inline-start:0}
 .quoteblock.excerpt blockquote,.quoteblock.excerpt p,.quoteblock .quoteblock blockquote,.quoteblock .quoteblock p{color:inherit;font-size:1.0625rem}
-.quoteblock.excerpt .attribution,.quoteblock .quoteblock .attribution{color:inherit;font-size:.85rem;text-align:left;margin-right:0}
+.quoteblock.excerpt .attribution,.quoteblock .quoteblock .attribution{color:inherit;font-size:.85rem;text-align:start;margin-inline-end:0}
 p.tableblock:last-child{margin-bottom:0}
 td.tableblock>.content{margin-bottom:1.25em;word-wrap:anywhere}
 td.tableblock>.content>:last-child{margin-bottom:-1.25em}
@@ -231,11 +232,11 @@ table.frame-ends{border-width:1px 0}
 table.frame-sides{border-width:0 1px}
 table.frame-none>colgroup+*>:first-child>*,table.frame-sides>colgroup+*>:first-child>*{border-top-width:0}
 table.frame-none>:last-child>:last-child>*,table.frame-sides>:last-child>:last-child>*{border-bottom-width:0}
-table.frame-none>*>tr>:first-child,table.frame-ends>*>tr>:first-child{border-left-width:0}
-table.frame-none>*>tr>:last-child,table.frame-ends>*>tr>:last-child{border-right-width:0}
+table.frame-none>*>tr>:first-child,table.frame-ends>*>tr>:first-child{border-inline-start-width:0}
+table.frame-none>*>tr>:last-child,table.frame-ends>*>tr>:last-child{border-inline-end-width:0}
 table.stripes-all>*>tr,table.stripes-odd>*>tr:nth-of-type(odd),table.stripes-even>*>tr:nth-of-type(even),table.stripes-hover>*>tr:hover{background:#f8f8f7}
-th.halign-left,td.halign-left{text-align:left}
-th.halign-right,td.halign-right{text-align:right}
+th.halign-left,td.halign-left{text-align:start}
+th.halign-right,td.halign-right{text-align:end}
 th.halign-center,td.halign-center{text-align:center}
 th.valign-top,td.valign-top{vertical-align:top}
 th.valign-bottom,td.valign-bottom{vertical-align:bottom}
@@ -245,19 +246,19 @@ tbody tr th{background:#f7f8f7}
 tbody tr th,tbody tr th p,tfoot tr th,tfoot tr th p{color:rgba(0,0,0,.8);font-weight:bold}
 p.tableblock>code:only-child{background:none;padding:0}
 p.tableblock{font-size:1em}
-ol{margin-left:1.75em}
-ul li ol{margin-left:1.5em}
+ol{margin-inline-start:1.75em}
+ul li ol{margin-inline-start:1.5em}
 dl dd:last-child,dl dd:last-child>:last-child{margin-bottom:0}
 li p,ul dd,ol dd,.olist .olist,.ulist .ulist,.ulist .olist,.olist .ulist{margin-bottom:.625em}
 ul.checklist,ul.none,ol.none,ul.no-bullet,ol.no-bullet,ol.unnumbered,ul.unstyled,ol.unstyled{list-style-type:none}
-ul.no-bullet,ol.no-bullet,ol.unnumbered{margin-left:.625em}
-ul.unstyled,ol.unstyled{margin-left:0}
+ul.no-bullet,ol.no-bullet,ol.unnumbered{margin-inline-start:.625em}
+ul.unstyled,ol.unstyled{margin-inline-start:0}
 li>p:empty:only-child::before{content:"";display:inline-block}
-ul.checklist>li>p:first-child{margin-left:-1em}
+ul.checklist>li>p:first-child{margin-inline-start:-1em}
 ul.checklist>li>p:first-child>.fa-square-o:first-child,ul.checklist>li>p:first-child>.fa-check-square-o:first-child{width:1.25em;font-size:.8em;position:relative;bottom:.125em}
-ul.checklist>li>p:first-child>input[type=checkbox]:first-child{font:inherit;margin:0 .25em 0 0;padding:0}
-ul.inline{display:flex;flex-flow:row wrap;list-style:none;margin:0 0 .625em -1.25em}
-ul.inline>li{margin-left:1.25em}
+ul.checklist>li>p:first-child>input[type=checkbox]:first-child{font:inherit;margin-block:0;margin-inline:.25em 0;padding:0}
+ul.inline{display:flex;flex-flow:row wrap;list-style:none;margin-block:0 .625em;margin-inline:0 -1.25em}
+ul.inline>li{margin-inline-start:1.25em}
 .unstyled dl dt{font-weight:400;font-style:normal}
 ol.arabic{list-style-type:decimal}
 ol.decimal{list-style-type:decimal-leading-zero}
@@ -272,27 +273,27 @@ td.hdlist1,td.hdlist2{vertical-align:top;padding:0 .625em}
 td.hdlist1{font-weight:bold;padding-bottom:1.25em}
 td.hdlist2{word-wrap:anywhere}
 .literalblock+.colist,.listingblock+.colist{margin-top:-.5em}
-.colist td:not([class]):first-child{padding:.4em .75em 0;line-height:1;vertical-align:top}
+.colist td:not([class]):first-child{padding-block:.4em 0;padding-inline:.75em;line-height:1;vertical-align:top}
 .colist td:not([class]):first-child img{max-width:none}
 .colist td:not([class]):last-child{padding:.25em 0}
 .thumb,.th{line-height:0;display:inline-block;border:4px solid #fff;box-shadow:0 0 0 1px #ddd}
-.imageblock.left{margin:.25em .625em 1.25em 0}
-.imageblock.right{margin:.25em 0 1.25em .625em}
+.imageblock.left{margin-block:.25em 1.25em;margin-inline:.625em 0}
+.imageblock.right{margin-block:.25em 1.25em;margin-inline:0 .625em}
 .imageblock>.title{margin-bottom:0}
 .imageblock.thumb,.imageblock.th{border-width:6px}
 .imageblock.thumb>.title,.imageblock.th>.title{padding:0 .125em}
 .image.left,.image.right{margin-top:.25em;margin-bottom:.25em;display:inline-block;line-height:0}
-.image.left{margin-right:.625em}
-.image.right{margin-left:.625em}
+.image.left{margin-inline-end:.625em}
+.image.right{margin-inline-start:.625em}
 a.image{text-decoration:none;display:inline-block}
 a.image object{pointer-events:none}
 sup.footnote,sup.footnoteref{font-size:.875em;position:static;vertical-align:super}
 sup.footnote a,sup.footnoteref a{text-decoration:none}
 sup.footnote a:active,sup.footnoteref a:active,#footnotes .footnote a:first-of-type:active{text-decoration:underline}
 #footnotes{padding-top:.75em;padding-bottom:.75em;margin-bottom:.625em}
-#footnotes hr{width:20%;min-width:6.25em;margin:-.25em 0 .75em;border-width:1px 0 0}
-#footnotes .footnote{padding:0 .375em 0 .225em;line-height:1.3334;font-size:.875em;margin-left:1.2em;margin-bottom:.2em}
-#footnotes .footnote a:first-of-type{font-weight:bold;text-decoration:none;margin-left:-1.05em}
+#footnotes hr{width:20%;min-width:6.25em;margin-block:-.25em .75em;border-width:1px 0 0}
+#footnotes .footnote{padding-inline:.375em .225em;line-height:1.3334;font-size:.875em;margin-inline-start:1.2em;margin-bottom:.2em}
+#footnotes .footnote a:first-of-type{font-weight:bold;text-decoration:none;margin-inline-start:-1.05em}
 #footnotes .footnote:last-of-type{margin-bottom:0}
 #content #footnotes{margin-top:-.625em;margin-bottom:0;padding:.75em 0}
 div.page-break{display:none}
@@ -360,7 +361,7 @@ p,blockquote,dt,td.content,td.hdlist1,span.alt,summary{font-size:1.0625rem}
 html{font-size:80%}
 a{color:inherit!important;text-decoration:underline!important}
 a.bare,a[href^="#"],a[href^="mailto:"]{text-decoration:none!important}
-a[href^="http:"]:not(.bare)::after,a[href^="https:"]:not(.bare)::after{content:"(" attr(href) ")";display:inline-block;font-size:.875em;padding-left:.25em}
+a[href^="http:"]:not(.bare)::after,a[href^="https:"]:not(.bare)::after{content:"(" attr(href) ")";display:inline-block;font-size:.875em;padding-inline-start:.25em}
 abbr[title]{border-bottom:1px dotted}
 abbr[title]::after{content:" (" attr(title) ")"}
 pre,blockquote,tr,img,object,svg{-moz-column-break-inside:avoid;break-inside:avoid}
@@ -371,12 +372,12 @@ body>div[id]{max-width:none}
 #toc,.sidebarblock,.exampleblock>.content{background:none!important}
 #toc{border-bottom:1px solid #dddddf!important;padding-bottom:0!important}
 body.book #header{text-align:center}
-body.book #header>h1:first-child{border:0!important;margin:2.5em 0 1em}
+body.book #header>h1:first-child{border:0!important;margin-block:2.5em 1em}
 body.book #header .details{border:0!important;display:block;padding:0!important}
-body.book #header .details span:first-child{margin-left:0!important}
+body.book #header .details span:first-child{margin-inline-start:0!important}
 body.book #header .details br{display:block}
 body.book #header .details br+span::before{content:none!important}
-body.book #toc{border:0!important;text-align:left!important;padding:0!important;margin:0!important}
+body.book #toc{border:0!important;text-align:start!important;padding:0!important;margin:0!important}
 body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{-moz-column-break-before:page;break-before:page}
 .listingblock code[data-lang]::before{display:block}
 div.page-break{display:block;-moz-column-break-after:page;break-after:page}

--- a/src/stylesheets/asciidoctor.css
+++ b/src/stylesheets/asciidoctor.css
@@ -129,7 +129,7 @@ hr {
   border-width: 1px 0 0;
   clear: both;
   height: 0;
-  margin: 1.25em 0 1.1875em;
+  margin-block: 1.25em 1.1875em;
 }
 
 mark {
@@ -205,21 +205,21 @@ audio:not([controls]) {
 }
 
 .left {
-  float: left !important;
+  float: inline-start !important;
 }
 
 .right {
-  float: right !important;
+  float: inline-end !important;
 }
 
 .text-left,
 div.text-left > * {
-  text-align: left !important;
+  text-align: start !important;
 }
 
 .text-right,
 div.text-right > * {
-  text-align: right !important;
+  text-align: end !important;
 }
 
 .text-center,
@@ -333,12 +333,12 @@ dl {
 
 ul,
 ol {
-  margin-left: 1.5em;
+  margin-inline-start: 1.5em;
 }
 
 ul li ul,
 ul li ol {
-  margin-left: 1.25em;
+  margin-inline-start: 1.25em;
   margin-bottom: 0;
 }
 
@@ -362,7 +362,7 @@ ul.square ul:not([class]) {
 
 ol li ul,
 ol li ol {
-  margin-left: 1.25em;
+  margin-inline-start: 1.25em;
   margin-bottom: 0;
 }
 
@@ -373,13 +373,14 @@ dl dt {
 
 dl dd {
   margin-bottom: 1.25em;
-  margin-left: 1.125em;
+  margin-inline-start: 1.125em;
 }
 
 blockquote {
   margin: 0 0 1.25em;
-  padding: 0.5625em 1.25em 0 1.1875em;
-  border-left: 1px solid #ddd;
+  padding-block: 0.5625em 0;
+  padding-inline: 1.25em 1.1875em;
+  border-inline-start: 1px solid #ddd;
 }
 
 blockquote,
@@ -426,10 +427,11 @@ table thead tr th,
 table thead tr td,
 table tfoot tr th,
 table tfoot tr td {
-  padding: 0.5em 0.625em 0.625em;
+  padding-block: 0.5em 0.625em;
+  padding-inline: 0.625em;
   font-size: inherit;
   color: rgb(0 0 0 / 0.8);
-  text-align: left;
+  text-align: inline-start;
 }
 
 table tr th,
@@ -464,8 +466,7 @@ h6 strong {
 }
 
 .center {
-  margin-left: auto;
-  margin-right: auto;
+  margin-inline: auto;
 }
 
 .stretch {
@@ -544,11 +545,11 @@ kbd {
 }
 
 .keyseq kbd:first-child {
-  margin-left: 0;
+  margin-inline-start: 0;
 }
 
 .keyseq kbd:last-child {
-  margin-right: 0;
+  margin-inline-end: 0;
 }
 
 .menuseq,
@@ -585,12 +586,12 @@ b.button::after {
 
 b.button::before {
   content: "[";
-  padding: 0 3px 0 2px;
+  padding-inline: 3px 2px;
 }
 
 b.button::after {
   content: "]";
-  padding: 0 2px 0 3px;
+  padding-inline: 2px 3px;
 }
 
 p a > code:hover {
@@ -601,8 +602,7 @@ body > div[id] {
   margin: 0 auto;
   max-width: 62.5em;
   position: relative;
-  padding-left: 0.9375em;
-  padding-right: 0.9375em;
+  padding-inline: 0.9375em;
   width: 100%;
 }
 
@@ -644,14 +644,14 @@ body > div[id]::after,
   line-height: 1.45;
   padding-top: 0.25em;
   padding-bottom: 0.25em;
-  padding-left: 0.25em;
+  padding-inline-start: 0.25em;
   color: rgb(0 0 0 / 0.6);
   display: flex;
   flex-flow: row wrap;
 }
 
 #header .details span:first-child {
-  margin-left: -0.125em;
+  margin-inline-start: -0.125em;
 }
 
 #header .details span.email a {
@@ -698,7 +698,7 @@ body > div[id]::after,
 }
 
 #toc > ul {
-  margin-left: 0.125em;
+  margin-inline-start: 0.125em;
 }
 
 #toc ul.sectlevel0 > li > a {
@@ -738,8 +738,8 @@ body > div[id]::after,
   }
 
   body.toc2 {
-    padding-left: 15em;
-    padding-right: 0;
+    padding-inline-start: 15em;
+    padding-inline-end: 0;
   }
 
   body.toc2 #header > h1:nth-last-child(2) {
@@ -752,9 +752,9 @@ body > div[id]::after,
     background: #f8f8f7;
     position: fixed;
     width: 15em;
-    left: 0;
+    inset-inline-start: 0;
     top: 0;
-    border-right: 1px solid #e7e7e9;
+    border-inline-end: 1px solid #e7e7e9;
     border-top-width: 0 !important;
     border-bottom-width: 0 !important;
     z-index: 1000;
@@ -775,33 +775,33 @@ body > div[id]::after,
   }
 
   #toc.toc2 ul ul {
-    margin-left: 0;
-    padding-left: 1em;
+    margin-inline-start: 0;
+    padding-inline-start: 1em;
   }
 
   #toc.toc2 ul.sectlevel0 ul.sectlevel1 {
-    padding-left: 0;
+    padding-inline-start: 0;
     margin-top: 0.5em;
     margin-bottom: 0.5em;
   }
 
   body.toc2.toc-right {
-    padding-left: 0;
-    padding-right: 15em;
+    padding-inline-start: 0;
+    padding-inline-end: 15em;
   }
 
   body.toc2.toc-right #toc.toc2 {
-    border-right-width: 0;
-    border-left: 1px solid #e7e7e9;
-    left: auto;
-    right: 0;
+    border-inline-end-width: 0;
+    border-inline-start: 1px solid #e7e7e9;
+    inset-inline-start: auto;
+    inset-inline-end: 0;
   }
 }
 
 @media screen and (min-width: 1280px) {
   body.toc2 {
-    padding-left: 20em;
-    padding-right: 0;
+    padding-inline-start: 20em;
+    padding-inline-end: 0;
   }
 
   #toc.toc2 {
@@ -817,12 +817,12 @@ body > div[id]::after,
   }
 
   #toc.toc2 ul ul {
-    padding-left: 1.25em;
+    padding-inline-start: 1.25em;
   }
 
   body.toc2.toc-right {
-    padding-left: 0;
-    padding-right: 20em;
+    padding-inline-start: 0;
+    padding-inline-end: 20em;
   }
 }
 
@@ -878,7 +878,7 @@ h6 > a.anchor {
   position: absolute;
   z-index: 1001;
   width: 1.5ex;
-  margin-left: -1.5ex;
+  margin-inline-start: -1.5ex;
   display: block;
   text-decoration: none !important;
   visibility: hidden;
@@ -953,7 +953,7 @@ details,
 }
 
 details {
-  margin-left: 1.25rem;
+  margin-inline-start: 1.25rem;
 }
 
 details > summary {
@@ -973,11 +973,11 @@ details > summary::-webkit-details-marker {
 details > summary::before {
   content: "";
   border: solid transparent;
-  border-left-color: currentColor;
+  border-inline-start-color: currentColor;
   border-width: 0.3em 0 0.3em 0.5em;
   position: absolute;
   top: 0.5em;
-  left: -1.25rem;
+  inset-inline-start: -1.25rem;
   transform: translateX(15%);
 }
 
@@ -994,7 +994,7 @@ details > summary::after {
   height: 1em;
   position: absolute;
   top: 0.3em;
-  left: -1.25rem;
+  inset-inline-start: -1.25rem;
 }
 
 .admonitionblock td.content > .title,
@@ -1016,7 +1016,7 @@ table.tableblock > .title,
 .qlist > .title,
 .hdlist > .title {
   text-rendering: optimizeLegibility;
-  text-align: left;
+  text-align: start;
   font-family: "Noto Serif", "DejaVu Serif", serif;
   font-size: 1rem;
   font-style: italic;
@@ -1057,9 +1057,9 @@ table.tableblock.fit-content > caption.title {
 }
 
 .admonitionblock > table td.content {
-  padding-left: 1.125em;
-  padding-right: 1.25em;
-  border-left: 1px solid #dddddf;
+  padding-inline-start: 1.125em;
+  padding-inline-end: 1.25em;
+  border-inline-start: 1px solid #dddddf;
   color: rgb(0 0 0 / 0.6);
   word-wrap: anywhere;
 }
@@ -1159,7 +1159,7 @@ table.tableblock.fit-content > caption.title {
   position: absolute;
   font-size: 0.75em;
   top: 0.425rem;
-  right: 0.5rem;
+  inset-inline-end: 0.5rem;
   line-height: 1;
   text-transform: uppercase;
   color: inherit;
@@ -1172,7 +1172,7 @@ table.tableblock.fit-content > caption.title {
 
 .listingblock.terminal pre .command::before {
   content: attr(data-prompt);
-  padding-right: 0.5em;
+  padding-inline-end: 0.5em;
   color: inherit;
   opacity: 0.5;
 }
@@ -1200,13 +1200,13 @@ table.tableblock.fit-content > caption.title {
 
 pre.prettyprint .linenums {
   line-height: 1.45;
-  margin-left: 2em;
+  margin-inline-start: 2em;
 }
 
 pre.prettyprint li {
   background: none;
   list-style-type: inherit;
-  padding-left: 0;
+  padding-inline-start: 0;
 }
 
 pre.prettyprint li code[data-lang]::before {
@@ -1233,7 +1233,7 @@ table.linenotable td[class] {
 }
 
 table.linenotable td.code {
-  padding-left: 0.75em;
+  padding-inline-start: 0.75em;
 }
 
 table.linenotable td.linenos {
@@ -1243,25 +1243,26 @@ table.linenotable td.linenos {
 table.linenotable td.linenos,
 pre.pygments .linenos,
 pre.rouge .linenos {
-  border-right: 1px solid;
+  border-inline-end: 1px solid;
   opacity: 0.35;
-  padding-right: 0.5em;
+  padding-inline-end: 0.5em;
   user-select: none;
 }
 
 pre.pygments span.linenos,
 pre.rouge span.linenos {
   display: inline-block;
-  margin-right: 0.75em;
+  margin-inline-end: 0.75em;
 }
 
 .quoteblock {
-  margin: 0 1em 1.25em 1.5em;
+  margin-block: 0 1.25em;
+  margin-inline: 1em 1.5em;
   display: table;
 }
 
 .quoteblock:not(.excerpt) > .title {
-  margin-left: -1.5em;
+  margin-inline-start: -1.5em;
   margin-bottom: 0.75em;
 }
 
@@ -1284,13 +1285,17 @@ pre.rouge span.linenos {
 
 .quoteblock blockquote::before {
   content: "\201c";
-  float: left;
+  float: inline-start;
   font-size: 2.75em;
   font-weight: bold;
   line-height: 0.6em;
-  margin-left: -0.6em;
+  margin-inline-start: -0.6em;
   color: #7a2518;
   text-shadow: 0 1px 2px rgb(0 0 0 / 0.1);
+}
+
+.quoteblock blockquote:dir(rtl)::before {
+  content: "\201d";
 }
 
 .quoteblock blockquote > .paragraph:last-child p {
@@ -1299,12 +1304,13 @@ pre.rouge span.linenos {
 
 .quoteblock .attribution {
   margin-top: 0.75em;
-  margin-right: 0.5ex;
-  text-align: right;
+  margin-inline-end: 0.5ex;
+  text-align: end;
 }
 
 .verseblock {
-  margin: 0 1em 1.25em;
+  margin-block: 0 1.25em;
+  margin-inline: 1em;
 }
 
 .verseblock pre {
@@ -1321,7 +1327,7 @@ pre.rouge span.linenos {
 
 .verseblock .attribution {
   margin-top: 1.25rem;
-  margin-left: 0.5ex;
+  margin-inline-start: 0.5ex;
 }
 
 .quoteblock .attribution,
@@ -1360,25 +1366,27 @@ pre.rouge span.linenos {
 }
 
 .quoteblock.abstract {
-  margin: 0 1em 1.25em;
+  margin-block: 0 1.25em;
+  margin-inline: 1em;
   display: block;
 }
 
 .quoteblock.abstract > .title {
-  margin: 0 0 0.375em;
+  margin-block: 0 0.375em;
   font-size: 1.15em;
   text-align: center;
 }
 
 .quoteblock.excerpt > blockquote,
 .quoteblock .quoteblock {
-  padding: 0 0 0.25em 1em;
-  border-left: 0.25em solid #dddddf;
+  padding-block: 0 0.25em;
+  padding-inline: 0 1em;
+  border-inline-start: 0.25em solid #dddddf;
 }
 
 .quoteblock.excerpt,
 .quoteblock .quoteblock {
-  margin-left: 0;
+  margin-inline-start: 0;
 }
 
 .quoteblock.excerpt blockquote,
@@ -1393,8 +1401,8 @@ pre.rouge span.linenos {
 .quoteblock .quoteblock .attribution {
   color: inherit;
   font-size: 0.85rem;
-  text-align: left;
-  margin-right: 0;
+  text-align: start;
+  margin-inline-end: 0;
 }
 
 p.tableblock:last-child {
@@ -1452,12 +1460,12 @@ table.frame-sides > :last-child > :last-child > * {
 
 table.frame-none > * > tr > :first-child,
 table.frame-ends > * > tr > :first-child {
-  border-left-width: 0;
+  border-inline-start-width: 0;
 }
 
 table.frame-none > * > tr > :last-child,
 table.frame-ends > * > tr > :last-child {
-  border-right-width: 0;
+  border-inline-end-width: 0;
 }
 
 table.stripes-all > * > tr,
@@ -1469,12 +1477,12 @@ table.stripes-hover > * > tr:hover {
 
 th.halign-left,
 td.halign-left {
-  text-align: left;
+  text-align: start;
 }
 
 th.halign-right,
 td.halign-right {
-  text-align: right;
+  text-align: end;
 }
 
 th.halign-center,
@@ -1524,11 +1532,11 @@ p.tableblock {
 }
 
 ol {
-  margin-left: 1.75em;
+  margin-inline-start: 1.75em;
 }
 
 ul li ol {
-  margin-left: 1.5em;
+  margin-inline-start: 1.5em;
 }
 
 dl dd:last-child,
@@ -1560,12 +1568,12 @@ ol.unstyled {
 ul.no-bullet,
 ol.no-bullet,
 ol.unnumbered {
-  margin-left: 0.625em;
+  margin-inline-start: 0.625em;
 }
 
 ul.unstyled,
 ol.unstyled {
-  margin-left: 0;
+  margin-inline-start: 0;
 }
 
 li > p:empty:only-child::before {
@@ -1574,7 +1582,7 @@ li > p:empty:only-child::before {
 }
 
 ul.checklist > li > p:first-child {
-  margin-left: -1em;
+  margin-inline-start: -1em;
 }
 
 ul.checklist > li > p:first-child > .fa-square-o:first-child,
@@ -1587,7 +1595,8 @@ ul.checklist > li > p:first-child > .fa-check-square-o:first-child {
 
 ul.checklist > li > p:first-child > input[type=checkbox]:first-child {
   font: inherit;
-  margin: 0 0.25em 0 0;
+  margin-block: 0;
+  margin-inline: 0.25em 0;
   padding: 0;
 }
 
@@ -1595,11 +1604,12 @@ ul.inline {
   display: flex;
   flex-flow: row wrap;
   list-style: none;
-  margin: 0 0 0.625em -1.25em;
+  margin-block: 0 0.625em;
+  margin-inline: 0 -1.25em;
 }
 
 ul.inline > li {
-  margin-left: 1.25em;
+  margin-inline-start: 1.25em;
 }
 
 .unstyled dl dt {
@@ -1667,7 +1677,8 @@ td.hdlist2 {
 }
 
 .colist td:not([class]):first-child {
-  padding: 0.4em 0.75em 0;
+  padding-block: 0.4em 0;
+  padding-inline: 0.75em;
   line-height: 1;
   vertical-align: top;
 }
@@ -1689,11 +1700,13 @@ td.hdlist2 {
 }
 
 .imageblock.left {
-  margin: 0.25em 0.625em 1.25em 0;
+  margin-block: 0.25em 1.25em;
+  margin-inline: 0.625em 0;
 }
 
 .imageblock.right {
-  margin: 0.25em 0 1.25em 0.625em;
+  margin-block: 0.25em 1.25em;
+  margin-inline: 0 0.625em;
 }
 
 .imageblock > .title {
@@ -1719,11 +1732,11 @@ td.hdlist2 {
 }
 
 .image.left {
-  margin-right: 0.625em;
+  margin-inline-end: 0.625em;
 }
 
 .image.right {
-  margin-left: 0.625em;
+  margin-inline-start: 0.625em;
 }
 
 a.image {
@@ -1762,22 +1775,22 @@ sup.footnoteref a:active,
 #footnotes hr {
   width: 20%;
   min-width: 6.25em;
-  margin: -0.25em 0 0.75em;
+  margin-block: -0.25em 0.75em;
   border-width: 1px 0 0;
 }
 
 #footnotes .footnote {
-  padding: 0 0.375em 0 0.225em;
+  padding-inline: 0.375em 0.225em;
   line-height: 1.3334;
   font-size: 0.875em;
-  margin-left: 1.2em;
+  margin-inline-start: 1.2em;
   margin-bottom: 0.2em;
 }
 
 #footnotes .footnote a:first-of-type {
   font-weight: bold;
   text-decoration: none;
-  margin-left: -1.05em;
+  margin-inline-start: -1.05em;
 }
 
 #footnotes .footnote:last-of-type {
@@ -2099,7 +2112,7 @@ p.tableblock {
     content: "(" attr(href) ")";
     display: inline-block;
     font-size: 0.875em;
-    padding-left: 0.25em;
+    padding-inline-start: 0.25em;
   }
 
   abbr[title] {
@@ -2160,7 +2173,7 @@ p.tableblock {
 
   body.book #header > h1:first-child {
     border: 0 !important;
-    margin: 2.5em 0 1em;
+    margin-block: 2.5em 1em;
   }
 
   body.book #header .details {
@@ -2170,7 +2183,7 @@ p.tableblock {
   }
 
   body.book #header .details span:first-child {
-    margin-left: 0 !important;
+    margin-inline-start: 0 !important;
   }
 
   body.book #header .details br {
@@ -2183,7 +2196,7 @@ p.tableblock {
 
   body.book #toc {
     border: 0 !important;
-    text-align: left !important;
+    text-align: start !important;
     padding: 0 !important;
     margin: 0 !important;
   }


### PR DESCRIPTION
Replace physical CSS (left/right) properties with logical (inline-start/inline-end etc) to support RTL languages.

See https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_logical_properties_and_values for an explanation of these properties. 

With this CSS there's no change for an English page, but an Arabic or Hebrew page only needs `<html dir="rtl">` for the page to flow as expected, TOC shown on the right, admonition icons are on the right, etc.

I haven't added any language-specific adjustments, like the numerals used for ordered lists, since that would also vary for LTR languages (`list-style-type: georgan` or `thai` for example).

For issue #1601 
