### PR TITLE
Avoid `CGI::Util` deprecation warning on Ruby 4.0

### DIFF
--- a/lib/asciidoctor.rb
+++ b/lib/asciidoctor.rb
@@ -7,7 +7,8 @@ if RUBY_ENGINE == 'opal'
   # this require is satisfied by the Asciidoctor.js build; it augments the Ruby environment for Asciidoctor.js
   require 'asciidoctor/js'
 else
-  require 'cgi/util'
+  require 'cgi/escape'
+  require 'cgi/util' unless ::CGI.respond_to?(:escape_html)
   autoload :OpenURI, 'open-uri'
   autoload :Pathname, 'pathname'
   autoload :StringScanner, 'strscan'


### PR DESCRIPTION
Ruby 4.0 emits a warning when `cgi/util` is required, since CGI::Util is removed there in favor of `cgi/escape`.

```
asciidoctor -b manpage -a version=20260512 -o share/man/man1/ruby-build.1 share/man/man1/ruby-build.1.adoc
/Users/hsbt/.local/share/gem/gems/asciidoctor-2.0.26/lib/asciidoctor.rb:9: warning: CGI::Util is removed from Ruby 4.0. Please use cgi/escape instead for CGI.escape and CGI.unescape features.
```

`cgi/escape` only exposes `CGI.escape_html` (snake_case) on Ruby 4.0+, so still fall back to `cgi/util` on older Rubies where that alias lives in `cgi/util`.