### PR TITLE
resolves #3743 add support aspect-ratio to the video macro

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -36,6 +36,7 @@ Enhancements::
   * Set logdev to $stderr if no arguments are passed to Logger constructor (#4250)
   * Add support for skipping TOML front matter (Hugo) when `skip-front-matter` attribute is set (#4300) (*@abhinav*)
   * Add support for Wistia using the video macro
+	* Add support for aspect-ratio to the video macro (#3743)
 
 Compliance::
 

--- a/lib/asciidoctor/converter/html5.rb
+++ b/lib/asciidoctor/converter/html5.rb
@@ -1033,7 +1033,9 @@ Your browser does not support the audio tag.
     title_element = node.title? ? %(\n<div class="title">#{node.title}</div>) : ''
     width_attribute = (node.attr? 'width') ? %( width="#{node.attr 'width'}") : ''
     height_attribute = (node.attr? 'height') ? %( height="#{node.attr 'height'}") : ''
-		aspect_ratio_attribute = (node.attr? 'aspect-ratio') ? %( style=aspect-ratio:#{node.attr 'aspect-ratio'} ) : ''
+		iframe_styles = []
+		iframe_styles << %(aspect-ratio:#{node.attr 'aspect-ratio'}) if node.attr? 'aspect-ratio'
+		iframe_style_attribute = iframe_styles.empty? ? "" : %(style="#{iframe_styles.join '; '};")
     case node.attr 'poster'
     when 'vimeo'
       unless (asset_uri_scheme = node.document.attr 'asset-uri-scheme', 'https').empty?
@@ -1048,7 +1050,7 @@ Your browser does not support the audio tag.
       muted_param = (node.option? 'muted') ? %(#{delimiter.pop || '&amp;'}muted=1) : ''
       %(<div#{id_attribute}#{class_attribute}>#{title_element}
 <div class="content">
-<iframe#{width_attribute}#{height_attribute} #{aspect_ratio_attribute} src="#{asset_uri_scheme}//player.vimeo.com/video/#{target}#{hash_param}#{autoplay_param}#{loop_param}#{muted_param}#{start_anchor}" frameborder="0"#{(node.option? 'nofullscreen') ? '' : (append_boolean_attribute 'allowfullscreen', xml)}></iframe>
+<iframe#{width_attribute}#{height_attribute} #{iframe_style_attribute} src="#{asset_uri_scheme}//player.vimeo.com/video/#{target}#{hash_param}#{autoplay_param}#{loop_param}#{muted_param}#{start_anchor}" frameborder="0"#{(node.option? 'nofullscreen') ? '' : (append_boolean_attribute 'allowfullscreen', xml)}></iframe>
 </div>
 </div>)
     when 'youtube'
@@ -1093,7 +1095,7 @@ Your browser does not support the audio tag.
 
       %(<div#{id_attribute}#{class_attribute}>#{title_element}
 <div class="content">
-<iframe#{width_attribute}#{height_attribute} #{aspect_ratio_attribute} src="#{asset_uri_scheme}//www.youtube.com/embed/#{target}?rel=#{rel_param_val}#{start_param}#{end_param}#{autoplay_param}#{loop_param}#{mute_param}#{controls_param}#{list_param}#{fs_param}#{modest_param}#{theme_param}#{hl_param}" frameborder="0"#{fs_attribute}></iframe>
+<iframe#{width_attribute}#{height_attribute} #{iframe_style_attribute} src="#{asset_uri_scheme}//www.youtube.com/embed/#{target}?rel=#{rel_param_val}#{start_param}#{end_param}#{autoplay_param}#{loop_param}#{mute_param}#{controls_param}#{list_param}#{fs_param}#{modest_param}#{theme_param}#{hl_param}" frameborder="0"#{fs_attribute}></iframe>
 </div>
 </div>)
     when 'wistia'

--- a/lib/asciidoctor/converter/html5.rb
+++ b/lib/asciidoctor/converter/html5.rb
@@ -1110,7 +1110,7 @@ Your browser does not support the audio tag.
       muted_param = (node.option? 'muted') ? %(#{delimiter.pop || '&amp;'}muted=true) : ''
       %(<div#{id_attribute}#{class_attribute}>#{title_element}
 <div class="content">
-<iframe#{width_attribute}#{height_attribute} src="#{asset_uri_scheme}//fast.wistia.com/embed/iframe/#{target}#{start_anchor}#{autoplay_param}#{end_video_behavior_param}#{muted_param}" frameborder="0"#{(node.option? 'nofullscreen') ? '' : (append_boolean_attribute 'allowfullscreen', xml)} class="wistia_embed" name="wistia_embed"></iframe>
+<iframe#{width_attribute}#{height_attribute} #{iframe_style_attribute} src="#{asset_uri_scheme}//fast.wistia.com/embed/iframe/#{target}#{start_anchor}#{autoplay_param}#{end_video_behavior_param}#{muted_param}" frameborder="0"#{(node.option? 'nofullscreen') ? '' : (append_boolean_attribute 'allowfullscreen', xml)} class="wistia_embed" name="wistia_embed"></iframe>
 </div>
 </div>)
     else

--- a/lib/asciidoctor/converter/html5.rb
+++ b/lib/asciidoctor/converter/html5.rb
@@ -1048,7 +1048,7 @@ Your browser does not support the audio tag.
       muted_param = (node.option? 'muted') ? %(#{delimiter.pop || '&amp;'}muted=1) : ''
       %(<div#{id_attribute}#{class_attribute}>#{title_element}
 <div class="content">
-<iframe#{width_attribute}#{height_attribute} src="#{asset_uri_scheme}//player.vimeo.com/video/#{target}#{hash_param}#{autoplay_param}#{loop_param}#{muted_param}#{start_anchor}" frameborder="0"#{(node.option? 'nofullscreen') ? '' : (append_boolean_attribute 'allowfullscreen', xml)}></iframe>
+<iframe#{width_attribute}#{height_attribute} #{aspect_ratio_attribute} src="#{asset_uri_scheme}//player.vimeo.com/video/#{target}#{hash_param}#{autoplay_param}#{loop_param}#{muted_param}#{start_anchor}" frameborder="0"#{(node.option? 'nofullscreen') ? '' : (append_boolean_attribute 'allowfullscreen', xml)}></iframe>
 </div>
 </div>)
     when 'youtube'

--- a/lib/asciidoctor/converter/html5.rb
+++ b/lib/asciidoctor/converter/html5.rb
@@ -1033,9 +1033,11 @@ Your browser does not support the audio tag.
     title_element = node.title? ? %(\n<div class="title">#{node.title}</div>) : ''
     width_attribute = (node.attr? 'width') ? %( width="#{node.attr 'width'}") : ''
     height_attribute = (node.attr? 'height') ? %( height="#{node.attr 'height'}") : ''
-		iframe_styles = []
-		iframe_styles << %(aspect-ratio:#{node.attr 'aspect-ratio'}) if node.attr? 'aspect-ratio'
-		iframe_style_attribute = iframe_styles.empty? ? "" : %(style="#{iframe_styles.join '; '};")
+		aspect_ratio_attribute = (node.attr? 'aspect-ratio') ? %(aspect-ratio:#{node.attr 'aspect-ratio'}) : ''
+		extra_styles = []
+		extra_styles << aspect_ratio_attribute if !aspect_ratio_attribute.empty?
+		extra_styles_attribute = extra_styles.empty? ? "" : %(style="#{extra_styles.join '; '};")
+
     case node.attr 'poster'
     when 'vimeo'
       unless (asset_uri_scheme = node.document.attr 'asset-uri-scheme', 'https').empty?
@@ -1050,7 +1052,7 @@ Your browser does not support the audio tag.
       muted_param = (node.option? 'muted') ? %(#{delimiter.pop || '&amp;'}muted=1) : ''
       %(<div#{id_attribute}#{class_attribute}>#{title_element}
 <div class="content">
-<iframe#{width_attribute}#{height_attribute} #{iframe_style_attribute} src="#{asset_uri_scheme}//player.vimeo.com/video/#{target}#{hash_param}#{autoplay_param}#{loop_param}#{muted_param}#{start_anchor}" frameborder="0"#{(node.option? 'nofullscreen') ? '' : (append_boolean_attribute 'allowfullscreen', xml)}></iframe>
+<iframe#{width_attribute}#{height_attribute} #{extra_styles_attribute} src="#{asset_uri_scheme}//player.vimeo.com/video/#{target}#{hash_param}#{autoplay_param}#{loop_param}#{muted_param}#{start_anchor}" frameborder="0"#{(node.option? 'nofullscreen') ? '' : (append_boolean_attribute 'allowfullscreen', xml)}></iframe>
 </div>
 </div>)
     when 'youtube'
@@ -1095,7 +1097,7 @@ Your browser does not support the audio tag.
 
       %(<div#{id_attribute}#{class_attribute}>#{title_element}
 <div class="content">
-<iframe#{width_attribute}#{height_attribute} #{iframe_style_attribute} src="#{asset_uri_scheme}//www.youtube.com/embed/#{target}?rel=#{rel_param_val}#{start_param}#{end_param}#{autoplay_param}#{loop_param}#{mute_param}#{controls_param}#{list_param}#{fs_param}#{modest_param}#{theme_param}#{hl_param}" frameborder="0"#{fs_attribute}></iframe>
+<iframe#{width_attribute}#{height_attribute} #{extra_styles_attribute} src="#{asset_uri_scheme}//www.youtube.com/embed/#{target}?rel=#{rel_param_val}#{start_param}#{end_param}#{autoplay_param}#{loop_param}#{mute_param}#{controls_param}#{list_param}#{fs_param}#{modest_param}#{theme_param}#{hl_param}" frameborder="0"#{fs_attribute}></iframe>
 </div>
 </div>)
     when 'wistia'
@@ -1110,7 +1112,7 @@ Your browser does not support the audio tag.
       muted_param = (node.option? 'muted') ? %(#{delimiter.pop || '&amp;'}muted=true) : ''
       %(<div#{id_attribute}#{class_attribute}>#{title_element}
 <div class="content">
-<iframe#{width_attribute}#{height_attribute} #{iframe_style_attribute} src="#{asset_uri_scheme}//fast.wistia.com/embed/iframe/#{target}#{start_anchor}#{autoplay_param}#{end_video_behavior_param}#{muted_param}" frameborder="0"#{(node.option? 'nofullscreen') ? '' : (append_boolean_attribute 'allowfullscreen', xml)} class="wistia_embed" name="wistia_embed"></iframe>
+<iframe#{width_attribute}#{height_attribute} #{extra_styles_attribute} src="#{asset_uri_scheme}//fast.wistia.com/embed/iframe/#{target}#{start_anchor}#{autoplay_param}#{end_video_behavior_param}#{muted_param}" frameborder="0"#{(node.option? 'nofullscreen') ? '' : (append_boolean_attribute 'allowfullscreen', xml)} class="wistia_embed" name="wistia_embed"></iframe>
 </div>
 </div>)
     else
@@ -1121,7 +1123,7 @@ Your browser does not support the audio tag.
       time_anchor = (start_t || end_t) ? %(#t=#{start_t || ''}#{end_t ? ",#{end_t}" : ''}) : ''
       %(<div#{id_attribute}#{class_attribute}>#{title_element}
 <div class="content">
-<video src="#{node.media_uri node.attr 'target'}#{time_anchor}"#{width_attribute}#{height_attribute}#{poster_attribute}#{(node.option? 'autoplay') ? (append_boolean_attribute 'autoplay', xml) : ''}#{(node.option? 'muted') ? (append_boolean_attribute 'muted', xml) : ''}#{(node.option? 'nocontrols') ? '' : (append_boolean_attribute 'controls', xml)}#{(node.option? 'loop') ? (append_boolean_attribute 'loop', xml) : ''}#{preload_attribute}>
+<video src="#{node.media_uri node.attr 'target'}#{time_anchor}"#{width_attribute}#{height_attribute}#{extra_styles_attribute}#{poster_attribute}#{(node.option? 'autoplay') ? (append_boolean_attribute 'autoplay', xml) : ''}#{(node.option? 'muted') ? (append_boolean_attribute 'muted', xml) : ''}#{(node.option? 'nocontrols') ? '' : (append_boolean_attribute 'controls', xml)}#{(node.option? 'loop') ? (append_boolean_attribute 'loop', xml) : ''}#{preload_attribute}>
 Your browser does not support the video tag.
 </video>
 </div>

--- a/lib/asciidoctor/converter/html5.rb
+++ b/lib/asciidoctor/converter/html5.rb
@@ -1033,6 +1033,7 @@ Your browser does not support the audio tag.
     title_element = node.title? ? %(\n<div class="title">#{node.title}</div>) : ''
     width_attribute = (node.attr? 'width') ? %( width="#{node.attr 'width'}") : ''
     height_attribute = (node.attr? 'height') ? %( height="#{node.attr 'height'}") : ''
+		aspect_ratio_attribute = (node.attr? 'aspect-ratio') ? %( style=aspect-ratio:#{node.attr 'aspect-ratio'} ) : ''
     case node.attr 'poster'
     when 'vimeo'
       unless (asset_uri_scheme = node.document.attr 'asset-uri-scheme', 'https').empty?
@@ -1092,7 +1093,7 @@ Your browser does not support the audio tag.
 
       %(<div#{id_attribute}#{class_attribute}>#{title_element}
 <div class="content">
-<iframe#{width_attribute}#{height_attribute} src="#{asset_uri_scheme}//www.youtube.com/embed/#{target}?rel=#{rel_param_val}#{start_param}#{end_param}#{autoplay_param}#{loop_param}#{mute_param}#{controls_param}#{list_param}#{fs_param}#{modest_param}#{theme_param}#{hl_param}" frameborder="0"#{fs_attribute}></iframe>
+<iframe#{width_attribute}#{height_attribute} #{aspect_ratio_attribute} src="#{asset_uri_scheme}//www.youtube.com/embed/#{target}?rel=#{rel_param_val}#{start_param}#{end_param}#{autoplay_param}#{loop_param}#{mute_param}#{controls_param}#{list_param}#{fs_param}#{modest_param}#{theme_param}#{hl_param}" frameborder="0"#{fs_attribute}></iframe>
 </div>
 </div>)
     when 'wistia'

--- a/lib/asciidoctor/parser.rb
+++ b/lib/asciidoctor/parser.rb
@@ -603,7 +603,7 @@ class Parser
               if blk_attrs
                 case blk_ctx
                 when :video
-                  posattrs = %w(poster width height)
+                  posattrs = %w(poster width height aspect-ratio)
                 when :audio
                   posattrs = []
                 else # :image

--- a/test/blocks_test.rb
+++ b/test/blocks_test.rb
@@ -3151,6 +3151,20 @@ context 'Blocks' do
       assert_css '.videoblock.text-center', output, 1
     end
 
+		test 'video macro shuold set aspect-ratio style for video tag if aspect-ratio attribute is set' do
+      input = 'video::cats-vs-dogs.avi[aspect-ratio=16/9]'
+      output = convert_string_to_embedded input
+      assert_css 'video', output, 1
+      assert_css 'video[style="aspect-ratio:16/9;"]', output, 1
+		end
+
+		test 'video macro shuold not set aspect-ratio style for video tag if aspect-ratio is not set' do
+      input = 'video::cats-vs-dogs.avi[]'
+      output = convert_string_to_embedded input
+      assert_css 'video', output, 1
+      assert_css 'video[style="aspect-ratio:16/9;"]', output, 0
+		end
+
     test 'video macro should honor all options' do
       input = 'video::cats-vs-dogs.avi[options="autoplay,muted,nocontrols,loop",preload="metadata"]'
       output = convert_string_to_embedded input
@@ -3240,6 +3254,22 @@ context 'Blocks' do
       assert_css 'iframe[height="300"]', output, 1
     end
 
+    test 'video macro should set aspect-ratio in custom HTML with iframe for vimeo service if aspect-ratio attribute is set' do
+      input = 'video::67480300[vimeo, aspect-ratio=16/9]'
+      output = convert_string_to_embedded input
+      assert_css 'video', output, 0
+      assert_css 'iframe', output, 1
+      assert_css 'iframe[style="aspect-ratio:16/9;"]', output, 1
+    end
+
+    test 'video macro should not set aspect-ratio in custom HTML with iframe for vimeo service if aspect-ratio attribute is not set' do
+      input = 'video::67480300[vimeo]'
+      output = convert_string_to_embedded input
+      assert_css 'video', output, 0
+      assert_css 'iframe', output, 1
+      assert_css 'iframe[style="aspect-ratio:16/9;"]', output, 0
+    end
+
     test 'video macro should output custom HTML with iframe for youtube service' do
       input = 'video::U8GBXvdmHT4/PLg7s6cbtAD15Das5LK9mXt_g59DLWxKUe[youtube, 640, 360, start=60, options="autoplay,muted,modest", theme=light]'
       output = convert_string_to_embedded input
@@ -3260,6 +3290,22 @@ context 'Blocks' do
       assert_css 'iframe[height="360"]', output, 1
     end
 
+    test 'video macro should set aspect-ratio in custom HTML with iframe for youtube service if aspect-ratio attribute is set' do
+      input = 'video::U8GBXvdmHT4/PLg7s6cbtAD15Das5LK9mXt_g59DLWxKUe[youtube, aspect-ratio=16/9]'
+      output = convert_string_to_embedded input
+      assert_css 'video', output, 0
+      assert_css 'iframe', output, 1
+      assert_css 'iframe[style="aspect-ratio:16/9;"]', output, 1
+    end
+
+    test 'video macro should not set aspect-ratio in custom HTML with iframe for youtube service if aspect-ratio attribute is not set' do
+      input = 'video::U8GBXvdmHT4/PLg7s6cbtAD15Das5LK9mXt_g59DLWxKUe[youtube]'
+      output = convert_string_to_embedded input
+      assert_css 'video', output, 0
+      assert_css 'iframe', output, 1
+      assert_css 'iframe[style="aspect-ratio:16/9;"]', output, 0
+    end
+
     test 'video macro should output custom HTML with iframe for wistia service' do
       input = 'video::be5gtsbaco[wistia,640,360,start=60,options="autoplay,loop,muted"]'
       output = convert_string_to_embedded input
@@ -3278,6 +3324,22 @@ context 'Blocks' do
       assert_css 'iframe[src="https://fast.wistia.com/embed/iframe/be5gtsbaco?time=60&autoPlay=true&endVideoBehavior=reset&muted=true"]', output, 1
       assert_css 'iframe[width="640"]', output, 1
       assert_css 'iframe[height="360"]', output, 1
+    end
+
+    test 'video macro should set aspect-ratio in custom HTML with iframe for wistia service if aspect-ratio attribute is set' do
+      input = 'video::be5gtsbaco[wistia, aspect-ratio=16/9]'
+      output = convert_string_to_embedded input
+      assert_css 'video', output, 0
+      assert_css 'iframe', output, 1
+      assert_css 'iframe[style="aspect-ratio:16/9;"]', output, 1
+    end
+
+    test 'video macro should not set aspect-ratio in custom HTML with iframe for wistia service if aspect-ratio attribute is not set' do
+      input = 'video::be5gtsbaco[wistia]'
+      output = convert_string_to_embedded input
+      assert_css 'video', output, 0
+      assert_css 'iframe', output, 1
+      assert_css 'iframe[style="aspect-ratio:16/9;"]', output, 0
     end
 
     test 'should detect and convert audio macro' do


### PR DESCRIPTION
This PR adds support for the aspect-ratio attribute to the video macro (resolves #3743).

The following four patterns of the video macro are modified to support aspect-ratio:
1. Regular video macro
2. Video macro for YouTube
3. Video macro for Vimeo
4. Video macro for Wistia

Additionally, test cases are added to check whether the aspect-ratio attribute exists or not for each of the four patterns:
1. Regular video macro
2. Video macro for YouTube
3. Video macro for Vimeo
4. Video macro for Wistia

Please review. Thank you!