### PR TITLE
fix BlockAttributeLineRx incorrectly matching paragraph lines ending with a footnote

### DIFF
--- a/lib/asciidoctor/rx.rb
+++ b/lib/asciidoctor/rx.rb
@@ -177,12 +177,12 @@ module Asciidoctor
   #   # as attribute reference
   #   [{lead}]
   #
-  BlockAttributeListRx = /^\[(|[#{CC_WORD}.#%{,"']#{CC_ANY}*)\]$/
+  BlockAttributeListRx = /^\[(|[#{CC_WORD}.#%{,"'][^\]]*)\]$/
 
   # A combined pattern that matches either a block anchor or a block attribute list.
   #
   # TODO this one gets hit a lot, should be optimized as much as possible
-  BlockAttributeLineRx = /^\[(?:|[#{CC_WORD}.#%{,"']#{CC_ANY}*|\[(?:|[#{CC_ALPHA}_:][#{CC_WORD}\-:.]*(?:, *#{CC_ANY}+)?)\])\]$/
+  BlockAttributeLineRx = /^\[(?:|[#{CC_WORD}.#%{,"'][^\]]*|\[(?:|[#{CC_ALPHA}_:][#{CC_WORD}\-:.]*(?:, *[^\]]+)?)\])\]$/
 
   # Matches a title above a block.
   #

--- a/test/blocks_test.rb
+++ b/test/blocks_test.rb
@@ -1093,6 +1093,19 @@ context 'Blocks' do
       assert_xpath '/tip/simpara[text()="Look for the warp under the bridge."]', output, 1
       refute_includes output, 'Pro Tip'
     end
+
+    test 'should not drop paragraph body in DocBook output when paragraph starts with inline role and contains a footnote' do
+      input = <<~'EOS'
+      [TIP]
+      ====
+      [.smallcaps]#Tip#: Some content here.footnote:[A footnote.]
+      ====
+      EOS
+
+      output = convert_string_to_embedded input, backend: :docbook
+      assert_css 'tip > simpara', output, 1
+      assert_xpath '//tip/simpara[contains(text(), "Some content here.")]', output, 1
+    end
   end
 
   context 'Preformatted Blocks' do


### PR DESCRIPTION
…with ]

A paragraph starting with an inline role (e.g. [.smallcaps]#text#) and ending with a footnote macro (e.g. footnote:[...]) was falsely matched by BlockAttributeLineRx because the regex used CC_ANY* which allows ] inside the match. This caused the parser to treat the paragraph line as a block attribute line and break out of paragraph reading with no content, silently dropping the paragraph body in the output (notably in DocBook5).

Fix by replacing CC_ANY* with [^\]]* in both BlockAttributeListRx and BlockAttributeLineRx so that a bare ] cannot appear inside the matched attribute list content.