### PR TITLE
Add the logger Gem dependency for Ruby 4.0

### DIFF
--- a/asciidoctor.gemspec
+++ b/asciidoctor.gemspec
@@ -34,6 +34,8 @@ Gem::Specification.new do |s|
   s.require_paths = ['lib']
   #s.test_files = files.grep %r/^(?:features|test)\/.+$/
 
+  s.add_dependency 'logger'
+
   # concurrent-ruby, haml, slim, and tilt are needed for testing custom templates
   s.add_development_dependency 'concurrent-ruby', '~> 1.3.0'
   s.add_development_dependency 'cucumber', '~> 9.2.0'


### PR DESCRIPTION
In Ruby 4.0, logger became a bundled gem, so please add it to dependencies and install it together.

I'm submitting an example change in this PR.

logger became a bundled gem in Ruby 4.0: https://www.ruby-lang.org/en/news/2025/12/25/ruby-4-0-0-released/#stdlib-updates

