### PR TITLE
use tocreftex or reftext in table of contents, resolves #4142

### DIFF
--- a/lib/asciidoctor/converter/html5.rb
+++ b/lib/asciidoctor/converter/html5.rb
@@ -357,22 +357,22 @@ MathJax.Hub.Register.StartupHook("AsciiMath Jax Ready", function () {
       if (slevel = section.level) > (stoclevels = (section.attr? 'toclevels') ? (section.attr 'toclevels').to_i : toclevels)
         next
       elsif section.caption
-        stitle = section.captioned_title
+        stitle = section.captioned_toc_title
       elsif section.numbered && slevel <= sectnumlevels
         if slevel < 2 && node.document.doctype == 'book'
           case section.sectname
           when 'chapter'
-            stitle =  %(#{(signifier = node.document.attributes['chapter-signifier']) ? "#{signifier} " : ''}#{section.sectnum} #{section.title})
+            stitle =  %(#{(signifier = node.document.attributes['chapter-signifier']) ? "#{signifier} " : ''}#{section.sectnum} #{section.toc_title})
           when 'part'
-            stitle =  %(#{(signifier = node.document.attributes['part-signifier']) ? "#{signifier} " : ''}#{section.sectnum nil, ':'} #{section.title})
+            stitle =  %(#{(signifier = node.document.attributes['part-signifier']) ? "#{signifier} " : ''}#{section.sectnum nil, ':'} #{section.toc_title})
           else
-            stitle = %(#{section.sectnum} #{section.title})
+            stitle = %(#{section.sectnum} #{section.toc_title})
           end
         else
-          stitle = %(#{section.sectnum} #{section.title})
+          stitle = %(#{section.sectnum} #{section.toc_title})
         end
       else
-        stitle = section.title
+        stitle = section.toc_title
       end
       stitle = stitle.gsub DropAnchorRx, '' if stitle.include? '<a'
       otag = slevel == sectlevel ? '<li>' : %(<li class="sectlevel#{slevel}">)

--- a/lib/asciidoctor/section.rb
+++ b/lib/asciidoctor/section.rb
@@ -156,6 +156,37 @@ class Section < AbstractBlock
     end
   end
 
+  # Public: A convenience method that returns the value of the tocreftext
+  # attribute with title substitutions applied.
+  def tocreftext
+    (val = @attributes['tocreftext']) ? (apply_title_subs val) : nil
+  end
+
+  # Public: Returns the title to be used in the table of contents.
+  #
+  # Use 'tocreftext' if defined. Fall back to 'reftext' if {toc-use-reftext} is set.
+  # Fall back to the title otherwise.
+  #
+  # @return [String] The title for the TOC.
+  def toc_title
+    if tocreftext
+      tocreftext
+    elsif @document.attr?('toc-use-reftext') && reftext?
+      apply_title_subs @attributes['reftext']
+    else
+      title
+    end
+  end
+
+  # Public: Returns the captioned title to be used in the table of contents.
+  #
+  # See AbstractBlock#captioned_title for details.
+  #
+  # @return [String] The captioned title for the TOC.
+  def captioned_toc_title
+    %(#{@caption}#{toc_title})
+  end
+
   # Public: Append a content block to this block's list of blocks.
   #
   # If the child block is a Section, assign an index to it.

--- a/test/sections_test.rb
+++ b/test/sections_test.rb
@@ -3093,6 +3093,154 @@ context 'Sections' do
       assert_xpath '//*[@id="header"]//*[@id="toc"]/ul/li[1]/a[@href="#_section_one"][text()="1. Section One"]', output, 1
     end
 
+    test 'should not use reftext in table of contents by default' do
+      input = <<~'EOS'
+      = Article
+      :toc:
+
+      [reftext="Section One"]
+      == Long Section One
+      EOS
+
+      output = convert_string input
+      assert_xpath '//*[@id="toc"]//a[@href="#_long_section_one"][text()="Long Section One"]', output, 1
+      assert_xpath '//h2[@id="_long_section_one"][text()="Long Section One"]', output, 1
+    end
+
+    test 'should use reftext in table of contents if toc-use-reftext is set' do
+      input = <<~'EOS'
+      = Article
+      :toc:
+      :toc-use-reftext:
+
+      [reftext="Section One"]
+      == Long Section One
+      EOS
+
+      output = convert_string input
+      assert_xpath '//*[@id="toc"]//a[@href="#_long_section_one"][text()="Section One"]', output, 1
+      assert_xpath '//h2[@id="_long_section_one"][text()="Long Section One"]', output, 1
+    end
+
+    test 'should use reftext in table of contents if toc-use-reftext and numbered is set' do
+      input = <<~'EOS'
+      = Article
+      :toc:
+      :toc-use-reftext:
+      :numbered:
+
+      [reftext="Section One"]
+      == Long Section One
+      EOS
+
+      output = convert_string input
+      assert_xpath '//*[@id="toc"]//a[@href="#_long_section_one"][text()="1. Section One"]', output, 1
+      assert_xpath '//h2[@id="_long_section_one"][text()="1. Long Section One"]', output, 1
+    end
+
+    test 'should use tocreftext in table of contents when available' do
+      input = <<~'EOS'
+      = Article
+      :toc:
+
+      [tocreftext="Section One"]
+      == Long Section One
+      EOS
+
+      output = convert_string input
+      assert_xpath '//*[@id="toc"]//a[@href="#_long_section_one"][text()="Section One"]', output, 1
+      assert_xpath '//h2[@id="_long_section_one"][text()="Long Section One"]', output, 1
+    end
+
+    test 'should use tocreftext in table of contents when numbered' do
+      input = <<~'EOS'
+      = Article
+      :toc:
+      :numbered:
+
+      [tocreftext="Section One"]
+      == Long Section One
+      EOS
+
+      output = convert_string input
+      assert_xpath '//*[@id="toc"]//a[@href="#_long_section_one"][text()="1. Section One"]', output, 1
+      assert_xpath '//h2[@id="_long_section_one"][text()="1. Long Section One"]', output, 1
+    end
+
+    test 'should use tocreftext over reftext even if toc-use-reftext is set' do
+      input = <<~'EOS'
+      = Article
+      :toc:
+      :toc-use-reftext:
+
+      [reftext="Reftext", reftext="Section One"]
+      == Long Section One
+      EOS
+
+      output = convert_string input
+      assert_xpath '//*[@id="toc"]//a[@href="#_long_section_one"][text()="Section One"]', output, 1
+      assert_xpath '//h2[@id="_long_section_one"][text()="Long Section One"]', output, 1
+    end
+
+    test 'should use reftext in table of contents on special sections if toc-use-reftext is set' do
+      input = <<~'EOS'
+      = Book
+      :doctype: book
+      :part-signifier: PS
+      :chapter-signifier: CS
+      :partnums:
+      :sectnums:
+      :toc:
+      :toc-use-reftext:
+
+      [reftext="Part"]
+      = Long Part
+
+      [reftext="Chapter"]
+      == Long Chapter
+
+      [appendix, reftext="Appendix"]
+      == Long Appendix
+      EOS
+
+      output = convert_string input
+      assert_xpath '//*[@id="toc"]//a[@href="#_long_part"][text()="PS I: Part"]', output, 1
+      assert_xpath '//*[@id="toc"]//a[@href="#_long_chapter"][text()="CS 1. Chapter"]', output, 1
+      assert_xpath '//*[@id="toc"]//a[@href="#_long_appendix"][text()="Appendix A: Appendix"]', output, 1
+      assert_xpath '//h1[text()="PS I: Long Part"]', output, 1
+      assert_xpath '//h2[text()="CS 1. Long Chapter"]', output, 1
+      assert_xpath '//h2[text()="Appendix A: Long Appendix"]', output, 1
+    end
+
+    test 'should use tocreftext in table of contents on special sections' do
+      input = <<~'EOS'
+      = Book
+      :doctype: book
+      :part-signifier: PS
+      :chapter-signifier: CS
+      :partnums:
+      :sectnums:
+      :toc:
+
+      [tocreftext="Part"]
+      = Long Part
+
+      [tocreftext="Chapter"]
+      == Long Chapter
+
+      [appendix, tocreftext="Appendix"]
+      == Long Appendix
+      EOS
+
+      output = convert_string input
+      assert_xpath '//*[@id="toc"]//a[@href="#_long_part"][text()="PS I: Part"]', output, 1
+      assert_xpath '//*[@id="toc"]//a[@href="#_long_chapter"][text()="CS 1. Chapter"]', output, 1
+      assert_xpath '//*[@id="toc"]//a[@href="#_long_appendix"][text()="Appendix A: Appendix"]', output, 1
+      assert_xpath '//h1[text()="PS I: Long Part"]', output, 1
+      assert_xpath '//h2[text()="CS 1. Long Chapter"]', output, 1
+      assert_xpath '//h2[text()="Appendix A: Long Appendix"]', output, 1
+    end
+
     test 'should set toc position if toc attribute is set to position' do
       input = <<~'EOS'
       = Article


### PR DESCRIPTION
This implements short/alt titles as suggested in #4142 using either `tocreftext` or `reftext`

`tocreftext` is usable for all sections as such:
```adoc
= My Book
:toc:

== Title

[tocreftext="Short Title"]
== Very Very Long Chapter Title
```

<img width="504" height="443" alt="image" src="https://github.com/user-attachments/assets/451093ae-1d6a-41bf-a8e2-6db7d3d8cbd7" />

For  `reftext` I added a document attribute` toc-use-reftext` that needs to be enabled,  so that people don't have their existing documents break or should they not want this feature:

```adoc
= My Book
:toc:
:toc-use-reftext:

== Title

[reftext="Short Title"]
== Very Very Long Chapter Title

[tocreftext="Supersedes Reftext", reftext="Another"]
== Another Very Very Long Chapter Title
```

<img width="670" height="590" alt="image" src="https://github.com/user-attachments/assets/e595dca7-c10a-405b-a831-873f20f94449" />

Tests are included.

Docs still need to be written.

~~Adjustments for pdf and epub3 are nearly ready to ship as well. Still trying to iron out some strange behavior for the pdf part, as it weirdly pulls in caption titles, which to my understanding sections don't have. Code paths for caption in section are present in the html converter as well but don't affect the toc generation code. Glad if anyone can shed some light on if I am missing something or if these are just bugs in the code. Like [here](https://github.com/asciidoctor/asciidoctor/pull/4845/changes#diff-ec0c7d6acd6a55d845249623ecaa876708a15531d02754135cc9dfabdacc5349R395).~~

Let me know your thoughts. Happy to make adjustments.

Edit: Update code and proposal with examples.