### PR TITLE
Checklists: remove whitespace after marker

### DIFF
--- a/data/stylesheets/asciidoctor-default.css
+++ b/data/stylesheets/asciidoctor-default.css
@@ -254,8 +254,8 @@ ul.no-bullet,ol.no-bullet,ol.unnumbered{margin-left:.625em}
 ul.unstyled,ol.unstyled{margin-left:0}
 li>p:empty:only-child::before{content:"";display:inline-block}
 ul.checklist>li>p:first-child{margin-left:-1em}
-ul.checklist>li>p:first-child>.fa-square-o:first-child,ul.checklist>li>p:first-child>.fa-check-square-o:first-child{width:1.25em;font-size:.8em;position:relative;bottom:.125em}
-ul.checklist>li>p:first-child>input[type=checkbox]:first-child{font:inherit;margin:0 .25em 0 0;padding:0}
+ul.checklist>li>p:first-child>.fa-square-o:first-child,ul.checklist>li>p:first-child>.fa-check-square-o:first-child{width:1.25em;font-size:.8em;position:relative;bottom:.125em;margin-right:.3em}
+ul.checklist>li>p:first-child>input[type=checkbox]:first-child{font:inherit;margin:0 .5em 0 0;padding:0}
 ul.inline{display:flex;flex-flow:row wrap;list-style:none;margin:0 0 .625em -1.25em}
 ul.inline>li{margin-left:1.25em}
 .unstyled dl dt{font-weight:400;font-style:normal}

--- a/lib/asciidoctor/converter/html5.rb
+++ b/lib/asciidoctor/converter/html5.rb
@@ -973,15 +973,15 @@ Your browser does not support the audio tag.
       ul_class_attribute = ' class="checklist"'
       if node.option? 'interactive'
         if @xml_mode
-          marker_checked = '<input type="checkbox" data-item-complete="1" checked="checked"/> '
-          marker_unchecked = '<input type="checkbox" data-item-complete="0"/> '
+          marker_checked = '<input type="checkbox" data-item-complete="1" checked="checked"/>'
+          marker_unchecked = '<input type="checkbox" data-item-complete="0"/>'
         else
-          marker_checked = '<input type="checkbox" data-item-complete="1" checked> '
-          marker_unchecked = '<input type="checkbox" data-item-complete="0"> '
+          marker_checked = '<input type="checkbox" data-item-complete="1" checked>'
+          marker_unchecked = '<input type="checkbox" data-item-complete="0">'
         end
       elsif node.document.attr? 'icons', 'font'
-        marker_checked = '<i class="fa fa-check-square-o"></i> '
-        marker_unchecked = '<i class="fa fa-square-o"></i> '
+        marker_checked = '<i class="fa fa-check-square-o"></i>'
+        marker_unchecked = '<i class="fa fa-square-o"></i>'
       else
         marker_checked = '&#10003; '
         marker_unchecked = '&#10063; '

--- a/test/lists_test.rb
+++ b/test/lists_test.rb
@@ -5475,6 +5475,38 @@ context 'Checklists' do
       refute list.option?('checklist')
     end
   end
+
+  test 'should create interactive checklists without any textual space between the checkbox and the content' do
+    input = <<~'EOS'
+    [%interactive]
+    - [ ] todo
+    - [x] done
+    EOS
+
+    doc = document_from_string input
+    checklist = doc.blocks[0]
+    assert checklist.option?('checklist')
+    assert checklist.option?('interactive')
+
+    output = doc.convert standalone: false
+    assert_xpath '(/*[@class="ulist checklist"]/ul/li)[1]/p[text()="todo"]', output, 1
+    assert_xpath '(/*[@class="ulist checklist"]/ul/li)[2]/p[text()="done"]', output, 1
+  end
+
+  test 'should create font-icon checklists without any textual space between the icon and the content' do
+    input = <<~'EOS'
+    - [ ] todo
+    - [x] done
+    EOS
+
+    doc = document_from_string input
+    checklist = doc.blocks[0]
+    assert checklist.option?('checklist')
+
+    output = convert_string_to_embedded input, attributes: { 'icons' => 'font' }
+    assert_xpath '(/*[@class="ulist checklist"]/ul/li)[1]/p[text()="todo"]', output, 1
+    assert_xpath '(/*[@class="ulist checklist"]/ul/li)[2]/p[text()="done"]', output, 1
+  end
 end
 
 context 'Lists model' do


### PR DESCRIPTION
### Preface

This PR makes the change I proposed in #4844, since I opened it a month ago and have heard no objections.

I'm not naive enough to imagine that "no objections" == "approval"/"support", and realize that silence in response to #4844 may simply indicate that it hasn't been looked at. It's very possible that reviewers _would_ be opposed to #4844, but simply haven't had the time to register that opposition. So, this PR can be seen as both an invitation to now register any concerns/objections, as well as a chance to bikeshed freely regarding the specifics of the change as implemented here.

### Motivation & Approach (but see also #4844 for details)

For interactive and font-icon checklists, the list marker is inserted as a DOM element (`<input>` or `<i class="fa">`) as the first child of the list item (`<li>`). To ensure that the content will align properly if that element is repositioned using CSS, ensure that there is no spurious whitespace inserted between the marker element and the start of the list item's textual content.

Adjust the default CSS file to create equivalent visual separation between the marker and the text using CSS `margin-right` applied to the marker element, instead.

### Tests included

A second commit adds two tests for this behavior, on both interactive and `:icons: font` style checklists. I have confirmed that the new tests both fail on the repo's `HEAD` without other changes, but pass once the first commit in this PR is applied.

Fixes #4844