### PR TITLE
Fix table issues in text converter example

### DIFF
--- a/docs/modules/convert/examples/text-converter.rb
+++ b/docs/modules/convert/examples/text-converter.rb
@@ -24,13 +24,25 @@ class TextConverter
           (dd&.blocks? ? ?\n + dd.content : '')
       end.join(?\n)
     when 'table'
-      ?\n + node.rows.th_h.map do |_, rows|
-        rows.each do |cells|
-          cell.each do |cell|
-            cell.content
-          end
-        end
-      end.join(?\n)
+      ?\n + node.rows.to_h.map do |tsec, rows|
+        rows.map do |row|
+          row.map do |cell|
+            if tsec == :head
+              cell.text
+            else
+              case cell.style
+              when :asciidoc
+                cell.content
+              when :literal
+                cell.text
+              else
+                # In this case it is an array of paragraphs.
+                cell.content.join ?\n
+              end
+            end
+          end.join ?|
+        end.join ?\n
+      end.join "\n===\n"
     else
       transform.start_with?('inline_') ? node.text : [?\n, node.content].compact.join
     end


### PR DESCRIPTION
This fixes a number of issues for the table node in the `text-converter.rb` example:

1. Typo of `th_h` - should be `to_h`.
2. Typo of `cells`/`cell`.
3. `cell.content` is not always text. I took the fix from the HTML5 output.
4. The loops were `each` but they should have been `map` with `.join`. This was especially confusing because you somehow still get a string output but it's the debug string for the Cell object.

Does Ruby have some kind of static type hint system? All of these issues would have been caught by it if it exists.