### PR TITLE
Remove the ignored inline_theme option for Rouge::Formatters::HTML

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,7 +15,7 @@ group :development do
   # pygments.rb is needed for testing source highlighting; Asciidoctor supports pygments.rb >= 1.2.0
   gem 'pygments.rb', ENV['PYGMENTS_VERSION'] if ENV.key? 'PYGMENTS_VERSION'
   # rouge is needed for testing source highlighting; Asciidoctor supports rouge >= 2
-  gem 'rouge', (ENV.fetch 'ROUGE_VERSION', '~> 3.0')
+  gem 'rouge', (ENV.fetch 'ROUGE_VERSION', '>= 4.0')
   if RUBY_ENGINE == 'truffleruby'
     gem 'nokogiri', '~> 1.10.0'
   elsif (Gem::Version.new RUBY_VERSION) < (Gem::Version.new '2.6.0')

--- a/lib/asciidoctor/syntax_highlighter/rouge.rb
+++ b/lib/asciidoctor/syntax_highlighter/rouge.rb
@@ -74,7 +74,7 @@ class SyntaxHighlighter::RougeAdapter < SyntaxHighlighter::Base
 
   def create_formatter node, source, lang, opts
     formatter = opts[:css_mode] == :class ?
-      (::Rouge::Formatters::HTML.new inline_theme: @style) :
+      (::Rouge::Formatters::HTML.new) :
       (::Rouge::Formatters::HTMLInline.new (::Rouge::Theme.find @style).new)
     if (number_lines = opts[:number_lines])
       formatter = RougeExt::Formatters::HTMLLineHighlighter.new formatter, lines: opts[:highlight_lines]


### PR DESCRIPTION
This has been ignored for some time. Otherwise, I think this code is 100% compatible with Rouge 5, which is great!

One possible issue that may come up is that old versions of Rouge depended on `CGI.parse(...)` which has been removed from newer versions of Ruby. For those using newer versions of Ruby, it is recommended to use at least Rouge 4, which uses `URI.decode_www_form` instead.