### PR TITLE
resolves #4522 introduce STEM adapter facility

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -20,6 +20,7 @@ This project utilizes semantic versioning.
 
 Enhancements::
 
+  * Introduce a pluggable STEM adapter facility, following the syntax highlighter pattern, to allow alternate STEM renderers (e.g., KaTeX) to be integrated into AsciiDoc processing; select the adapter using the `stem-adapter` document attribute (default: `mathjax` for the html5 backend) (#4522)
   * Introduce 4+ tilde (`~`) delimiter for open blocks; restrict masquerading to partintro and abstract (#1121)
   * Allow the CLI to control the logging level using the `--log-level` option (#3868)
   * Ignore `--log-level` CLI option if `-q` is specified; ignore `-v` CLI option if `--log-level` is specified (#3868)

--- a/docs/modules/stem/nav.adoc
+++ b/docs/modules/stem/nav.adoc
@@ -3,3 +3,4 @@
 ** xref:mathematical.adoc[]
 ** xref:docbook.adoc[]
 ** xref:asciimath-gem.adoc[]
+** xref:custom-adapter.adoc[]

--- a/docs/modules/stem/pages/custom-adapter.adoc
+++ b/docs/modules/stem/pages/custom-adapter.adoc
@@ -1,0 +1,107 @@
+= Custom STEM Adapter
+:navtitle: Custom Adapter
+
+You can integrate an alternate STEM renderer into Asciidoctor by implementing and registering a STEM adapter.
+This allows you to replace the built-in MathJax integration with another library such as KaTeX, or to pre-process STEM expressions during conversion.
+
+[#new]
+== Create a new adapter
+
+To implement a new adapter, create a class that includes the `Asciidoctor::StemAdapter` module, register the adapter for a name, and implement the required methods.
+
+A STEM adapter can implement three integration points:
+
+`convert(node, opts = {})`::
+Converts the STEM content of a block or inline node, including adding delimiters.
+Called for both block and inline STEM nodes.
+
+`format(node, opts = {})`::
+Formats the enclosing element of a STEM block (e.g., the outer `<div>`).
+Typically calls `convert` internally.
+
+`docinfo?(location)`::
+Returns `true` if the adapter needs to inject markup at the given location (`:head` or `:footer`).
+
+`docinfo(location, doc, opts)`::
+Returns the markup to inject at the specified location.
+Only called if `docinfo?` returns `true` for that location.
+
+Here's an example of a STEM adapter for the https://katex.org[KaTeX^] rendering library.
+KaTeX is a client-side renderer, so the adapter injects a stylesheet in the `<head>` and a script at the end of `<body>`, and wraps each STEM expression in the delimiters KaTeX expects.
+
+.STEM adapter for KaTeX
+[,ruby]
+----
+class KaTeXAdapter
+  include Asciidoctor::StemAdapter
+
+  register_for 'katex'
+
+  KATEX_VERSION = '0.16.9'
+  KATEX_BASE_URL = %(https://cdn.jsdelivr.net/npm/katex@#{KATEX_VERSION}/dist)
+
+  def docinfo? location
+    location == :head || location == :footer
+  end
+
+  def docinfo location, doc, opts
+    if location == :head
+      slash = opts[:self_closing_tag_slash]
+      %(<link rel="stylesheet" href="#{KATEX_BASE_URL}/katex.min.css"#{slash}>)
+    else
+      %(<script defer src="#{KATEX_BASE_URL}/katex.min.js"></script>
+<script defer src="#{KATEX_BASE_URL}/contrib/auto-render.min.js"
+  onload="renderMathInElement(document.body)"></script>)
+    end
+  end
+
+  def convert node, opts = {}
+    if node.block?
+      %(\\[#{node.content}\\])
+    else
+      %(\\(#{node.text}\\))
+    end
+  end
+
+  def format node, opts = {}
+    id_attribute = node.id ? %( id="#{node.id}") : ''
+    title_element = node.title? ? %(<div class="title">#{node.title}</div>\n) : ''
+    %(<div#{id_attribute} class="stemblock">
+#{title_element}<div class="content">
+#{convert node}
+</div>
+</div>)
+  end
+end
+----
+
+Save this code to a file named [.path]_katex-stem-adapter.rb_.
+Then, require this file when invoking Asciidoctor, set `stem` to activate STEM processing, and set `stem-adapter=katex` to use your adapter:
+
+ $ asciidoctor -r ./katex-stem-adapter.rb -a stem -a stem-adapter=katex document.adoc
+
+Or, declare the attributes in the document header:
+
+[,asciidoc]
+----
+:stem:
+:stem-adapter: katex
+----
+
+[#extend]
+== Extend the built-in MathJax adapter
+
+You can also customize the built-in MathJax adapter by extending it and overriding specific methods.
+Look up the built-in adapter using `Asciidoctor::StemAdapter.for`, extend it, and register the subclass under the same name (or a new one).
+
+[,ruby]
+----
+class CustomMathJaxAdapter < (Asciidoctor::StemAdapter.for 'mathjax')
+  register_for 'mathjax'
+
+  def docinfo location, doc, opts
+    # prepend custom styles then delegate to built-in MathJax docinfo
+    location == :head ? '<style>.stemblock { border-left: 3px solid #ccc; }</style>' : super
+  end
+end
+----

--- a/docs/modules/stem/pages/index.adoc
+++ b/docs/modules/stem/pages/index.adoc
@@ -39,3 +39,17 @@ The STEM integrations are activated when the xref:asciidoc:stem:stem.adoc[stem d
 You can explore these integrations in depth on the xref:mathjax.adoc[], xref:mathematical.adoc[], and xref:asciimath-gem.adoc[] pages.
 
 If you're planning to convert to DocBook to leverage the DocBook toolchain, be sure to consider xref:docbook.adoc[] when deciding which STEM notation to use in your AsciiDoc document.
+
+== STEM adapter facility
+
+When converting to HTML, Asciidoctor uses a pluggable STEM adapter to handle STEM processing.
+The built-in adapter integrates with MathJax.
+You can replace it with an alternate adapter — such as one for KaTeX — by setting the `stem-adapter` document attribute.
+
+ :stem-adapter: katex
+
+If `stem-adapter` is not set, Asciidoctor uses the built-in MathJax adapter by default whenever the `stem` attribute is set.
+
+A STEM adapter controls three integration points: how the STEM content is converted (including delimiters), how the enclosing block element is formatted, and what markup is injected into the document head and footer (e.g., a stylesheet or rendering script).
+
+See xref:custom-adapter.adoc[] to learn how to implement and register a custom STEM adapter.

--- a/lib/asciidoctor.rb
+++ b/lib/asciidoctor.rb
@@ -539,6 +539,7 @@ module Asciidoctor
   end unless RUBY_ENGINE == 'opal'
 
   unless RUBY_ENGINE == 'opal'
+    autoload :StemAdapter, %(#{__dir__}/asciidoctor/stem_adapter)
     autoload :SyntaxHighlighter, %(#{__dir__}/asciidoctor/syntax_highlighter)
     autoload :Timings, %(#{__dir__}/asciidoctor/timings)
   end
@@ -579,6 +580,7 @@ require_relative 'asciidoctor/load'
 require_relative 'asciidoctor/convert'
 
 if RUBY_ENGINE == 'opal'
+  require_relative 'asciidoctor/stem_adapter'
   require_relative 'asciidoctor/syntax_highlighter'
   require_relative 'asciidoctor/timings'
   # this require is satisfied by the Asciidoctor.js build; it supplies compile and runtime overrides for Asciidoctor.js

--- a/lib/asciidoctor/converter/html5.rb
+++ b/lib/asciidoctor/converter/html5.rb
@@ -159,6 +159,9 @@ class Converter::Html5Converter < Converter::Base
     if (syntax_hl = node.syntax_highlighter)
       result << (syntax_hl_docinfo_head_idx = result.size)
     end
+    if (stem_adpt = node.stem_adapter)
+      result << (stem_adpt_docinfo_head_idx = result.size)
+    end
 
     unless (docinfo_content = node.docinfo).empty?
       result << docinfo_content
@@ -257,41 +260,22 @@ class Converter::Html5Converter < Converter::Base
         result[syntax_hl_docinfo_head_idx] = syntax_hl.docinfo :head, node, cdn_base_url: cdn_base_url, linkcss: linkcss, self_closing_tag_slash: slash
       else
         result.delete_at syntax_hl_docinfo_head_idx
+        stem_adpt_docinfo_head_idx -= 1 if stem_adpt
       end
       if syntax_hl.docinfo? :footer
         result << (syntax_hl.docinfo :footer, node, cdn_base_url: cdn_base_url, linkcss: linkcss, self_closing_tag_slash: slash)
       end
     end
 
-    if node.attr? 'stem'
-      eqnums_val = node.attr 'eqnums', 'none'
-      eqnums_val = 'AMS' if eqnums_val.empty?
-      eqnums_opt = %( equationNumbers: { autoNumber: "#{eqnums_val}" } )
-      # IMPORTANT inspect calls on delimiter arrays are intentional for JavaScript compat (emulates JSON.stringify)
-      result << %(<script type="text/x-mathjax-config">
-MathJax.Hub.Config({
-  messageStyle: "none",
-  tex2jax: {
-    inlineMath: [#{INLINE_MATH_DELIMITERS[:latexmath].inspect}],
-    displayMath: [#{BLOCK_MATH_DELIMITERS[:latexmath].inspect}],
-    ignoreClass: "nostem|nolatexmath"
-  },
-  asciimath2jax: {
-    delimiters: [#{BLOCK_MATH_DELIMITERS[:asciimath].inspect}],
-    ignoreClass: "nostem|noasciimath"
-  },
-  TeX: {#{eqnums_opt}}
-})
-MathJax.Hub.Register.StartupHook("AsciiMath Jax Ready", function () {
-  MathJax.InputJax.AsciiMath.postfilterHooks.Add(function (data, node) {
-    if ((node = data.script.parentNode) && (node = node.parentNode) && node.classList.contains("stemblock")) {
-      data.math.root.display = "block"
-    }
-    return data
-  })
-})
-</script>
-<script src="#{cdn_base_url}/mathjax/#{MATHJAX_VERSION}/MathJax.js?config=TeX-MML-AM_CHTML"></script>)
+    if stem_adpt
+      if stem_adpt.docinfo? :head
+        result[stem_adpt_docinfo_head_idx] = stem_adpt.docinfo :head, node, cdn_base_url: cdn_base_url, self_closing_tag_slash: slash
+      else
+        result.delete_at stem_adpt_docinfo_head_idx
+      end
+      if stem_adpt.docinfo? :footer
+        result << (stem_adpt.docinfo :footer, node, cdn_base_url: cdn_base_url, self_closing_tag_slash: slash)
+      end
     end
 
     unless (docinfo_content = node.docinfo :footer).empty?
@@ -708,6 +692,7 @@ Your browser does not support the audio tag.
   end
 
   def convert_stem node
+    return node.document.stem_adapter.format node if node.document.stem_adapter
     id_attribute = node.id ? %( id="#{node.id}") : ''
     title_element = node.title? ? %(<div class="title">#{node.title}</div>\n) : ''
     open, close = BLOCK_MATH_DELIMITERS[style = node.style.to_sym]
@@ -1293,22 +1278,33 @@ Your browser does not support the video tag.
   end
 
   def convert_inline_quoted node
-    open, close, tag = QUOTE_TAGS[node.type]
-    if node.id
-      class_attr = node.role ? %( class="#{node.role}") : ''
-      if tag
-        %(#{open.chop} id="#{node.id}"#{class_attr}>#{node.text}#{close})
+    if (node.type == :asciimath || node.type == :latexmath) && (stem_adpt = node.document.stem_adapter)
+      content = stem_adpt.convert node
+      if node.id
+        %(<span id="#{node.id}"#{node.role ? %( class="#{node.role}") : ''}>#{content}</span>)
+      elsif node.role
+        %(<span class="#{node.role}">#{content}</span>)
       else
-        %(<span id="#{node.id}"#{class_attr}>#{open}#{node.text}#{close}</span>)
-      end
-    elsif node.role
-      if tag
-        %(#{open.chop} class="#{node.role}">#{node.text}#{close})
-      else
-        %(<span class="#{node.role}">#{open}#{node.text}#{close}</span>)
+        content
       end
     else
-      %(#{open}#{node.text}#{close})
+      open, close, tag = QUOTE_TAGS[node.type]
+      if node.id
+        class_attr = node.role ? %( class="#{node.role}") : ''
+        if tag
+          %(#{open.chop} id="#{node.id}"#{class_attr}>#{node.text}#{close})
+        else
+          %(<span id="#{node.id}"#{class_attr}>#{open}#{node.text}#{close}</span>)
+        end
+      elsif node.role
+        if tag
+          %(#{open.chop} class="#{node.role}">#{node.text}#{close})
+        else
+          %(<span class="#{node.role}">#{open}#{node.text}#{close}</span>)
+        end
+      else
+        %(#{open}#{node.text}#{close})
+      end
     end
   end
 

--- a/lib/asciidoctor/document.rb
+++ b/lib/asciidoctor/document.rb
@@ -233,6 +233,9 @@ class Document < AbstractBlock
   # Public: Get the Converter associated with this document
   attr_reader :converter
 
+  # Public: Get the StemAdapter associated with this document
+  attr_reader :stem_adapter
+
   # Public: Get the SyntaxHighlighter associated with this document
   attr_reader :syntax_highlighter
 
@@ -280,6 +283,7 @@ class Document < AbstractBlock
       @converter = parent_doc.converter
       initialize_extensions = nil
       @extensions = parent_doc.extensions
+      @stem_adapter = parent_doc.stem_adapter
       @syntax_highlighter = parent_doc.syntax_highlighter
     else
       @parent_document = nil
@@ -1239,6 +1243,17 @@ class Document < AbstractBlock
             @syntax_highlighter = (SyntaxHighlighter::DefaultFactoryProxy.new syntax_hls).create syntax_hl_name, @backend, document: self
           else
             @syntax_highlighter = SyntaxHighlighter.create syntax_hl_name, @backend, document: self
+          end
+        end
+        if attrs.key? 'stem'
+          stem_adpt_name = (adpt_val = attrs['stem-adapter']) && !adpt_val.empty? ? adpt_val : 'mathjax'
+          if (stem_adpt_factory = @options[:stem_adapter_factory])
+            @stem_adapter = stem_adpt_factory.create stem_adpt_name, @backend, document: self
+          elsif (stem_adpts = @options[:stem_adapters])
+            @stem_adapter = (StemAdapter::DefaultFactoryProxy.new stem_adpts).create stem_adpt_name, @backend, document: self
+          else
+            @stem_adapter = StemAdapter.create(stem_adpt_name, @backend, document: self) ||
+              StemAdapter.create('mathjax', @backend, document: self)
           end
         end
       # enable toc and sectnums (i.e., numbered) by default in DocBook backend

--- a/lib/asciidoctor/stem_adapter.rb
+++ b/lib/asciidoctor/stem_adapter.rb
@@ -1,0 +1,192 @@
+# frozen_string_literal: true
+
+module Asciidoctor
+# Public: A pluggable adapter for integrating a STEM processor into AsciiDoc processing.
+#
+# There are two types of STEM adapters. The first performs STEM processing during the convert phase.
+# This adapter type must define a convert method to process the content, including adding delimiters,
+# and a format method to generate the enclosing block element. The second assumes STEM processing is
+# performed on the client (e.g., when the HTML document is loaded). This adapter type must define a
+# docinfo? method that returns true. The companion docinfo method will then be called to insert markup
+# into the output document. The docinfo functionality is available to both adapter types.
+#
+# Asciidoctor provides a built-in MathJax adapter. Additional adapters can be registered using
+# StemAdapter.register or by supplying a custom factory.
+module StemAdapter
+  # Public: Returns the String name of this STEM adapter.
+  attr_reader :name
+
+  def initialize name, backend = 'html5', opts = {}
+    @name = name
+  end
+
+  # Public: Indicates whether this STEM adapter has docinfo (i.e., markup) to insert into the output
+  # document at the specified location. Should be called by converter after main content has been converted.
+  #
+  # location - The Symbol representing the location slot (:head or :footer).
+  #
+  # Returns a [Boolean] indicating whether the docinfo method should be called for this location.
+  def docinfo? location; end
+
+  # Public: Generates docinfo markup for this STEM adapter to insert at the specified location in the
+  # output document. Should be called by converter after main content has been converted.
+  #
+  # location - The Symbol representing the location slot (:head or :footer).
+  # doc      - The Document in which this STEM adapter is being used.
+  # opts     - A Hash of options:
+  #            :cdn_base_url - The String base URL for assets loaded from the CDN.
+  #            :self_closing_tag_slash - The String '/' if the converter emits self-closing tags.
+  #
+  # Returns the [String] markup to insert.
+  def docinfo location, doc, opts
+    raise ::NotImplementedError, %(#{StemAdapter} subclass #{self.class} must implement the ##{__method__} method since #docinfo? returns true)
+  end
+
+  # Public: Converts the STEM content for the specified node, including adding delimiters.
+  # Called for both inline STEM nodes (Inline) and block STEM nodes (Block).
+  #
+  # node - The STEM Block or Inline node being converted.
+  # opts - An optional Hash of options.
+  #
+  # Returns the converted STEM content [String].
+  def convert node, opts = {}
+    raise ::NotImplementedError, %(#{StemAdapter} subclass #{self.class} must implement the ##{__method__} method)
+  end
+
+  # Public: Formats the enclosing element for a STEM block node.
+  #
+  # node - The STEM Block node being formatted.
+  # opts - An optional Hash of options.
+  #
+  # Returns the formatted STEM block [String] including the enclosing element and converted content.
+  def format node, opts = {}
+    raise ::NotImplementedError, %(#{StemAdapter} subclass #{self.class} must implement the ##{__method__} method)
+  end
+
+  def self.included into
+    into.extend Config
+  end
+  private_class_method :included # use separate declaration for Ruby 2.0.x
+
+  module Config
+    # Public: Statically register the current class in the registry for the specified names.
+    #
+    # names - one or more String or Symbol names with which to register the current class as a STEM
+    #         adapter implementation. Symbol arguments are coerced to Strings.
+    #
+    # Returns nothing.
+    def register_for *names
+      StemAdapter.register self, *(names.map {|name| name.to_s })
+    end
+  end
+
+  module Factory
+    # Public: Associates the STEM adapter class or object with the specified names.
+    #
+    # stem_adapter - the STEM adapter implementation to register
+    # names        - one or more String names with which to register this STEM adapter implementation.
+    #
+    # Returns nothing.
+    def register stem_adapter, *names
+      names.each {|name| registry[name] = stem_adapter }
+    end
+
+    # Public: Retrieves the STEM adapter class or object registered for the specified name.
+    #
+    # name - The String name of the STEM adapter to retrieve.
+    #
+    # Returns the StemAdapter Class or Object instance registered for this name.
+    def for name
+      registry[name]
+    end
+
+    # Public: Resolves the name to a STEM adapter instance, if found in the registry.
+    #
+    # name    - The String name of the STEM adapter to create.
+    # backend - The String name of the backend for which this STEM adapter is being used (default: 'html5').
+    # opts    - A Hash of options providing information about the context in which this STEM adapter is used:
+    #           :document - The Document for which this STEM adapter was created.
+    #
+    # Returns a [StemAdapter] instance for the specified name.
+    def create name, backend = 'html5', opts = {}
+      return unless (stem_adpt = self.for name)
+      stem_adpt = stem_adpt.new name, backend, opts if ::Class === stem_adpt
+      raise ::NameError, %(#{stem_adpt.class} must specify a value for `name') unless stem_adpt.name
+      stem_adpt
+    end
+
+    private
+
+    def registry
+      raise ::NotImplementedError, %(#{Factory} subclass #{self.class} must implement the ##{__method__} method)
+    end
+  end
+
+  class CustomFactory
+    include Factory
+
+    def initialize seed_registry = nil
+      @registry = seed_registry || {}
+    end
+
+    private
+
+    attr_reader :registry
+  end
+
+  module DefaultFactory
+    include Factory
+
+    @@registry = {}
+
+    private
+
+    def registry
+      @@registry
+    end
+    unless RUBY_ENGINE == 'opal'
+
+      public
+
+      def register stem_adapter, *names
+        @@mutex.owned? ? names.each {|name| @@registry = @@registry.merge name => stem_adapter } :
+            @@mutex.synchronize { register stem_adapter, *names }
+      end
+
+      # This method will lazy require and register additional built-in implementations.
+      # Refer to {Factory#for} for parameters and return value.
+      def for name
+        @@registry.fetch name do
+          @@mutex.synchronize do
+            @@registry.fetch name do
+              if (require_path = PROVIDED[name])
+                require require_path
+                @@registry[name]
+              else
+                @@registry = @@registry.merge name => nil
+                nil
+              end
+            end
+          end
+        end
+      end
+
+      PROVIDED = {}
+
+      @@mutex = ::Mutex.new
+    end
+  end
+
+  class DefaultFactoryProxy < CustomFactory
+    include DefaultFactory # inserts module into ancestors immediately after superclass
+
+    def for name
+      @registry.fetch(name) { super }
+    end unless RUBY_ENGINE == 'opal'
+  end
+
+  extend DefaultFactory # exports static methods
+end
+end
+
+require_relative 'stem_adapter/mathjax'

--- a/lib/asciidoctor/stem_adapter/mathjax.rb
+++ b/lib/asciidoctor/stem_adapter/mathjax.rb
@@ -1,0 +1,79 @@
+# frozen_string_literal: true
+
+module Asciidoctor
+class StemAdapter::MathJaxAdapter
+  include StemAdapter
+
+  register_for 'mathjax'
+
+  StemBreakRx = / *\\\n(?:\\?\n)*|\n\n+/
+
+  def docinfo? location
+    location == :footer
+  end
+
+  def docinfo location, doc, opts
+    cdn_base_url = opts[:cdn_base_url]
+    eqnums_val = doc.attr 'eqnums', 'none'
+    eqnums_val = 'AMS' if eqnums_val.empty?
+    eqnums_opt = %( equationNumbers: { autoNumber: "#{eqnums_val}" } )
+    # IMPORTANT inspect calls on delimiter arrays are intentional for JavaScript compat (emulates JSON.stringify)
+    %(<script type="text/x-mathjax-config">
+MathJax.Hub.Config({
+  messageStyle: "none",
+  tex2jax: {
+    inlineMath: [#{INLINE_MATH_DELIMITERS[:latexmath].inspect}],
+    displayMath: [#{BLOCK_MATH_DELIMITERS[:latexmath].inspect}],
+    ignoreClass: "nostem|nolatexmath"
+  },
+  asciimath2jax: {
+    delimiters: [#{BLOCK_MATH_DELIMITERS[:asciimath].inspect}],
+    ignoreClass: "nostem|noasciimath"
+  },
+  TeX: {#{eqnums_opt}}
+})
+MathJax.Hub.Register.StartupHook("AsciiMath Jax Ready", function () {
+  MathJax.InputJax.AsciiMath.postfilterHooks.Add(function (data, node) {
+    if ((node = data.script.parentNode) && (node = node.parentNode) && node.classList.contains("stemblock")) {
+      data.math.root.display = "block"
+    }
+    return data
+  })
+})
+</script>
+<script src="#{cdn_base_url}/mathjax/#{MATHJAX_VERSION}/MathJax.js?config=TeX-MML-AM_CHTML"></script>)
+  end
+
+  def convert node, opts = {}
+    if node.block?
+      open, close = BLOCK_MATH_DELIMITERS[style = node.style.to_sym]
+      if (equation = node.content)
+        if style == :asciimath && (equation.include? LF)
+          void_element_slash = node.document.attr('htmlsyntax') == 'xml' ? '/' : ''
+          br = %(#{LF}<br#{void_element_slash}>)
+          equation = equation.gsub(StemBreakRx) { %(#{close}#{br * (($&.count LF) - 1)}#{LF}#{open}) }
+        end
+        unless (equation.start_with? open) && (equation.end_with? close)
+          equation = %(#{open}#{equation}#{close})
+        end
+      else
+        equation = ''
+      end
+      equation
+    else
+      open, close = INLINE_MATH_DELIMITERS[node.type]
+      %(#{open}#{node.text}#{close})
+    end
+  end
+
+  def format node, opts = {}
+    id_attribute = node.id ? %( id="#{node.id}") : ''
+    title_element = node.title? ? %(<div class="title">#{node.title}</div>\n) : ''
+    %(<div#{id_attribute} class="stemblock#{(role = node.role) ? " #{role}" : ''}">
+#{title_element}<div class="content">
+#{convert node, opts}
+</div>
+</div>)
+  end
+end
+end

--- a/test/stem_adapter_test.rb
+++ b/test/stem_adapter_test.rb
@@ -1,0 +1,325 @@
+# frozen_string_literal: true
+
+require_relative 'test_helper'
+
+context 'Stem Adapter' do
+  test 'should set stem_adapter property on document if stem attribute is set and basebackend is html' do
+    input = ':stem:'
+    doc = document_from_string input, safe: :safe, parse: true
+    assert doc.basebackend? 'html'
+    refute_nil doc.stem_adapter
+    assert_kind_of Asciidoctor::StemAdapter, doc.stem_adapter
+  end
+
+  test 'should not set stem_adapter property on document if stem attribute is not set' do
+    doc = document_from_string '', safe: :safe, parse: true
+    assert_nil doc.stem_adapter
+  end
+
+  test 'should not set stem_adapter property on document if basebackend is not html' do
+    input = ':stem:'
+    doc = document_from_string input, safe: :safe, backend: 'docbook', parse: true
+    refute doc.basebackend? 'html'
+    assert_nil doc.stem_adapter
+  end
+
+  test 'should use mathjax adapter by default when stem attribute is set' do
+    input = ':stem:'
+    doc = document_from_string input, safe: :safe, parse: true
+    assert_equal 'mathjax', doc.stem_adapter.name
+  end
+
+  test 'should use mathjax adapter when stem-adapter attribute is not set regardless of stem value' do
+    [
+      { 'stem' => '' },
+      { 'stem' => 'asciimath' },
+      { 'stem' => 'latexmath' },
+    ].each do |attributes|
+      doc = document_from_string '', safe: :safe, attributes: attributes, parse: true
+      assert_equal 'mathjax', doc.stem_adapter.name
+    end
+  end
+
+  test 'should use adapter specified by stem-adapter attribute' do
+    Class.new do
+      include Asciidoctor::StemAdapter
+      register_for 'katex'
+
+      def convert node, opts = {}
+        node.block? ? node.content : node.text
+      end
+
+      def format node, opts = {}
+        %(<div class="stemblock katex">#{convert node}</div>)
+      end
+    end
+
+    input = ':stem:'
+    doc = document_from_string input, safe: :safe, attributes: { 'stem' => '', 'stem-adapter' => 'katex' }, parse: true
+    assert_equal 'katex', doc.stem_adapter.name
+  ensure
+    Asciidoctor::StemAdapter.register nil, 'katex'
+  end
+
+  test 'should fall back to mathjax if stem-adapter attribute specifies unknown adapter' do
+    input = ':stem:'
+    doc = document_from_string input, safe: :safe, attributes: { 'stem' => '', 'stem-adapter' => 'unknown' }, parse: true
+    assert_equal 'mathjax', doc.stem_adapter.name
+  end
+
+  test 'should be able to register stem adapter from adapter class itself' do
+    adapter = Class.new do
+      include Asciidoctor::StemAdapter
+
+      def convert node, opts = {}; end
+
+      def format node, opts = {}; end
+    end
+
+    adapter.register_for 'myadapter'
+    assert_equal adapter, (Asciidoctor::StemAdapter.for 'myadapter')
+  ensure
+    Asciidoctor::StemAdapter.register nil, 'myadapter'
+  end
+
+  test 'should propagate stem_adapter from parent document to child document' do
+    input = <<~'EOS'
+    :stem:
+
+    |===
+    a|
+    stem:[x^2]
+    |===
+    EOS
+    doc = document_from_string input, safe: :safe, parse: true
+    table_cell_doc = (doc.find_by context: :table_cell)[0].inner_document
+    refute_nil table_cell_doc.stem_adapter
+    assert_equal doc.stem_adapter.name, table_cell_doc.stem_adapter.name
+  end
+
+  context 'MathJax' do
+    test 'should inject MathJax script in footer when stem attribute is set' do
+      input = ':stem:'
+      output = convert_string input, safe: :safe
+      assert_css 'body > script[src*="MathJax.js"]', output, 1
+    end
+
+    test 'should not inject MathJax script when stem attribute is not set' do
+      output = convert_string '', safe: :safe
+      assert_css 'script[src*="MathJax.js"]', output, 0
+    end
+
+    test 'should inject MathJax config script before MathJax script' do
+      input = ':stem:'
+      output = convert_string input, safe: :safe
+      assert_xpath '//script[@type="text/x-mathjax-config"]', output, 1
+      assert_css 'script[type="text/x-mathjax-config"] ~ script[src*="MathJax.js"]', output, 1
+    end
+
+    test 'should use eqnums AMS if eqnums attribute is set to empty' do
+      input = <<~'EOS'
+      :stem:
+      :eqnums:
+      EOS
+      output = convert_string input, safe: :safe
+      assert_includes output, 'autoNumber: "AMS"'
+    end
+
+    test 'should use custom eqnums value if eqnums attribute is set' do
+      input = <<~'EOS'
+      :stem:
+      :eqnums: all
+      EOS
+      output = convert_string input, safe: :safe
+      assert_includes output, 'autoNumber: "all"'
+    end
+
+    test 'should wrap stem block content in asciimath delimiters by default' do
+      input = <<~'EOS'
+      :stem:
+
+      [stem]
+      ++++
+      x^2
+      ++++
+      EOS
+      output = convert_string_to_embedded input, safe: :safe
+      assert_css '.stemblock', output, 1
+      nodes = xmlnodes_at_xpath '//*[@class="content"]/child::text()', output
+      assert_equal '\$x^2\$', nodes.first.to_s.strip
+    end
+
+    test 'should wrap stem block content in latexmath delimiters when stem is latexmath' do
+      input = <<~'EOS'
+      :stem: latexmath
+
+      [stem]
+      ++++
+      x^2
+      ++++
+      EOS
+      output = convert_string_to_embedded input, safe: :safe
+      assert_css '.stemblock', output, 1
+      nodes = xmlnodes_at_xpath '//*[@class="content"]/child::text()', output
+      assert_equal '\[x^2\]', nodes.first.to_s.strip
+    end
+
+    test 'should wrap inline stem macro content in asciimath delimiters' do
+      input = <<~'EOS'
+      :stem:
+
+      Use stem:[x^2] in your formula.
+      EOS
+      output = convert_string_to_embedded input, safe: :safe
+      assert_includes output, '\$x^2\$'
+    end
+
+    test 'should wrap inline latexmath macro content in latexmath delimiters' do
+      input = <<~'EOS'
+      :stem: latexmath
+
+      Use stem:[x^2] in your formula.
+      EOS
+      output = convert_string_to_embedded input, safe: :safe
+      assert_includes output, '\(x^2\)'
+    end
+  end
+
+  context 'Custom Adapter' do
+    test 'should call format on custom adapter for stem block' do
+      Class.new do
+        include Asciidoctor::StemAdapter
+        register_for 'katex'
+
+        def convert node, opts = {}
+          %($#{node.content}$)
+        end
+
+        def format node, opts = {}
+          %(<div class="stemblock katex">#{convert node}</div>)
+        end
+      end
+
+      input = <<~'EOS'
+      :stem:
+      :stem-adapter: katex
+
+      [stem]
+      ++++
+      x^2
+      ++++
+      EOS
+      output = convert_string_to_embedded input, safe: :safe
+      assert_css '.stemblock.katex', output, 1
+      assert_includes output, '$x^2$'
+    ensure
+      Asciidoctor::StemAdapter.register nil, 'katex'
+    end
+
+    test 'should call convert on custom adapter for inline stem macro' do
+      Class.new do
+        include Asciidoctor::StemAdapter
+        register_for 'katex'
+
+        def convert node, opts = {}
+          node.block? ? %($#{node.content}$) : %($#{node.text}$)
+        end
+
+        def format node, opts = {}
+          %(<div class="stemblock katex">#{convert node}</div>)
+        end
+      end
+
+      input = <<~'EOS'
+      :stem:
+      :stem-adapter: katex
+
+      Use stem:[x^2] here.
+      EOS
+      output = convert_string_to_embedded input, safe: :safe
+      assert_includes output, '$x^2$'
+    ensure
+      Asciidoctor::StemAdapter.register nil, 'katex'
+    end
+
+    test 'should inject custom adapter docinfo in head and footer' do
+      Class.new do
+        include Asciidoctor::StemAdapter
+        register_for 'katex'
+
+        def docinfo? location
+          location == :head || location == :footer
+        end
+
+        def docinfo location, doc, opts
+          if location == :head
+            %(<link rel="stylesheet" href="https://cdn.example.org/katex/katex.min.css">)
+          else
+            %(<script src="https://cdn.example.org/katex/katex.min.js"></script>)
+          end
+        end
+
+        def convert node, opts = {}
+          node.block? ? node.content : node.text
+        end
+
+        def format node, opts = {}
+          %(<div class="stemblock">#{convert node}</div>)
+        end
+      end
+
+      input = <<~'EOS'
+      :stem:
+      :stem-adapter: katex
+
+      [stem]
+      ++++
+      x^2
+      ++++
+      EOS
+      output = convert_string input, safe: :safe
+      assert_css 'head > link[href*="katex.min.css"]', output, 1
+      assert_css 'body > script[src*="katex.min.js"]', output, 1
+    ensure
+      Asciidoctor::StemAdapter.register nil, 'katex'
+    end
+
+    test 'should inject custom adapter docinfo only in footer if head docinfo is not defined' do
+      Class.new do
+        include Asciidoctor::StemAdapter
+        register_for 'katex'
+
+        def docinfo? location
+          location == :footer
+        end
+
+        def docinfo location, doc, opts
+          %(<script src="https://cdn.example.org/katex/katex.min.js"></script>)
+        end
+
+        def convert node, opts = {}
+          node.block? ? node.content : node.text
+        end
+
+        def format node, opts = {}
+          %(<div class="stemblock">#{convert node}</div>)
+        end
+      end
+
+      input = <<~'EOS'
+      :stem:
+      :stem-adapter: katex
+
+      [stem]
+      ++++
+      x^2
+      ++++
+      EOS
+      output = convert_string input, safe: :safe
+      assert_css 'head > script', output, 0
+      assert_css 'body > script[src*="katex.min.js"]', output, 1
+    ensure
+      Asciidoctor::StemAdapter.register nil, 'katex'
+    end
+  end
+end


### PR DESCRIPTION
Adds a pluggable StemAdapter module that allows alternate STEM renderers (e.g., KaTeX, MathML converters) to be integrated into AsciiDoc processing.
The built-in MathJaxAdapter reproduces existing behavior and registers for all standard stem attribute values (mathjax, asciimath, latexmath, latex, tex).
The adapter exposes three integration points: `convert` (content with delimiters), `format` (enclosing block element), and `docinfo` (client-side script injection).

Resolves #4522