### PR TITLE
resolves #4684 inline minimal logger to drop stdlib logger dependency

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -73,6 +73,10 @@ Improvements::
   * Return `nil` if name passed to `Asciidoctor::SafeMode.value_for_name` is not recognized (#3526)
   * Modify default stylesheet to honor text-* roles on quote blocks
 
+Infrastructure::
+
+  * Inline a minimal logger implementation to remove the runtime dependency on the stdlib `logger` gem (#4684)
+
 Bug Fixes::
 
   * When skip-front-matter document attribute is set, only skip front matter in primary document, not included content (#3437)

--- a/lib/asciidoctor/cli/invoker.rb
+++ b/lib/asciidoctor/cli/invoker.rb
@@ -72,7 +72,7 @@ module Asciidoctor
               $VERBOSE = nil
               old_logger, LoggerManager.logger = logger, NullLogger.new
             when 2
-              old_logger_level, logger.level = logger.level, ::Logger::Severity::DEBUG
+              old_logger_level, logger.level = logger.level, Logger::Severity::DEBUG
             end
           else
             opts[key] = val unless val.nil?

--- a/lib/asciidoctor/cli/options.rb
+++ b/lib/asciidoctor/cli/options.rb
@@ -26,7 +26,7 @@ module Asciidoctor
         self[:source_dir] = options[:source_dir]
         self[:destination_dir] = options[:destination_dir]
         self[:log_level] = options[:log_level]
-        self[:failure_level] = ::Logger::Severity::FATAL
+        self[:failure_level] = Logger::Severity::FATAL
         self[:sourcemap] = options[:sourcemap]
         self[:trace] = false
         self[:timings] = false
@@ -131,11 +131,11 @@ module Asciidoctor
           end
           opts.on '--log-level LEVEL', %w(debug DEBUG info INFO warning WARNING error ERROR fatal FATAL), 'set minimum level of log messages that get logged: [DEBUG, INFO, WARN, ERROR, FATAL] (default: WARN)' do |level|
             level = 'WARN' if (level = level.upcase) == 'WARNING'
-            self[:log_level] = ::Logger::Severity.const_get level
+            self[:log_level] = Logger::Severity.const_get level
           end
           opts.on '--failure-level LEVEL', %w(info INFO warning WARNING error ERROR fatal FATAL), 'set minimum log level that yields a non-zero exit code: [INFO, WARN, ERROR, FATAL] (default: FATAL)' do |level|
             level = 'WARN' if (level = level.upcase) == 'WARNING'
-            self[:failure_level] = ::Logger::Severity.const_get level
+            self[:failure_level] = Logger::Severity.const_get level
           end
           opts.on '-q', '--quiet', 'silence application log messages and script warnings (default: false)' do
             self[:verbose] = 0

--- a/lib/asciidoctor/logging.rb
+++ b/lib/asciidoctor/logging.rb
@@ -1,28 +1,102 @@
 # frozen_string_literal: true
 
-proc do
-  old_verbose, $VERBOSE = $VERBOSE, nil
-  require 'logger' # suppress warning in Ruby 3.4 about loading logger from stdlib
-  $VERBOSE = old_verbose
-end.call
-
 module Asciidoctor
-class Logger < ::Logger
+class Logger
+  module Severity
+    DEBUG   = 0
+    INFO    = 1
+    WARN    = 2
+    ERROR   = 3
+    FATAL   = 4
+    UNKNOWN = 5
+  end
+
+  # Makes severity constants (DEBUG, WARN, etc.) directly accessible on the class, e.g. Logger::WARN
+  include Severity
+
+  # Index matches the Severity integer value; index 5 (UNKNOWN) maps to 'ANY' to match stdlib Logger output
+  SEVERITY_LABELS = %w(DEBUG INFO WARN ERROR FATAL ANY).freeze
+
+  attr_reader :level
+  attr_accessor :progname
+  attr_accessor :formatter
   attr_reader :max_severity
 
-  def initialize *args, **opts
-    opts[:progname] = 'asciidoctor'
-    opts[:formatter] = BasicFormatter.new unless opts.key? :formatter
-    opts[:level] = WARN unless opts.key? :level
-    args = [$stderr] if args.empty?
-    super
+  def initialize logdev = $stderr, *_, level: WARN, progname: 'asciidoctor', **opts
+    # *_ absorbs positional args from stdlib Logger's shift_age/shift_size (ignored, no log rotation)
+    @logdev = logdev && (::String === logdev ? (::File.open logdev, 'a') : logdev)
+    @logdev.sync = true if @logdev.respond_to? :sync=
+    @level = resolve_level level
+    @progname = progname
+    # formatter: nil is an explicit opt-in to the plain Formatter; absence of the key uses BasicFormatter
+    @formatter = opts.key?(:formatter) ? (opts[:formatter] || Formatter.new) : BasicFormatter.new
+  end
+
+  def level= value
+    @level = resolve_level value
   end
 
   def add severity, message = nil, progname = nil
+    # Initialize @max_severity lazily on first call; update only when severity increases
     if (severity ||= UNKNOWN) > (@max_severity ||= severity)
       @max_severity = severity
     end
-    super
+    return true if severity < @level || !@logdev
+    progname ||= @progname
+    if message.nil?
+      if block_given?
+        message = yield
+      else
+        message = progname
+        progname = @progname
+      end
+    end
+    @logdev.write (@formatter || Formatter.new).call(SEVERITY_LABELS[severity] || 'ANY', ::Time.now, progname, message)
+    true
+  end
+  alias log add
+
+  def close
+    @logdev&.close
+    @logdev = nil
+  end
+
+  # Generates debug/info/warn/error/fatal/unknown and their predicate variants (debug?, etc.)
+  # severity_val is captured in the closure so each method gets its own fixed integer
+  (Severity.constants false).sort_by {|c| Severity.const_get c }.each do |const|
+    method_name = const.to_s.downcase
+    severity_val = Severity.const_get const
+    define_method method_name do |message = nil, &block|
+      add severity_val, message, &block
+    end
+    define_method :"#{method_name}?" do
+      @level <= severity_val
+    end
+  end
+
+  # 'warning' accepted as an alias for 'warn' for compatibility with CLI input
+  LEVEL_COERCE = {
+    'debug' => DEBUG,
+    'info' => INFO,
+    'warn' => WARN,
+    'warning' => WARN,
+    'error' => ERROR,
+    'fatal' => FATAL,
+    'unknown' => UNKNOWN,
+  }.freeze
+
+  def resolve_level value
+    ::Integer === value ? value : (LEVEL_COERCE[value.to_s.downcase] || UNKNOWN)
+  end
+
+  class Formatter
+    def call severity, time, progname, msg
+      datetime = time.strftime '%Y-%m-%dT%H:%M:%S.%6N'
+      # $$ is the PID of the current process (see https://ruby-doc.org/3.4/globals_rdoc.html)
+      # ##{$$} produces a literal '#' followed by the interpolated PID, e.g. #12345
+      # Output: "D, [2026-06-08T12:00:00.000000 #12345] DEBUG -- asciidoctor: message\n"
+      %(#{severity[0]}, [#{datetime} ##{$$}] #{severity.rjust 5} -- #{progname}: #{::String === msg ? msg : msg.inspect}\n)
+    end
   end
 
   class BasicFormatter < Formatter
@@ -40,7 +114,8 @@ class Logger < ::Logger
   end
 end
 
-class MemoryLogger < ::Logger
+class MemoryLogger < Logger
+  # Reverse map: integer severity value → symbol name (e.g. 2 → :WARN), built once at class load time
   SEVERITY_SYMBOL_BY_VALUE = (Severity.constants false).map {|c| [(Severity.const_get c), c] }.to_h # rubocop:disable Style/MapToHash
 
   attr_reader :messages
@@ -69,9 +144,7 @@ class MemoryLogger < ::Logger
   end
 end
 
-class NullLogger < ::Logger
-  attr_reader :max_severity
-
+class NullLogger < Logger
   def initialize
     super nil, level: UNKNOWN
   end
@@ -103,8 +176,9 @@ module LoggerManager
     private
 
     def memoize_logger
+      # Redefine logger as a plain attr_reader so subsequent calls bypass the lazy-init branch
       class << self
-        alias logger logger # suppresses warning from CRuby
+        alias logger logger # suppresses redefinition warning from CRuby
         attr_reader :logger
       end
     end

--- a/test/blocks_test.rb
+++ b/test/blocks_test.rb
@@ -2295,7 +2295,7 @@ This is just an open block.
       bar
       --
       EOS
-      using_memory_logger Logger::Severity::DEBUG do |logger|
+      using_memory_logger Asciidoctor::Logger::Severity::DEBUG do |logger|
         convert_string_to_embedded input
         assert_message logger, :DEBUG, '<stdin>: line 2: unknown style for open block: foo', Hash
       end

--- a/test/extensions_test.rb
+++ b/test/extensions_test.rb
@@ -1158,7 +1158,7 @@ context 'Extensions' do
 
     test 'should log debug message if custom block macro is unknown' do
       input = 'unknown::[]'
-      using_memory_logger Logger::Severity::DEBUG do |logger|
+      using_memory_logger Asciidoctor::Logger::Severity::DEBUG do |logger|
         result = convert_string_to_embedded input
         assert_message logger, :DEBUG, '<stdin>: line 1: unknown name for block macro: unknown', Hash
         assert_xpath %(/*[@class="paragraph"]/p[text()="#{input}"]), result, 1
@@ -1171,7 +1171,7 @@ context 'Extensions' do
         Asciidoctor::Extensions.register do
           block_macro SampleBlockMacro, :sample
         end
-        using_memory_logger Logger::Severity::DEBUG do |logger|
+        using_memory_logger Asciidoctor::Logger::Severity::DEBUG do |logger|
           result = convert_string_to_embedded input
           assert_message logger, :DEBUG, '<stdin>: line 1: unknown name for block macro: unknown', Hash
           assert_xpath %(/*[@class="paragraph"]/p[text()="#{input}"]), result, 1
@@ -1187,7 +1187,7 @@ context 'Extensions' do
         Asciidoctor::Extensions.register do
           block_macro SampleBlockMacro, :sample
         end
-        using_memory_logger Logger::Severity::DEBUG do |logger|
+        using_memory_logger Asciidoctor::Logger::Severity::DEBUG do |logger|
           result = convert_string_to_embedded input
           assert_empty logger.messages
           assert_css 'ul li a[href="component::page.html"]', result, 1

--- a/test/logger_test.rb
+++ b/test/logger_test.rb
@@ -127,16 +127,121 @@ context 'Logger' do
       assert_includes err_string, %(asciidoctor: FAILED: it cannot be done)
     end
 
+    test 'should accept level as an integer' do
+      logger = Asciidoctor::Logger.new level: Asciidoctor::Logger::Severity::ERROR
+      assert_equal Asciidoctor::Logger::Severity::ERROR, logger.level
+    end
+
+    test 'should accept warning as an alias for warn when setting level' do
+      logger = Asciidoctor::Logger.new level: 'warning'
+      assert_equal Asciidoctor::Logger::Severity::WARN, logger.level
+    end
+
+    test 'should support severity predicate methods' do
+      logger = Asciidoctor::Logger.new level: Asciidoctor::Logger::Severity::WARN
+      refute logger.debug?
+      refute logger.info?
+      assert logger.warn?
+      assert logger.error?
+      assert logger.fatal?
+    end
+
+    test 'should evaluate block lazily when message is a block' do
+      evaluated = false
+      redirect_streams do
+        logger = Asciidoctor::Logger.new level: Asciidoctor::Logger::Severity::FATAL
+        logger.warn do
+          evaluated = true
+          'lazy message'
+        end
+      end
+      refute evaluated
+    end
+
+    test 'should write message returned by block' do
+      err_string = redirect_streams do |_, err|
+        logger = Asciidoctor::Logger.new
+        logger.warn { 'block message' }
+        err.string
+      end
+      assert_includes err_string, 'block message'
+    end
+
+    test 'log is an alias for add' do
+      err_string = redirect_streams do |_, err|
+        logger = Asciidoctor::Logger.new
+        logger.log Asciidoctor::Logger::Severity::WARN, 'via log alias'
+        err.string
+      end
+      assert_includes err_string, 'via log alias'
+    end
+
+    test 'should track max severity across calls' do
+      logger = Asciidoctor::Logger.new level: Asciidoctor::Logger::Severity::UNKNOWN
+      assert_nil logger.max_severity
+      logger.add Asciidoctor::Logger::Severity::WARN
+      assert_equal Asciidoctor::Logger::Severity::WARN, logger.max_severity
+      logger.add Asciidoctor::Logger::Severity::ERROR
+      assert_equal Asciidoctor::Logger::Severity::ERROR, logger.max_severity
+      logger.add Asciidoctor::Logger::Severity::INFO
+      assert_equal Asciidoctor::Logger::Severity::ERROR, logger.max_severity
+    end
+
     test 'NullLogger level is not nil' do
       logger = Asciidoctor::NullLogger.new
       refute_nil logger.level
       assert_equal Asciidoctor::Logger::UNKNOWN, logger.level
     end
 
+    test 'NullLogger tracks max severity without writing' do
+      logger = Asciidoctor::NullLogger.new
+      assert_nil logger.max_severity
+      logger.warn 'discarded'
+      assert_equal Asciidoctor::Logger::Severity::WARN, logger.max_severity
+      logger.error 'discarded'
+      assert_equal Asciidoctor::Logger::Severity::ERROR, logger.max_severity
+    end
+
     test 'MemoryLogger level is not nil' do
       logger = Asciidoctor::MemoryLogger.new
       refute_nil logger.level
       assert_equal Asciidoctor::Logger::UNKNOWN, logger.level
+    end
+
+    test 'MemoryLogger stores messages with their severity' do
+      logger = Asciidoctor::MemoryLogger.new
+      logger.warn 'first'
+      logger.error 'second'
+      assert_equal 2, logger.messages.size
+      assert_equal :WARN, logger.messages[0][:severity]
+      assert_equal :ERROR, logger.messages[1][:severity]
+    end
+
+    test 'MemoryLogger#add accepts a block for the message' do
+      logger = Asciidoctor::MemoryLogger.new
+      logger.add(Asciidoctor::Logger::Severity::WARN) { 'block message' }
+      assert_equal 'block message', logger.messages[0][:message]
+    end
+
+    test 'MemoryLogger#clear empties the message list' do
+      logger = Asciidoctor::MemoryLogger.new
+      logger.warn 'one'
+      refute_empty logger
+      logger.clear
+      assert_empty logger
+      assert_nil logger.max_severity
+    end
+
+    test 'MemoryLogger#max_severity returns nil when empty' do
+      assert_nil Asciidoctor::MemoryLogger.new.max_severity
+    end
+
+    test 'MemoryLogger#max_severity returns highest severity logged' do
+      logger = Asciidoctor::MemoryLogger.new
+      logger.warn 'w'
+      logger.error 'e'
+      logger.info 'i'
+      assert_equal Asciidoctor::Logger::Severity::ERROR, logger.max_severity
     end
   end
 

--- a/test/logger_test.rb
+++ b/test/logger_test.rb
@@ -3,13 +3,13 @@
 require_relative 'test_helper'
 
 context 'Logger' do
-  MyLogger = Class.new Logger
+  MyLogger = Class.new Asciidoctor::Logger
 
   context 'LoggerManager' do
     test 'provides access to logger via static logger method' do
       logger = Asciidoctor::LoggerManager.logger
       refute_nil logger
-      assert_kind_of Logger, logger
+      assert_kind_of Asciidoctor::Logger, logger
     end
 
     test 'allows logger instance to be changed' do
@@ -29,7 +29,7 @@ context 'Logger' do
         Asciidoctor::LoggerManager.logger = MyLogger.new $stdout
         Asciidoctor::LoggerManager.logger = nil
         refute_nil Asciidoctor::LoggerManager.logger
-        assert_kind_of Logger, Asciidoctor::LoggerManager.logger
+        assert_kind_of Asciidoctor::Logger, Asciidoctor::LoggerManager.logger
       ensure
         Asciidoctor::LoggerManager.logger = old_logger
       end
@@ -88,7 +88,7 @@ context 'Logger' do
       end
       assert_empty out_string
       assert_empty err_string
-      assert_equal Logger::Severity::FATAL, log_level
+      assert_equal Asciidoctor::Logger::Severity::FATAL, log_level
     end
 
     test 'should configure logger with progname set to asciidoctor' do
@@ -96,7 +96,7 @@ context 'Logger' do
     end
 
     test 'should configure logger with level set to WARN by default' do
-      assert_equal Logger::Severity::WARN, Asciidoctor::Logger.new.level
+      assert_equal Asciidoctor::Logger::Severity::WARN, Asciidoctor::Logger.new.level
     end
 
     test 'configures default logger with progname set to asciidoctor' do
@@ -104,7 +104,7 @@ context 'Logger' do
     end
 
     test 'configures default logger with level set to WARN' do
-      assert_equal Logger::Severity::WARN, Asciidoctor::LoggerManager.logger.level
+      assert_equal Asciidoctor::Logger::Severity::WARN, Asciidoctor::LoggerManager.logger.level
     end
 
     test 'configures default logger to write messages to $stderr' do
@@ -130,13 +130,13 @@ context 'Logger' do
     test 'NullLogger level is not nil' do
       logger = Asciidoctor::NullLogger.new
       refute_nil logger.level
-      assert_equal Logger::UNKNOWN, logger.level
+      assert_equal Asciidoctor::Logger::UNKNOWN, logger.level
     end
 
     test 'MemoryLogger level is not nil' do
       logger = Asciidoctor::MemoryLogger.new
       refute_nil logger.level
-      assert_equal Logger::UNKNOWN, logger.level
+      assert_equal Asciidoctor::Logger::UNKNOWN, logger.level
     end
   end
 

--- a/test/options_test.rb
+++ b/test/options_test.rb
@@ -247,27 +247,27 @@ context 'Options' do
 
   test 'should set failure level to FATAL by default' do
     options = Asciidoctor::Cli::Options.parse! %w(test/fixtures/sample.adoc)
-    assert_equal Logger::Severity::FATAL, options[:failure_level]
+    assert_equal Asciidoctor::Logger::Severity::FATAL, options[:failure_level]
   end
 
   test 'should allow failure level to be set to FATAL using any recognized abbreviation' do
     %w(f fatal FATAL).each do |val|
       options = Asciidoctor::Cli::Options.parse! %W(--failure-level=#{val} test/fixtures/sample.adoc)
-      assert_equal Logger::Severity::FATAL, options[:failure_level]
+      assert_equal Asciidoctor::Logger::Severity::FATAL, options[:failure_level]
     end
   end
 
   test 'should allow failure level to be set to ERROR using any recognized abbreviation' do
     %w(e err ERR error ERROR).each do |val|
       options = Asciidoctor::Cli::Options.parse! %W(--failure-level=#{val} test/fixtures/sample.adoc)
-      assert_equal Logger::Severity::ERROR, options[:failure_level]
+      assert_equal Asciidoctor::Logger::Severity::ERROR, options[:failure_level]
     end
   end
 
   test 'should allow failure level to be set to WARN using any recognized abbreviation' do
     %w(w warn WARN warning WARNING).each do |val|
       options = Asciidoctor::Cli::Options.parse! %W(--failure-level=#{val} test/fixtures/sample.adoc)
-      assert_equal Logger::Severity::WARN, options[:failure_level]
+      assert_equal Asciidoctor::Logger::Severity::WARN, options[:failure_level]
     end
   end
 
@@ -281,13 +281,13 @@ context 'Options' do
 
   test 'should set log level to DEBUG when --log-level option is specified' do
     options = Asciidoctor::Cli::Options.parse! %w(--log-level debug test/fixtures/sample.adoc)
-    assert_equal Logger::Severity::DEBUG, options[:log_level]
+    assert_equal Asciidoctor::Logger::Severity::DEBUG, options[:log_level]
   end
 
   test 'should allow log level to be set to WARN using any recognized abbreviation' do
     %w(w warn WARN warning WARNING).each do |val|
       options = Asciidoctor::Cli::Options.parse! %W(--log-level=#{val} test/fixtures/sample.adoc)
-      assert_equal Logger::Severity::WARN, options[:log_level]
+      assert_equal Asciidoctor::Logger::Severity::WARN, options[:log_level]
     end
   end
 

--- a/test/paragraphs_test.rb
+++ b/test/paragraphs_test.rb
@@ -621,7 +621,7 @@ context 'Paragraphs' do
       [foo]
       bar
       EOS
-      using_memory_logger Logger::Severity::DEBUG do |logger|
+      using_memory_logger Asciidoctor::Logger::Severity::DEBUG do |logger|
         convert_string_to_embedded input
         assert_message logger, :DEBUG, '<stdin>: line 2: unknown style for paragraph: foo', Hash
       end

--- a/test/reader_test.rb
+++ b/test/reader_test.rb
@@ -2053,7 +2053,7 @@ class ReaderTest < Minitest::Test
 
       test 'include is dropped if target contains missing attribute and attribute-missing is drop-line' do
         input = 'include::{foodir}/include-file.adoc[]'
-        using_memory_logger Logger::INFO do |logger|
+        using_memory_logger Asciidoctor::Logger::INFO do |logger|
           doc = empty_safe_document base_dir: DIRNAME, attributes: { 'attribute-missing' => 'drop-line' }
           reader = Asciidoctor::PreprocessorReader.new doc, input, nil, normalize: true
           line = reader.read_line

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -321,7 +321,7 @@ class Minitest::Test
 
   def in_verbose_mode
     begin
-      old_logger_level, Asciidoctor::LoggerManager.logger.level = Asciidoctor::LoggerManager.logger.level, Logger::Severity::DEBUG
+      old_logger_level, Asciidoctor::LoggerManager.logger.level = Asciidoctor::LoggerManager.logger.level, Asciidoctor::Logger::Severity::DEBUG
       yield
     ensure
       Asciidoctor::LoggerManager.logger.level = old_logger_level


### PR DESCRIPTION
Recent Ruby versions no longer bundle the `logger` gem in stdlib, which caused a deprecation warning in Ruby 3.4 and a missing dependency in Ruby 3.5+. Rather than adding `logger` as an explicit runtime dependency, this PR inlines a minimal implementation directly in `logging.rb`.
  
The new `Asciidoctor::Logger` is a self-contained class (no longer inheriting from `::Logger`) that covers exactly what the project uses: 
- severity constants,
- `debug`/`info`/`warn`/`error`/`fatal` methods and their predicate variants,
- a `BasicFormatter` for the traditional Asciidoctor output format,
- a `Formatter` for stdlib-compatible output,
- and `max_severity` tracking.

Log rotation and thread safety are intentionally omitted as the project has no use for them.
All references to `::Logger::Severity` in the CLI and test files have been updated accordingly.

*I used Claude Code (Claude Sonnet 4.6) to help write the implementation and the test updates, reviewed and adapted the output, and also asked it to identify and cover the areas of the logger that were not yet covered by tests.*

resolves #4684