### PR TITLE
resolves #3791 add support for data URI image targets

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -33,6 +33,7 @@ Enhancements::
   * Don't add empty line before block content if principal text of dlist item is not specified when converting to man page (#4182)
   * Add support for role on thematic break in HTML converter (#4101)
   * Add support for link=self on image macros (#3656)
+  * Support a `data:` URI as the target of a block or inline image; embed inline SVG (Base64 or percent-encoded) when the `inline` option is set and infer the SVG format from the `image/svg+xml` media type (#3791)
   * Alias Inline#content to Inline#text so Inline node quacks like other nodes (#3220)
   * Add support for skipping TOML front matter (Hugo) when `skip-front-matter` attribute is set (#4300) (*@abhinav*)
   * Add support for Wistia using the video macro
@@ -76,6 +77,7 @@ Improvements::
 Bug Fixes::
 
   * When skip-front-matter document attribute is set, only skip front matter in primary document, not included content (#3437)
+  * Don't attempt to read a `data:` URI image target as a file or remote URI when `data-uri` and `allow-uri-read` are set (avoids a spurious "could not retrieve image data from URI" warning) (#3791)
   * When normalizing toclevels, detect part even when book starts with special section (#4814)
   * Add parts at correct level in TOC even when book starts with special section (#2262)
 

--- a/lib/asciidoctor/abstract_node.rb
+++ b/lib/asciidoctor/abstract_node.rb
@@ -302,7 +302,8 @@ class AbstractNode
 
   # Public: Construct a URI reference or data URI to the target image.
   #
-  # If the target image is a URI reference, then leave it untouched.
+  # If the target image is a URI reference, then leave it untouched. If the target image is a data
+  # URI, then it is already an embedded image, so it is returned as-is.
   #
   # The target image is resolved relative to the directory retrieved from the
   # specified attribute key, if provided.
@@ -320,6 +321,8 @@ class AbstractNode
   #
   # Returns A String reference or data URI for the target image
   def image_uri target_image, asset_dir_key = 'imagesdir'
+    # A data URI is already an embedded image, so use it as-is rather than reading or re-encoding it.
+    return target_image if target_image.start_with? 'data:'
     if (doc = @document).safe < SafeMode::SECURE && (doc.attr? 'data-uri')
       if ((Helpers.uriish? target_image) && (target_image = Helpers.encode_spaces_in_uri target_image)) ||
           (asset_dir_key && (images_base = attr asset_dir_key, nil, true) && (Helpers.uriish? images_base) &&

--- a/lib/asciidoctor/converter/html5.rb
+++ b/lib/asciidoctor/converter/html5.rb
@@ -640,7 +640,7 @@ Your browser does not support the audio tag.
     target = node.attr 'target'
     width_attr = (node.attr? 'width') ? %( width="#{node.attr 'width'}") : ''
     height_attr = (node.attr? 'height') ? %( height="#{node.attr 'height'}") : ''
-    if ((node.attr? 'format', 'svg') || (target.include? '.svg')) && node.document.safe < SafeMode::SECURE
+    if ((node.attr? 'format', 'svg') || (target.include? '.svg') || (target.start_with? 'data:image/svg+xml')) && node.document.safe < SafeMode::SECURE
       if node.option? 'inline'
         img = (read_svg_contents node, target) || %(<span class="alt">#{node.alt}</span>)
       elsif node.option? 'interactive'
@@ -1239,7 +1239,7 @@ Your browser does not support the video tag.
       attrs = (node.attr? 'width') ? %( width="#{node.attr 'width'}") : ''
       attrs = %(#{attrs} height="#{node.attr 'height'}") if node.attr? 'height'
       attrs = %(#{attrs} title="#{node.attr 'title'}") if node.attr? 'title'
-      if ((node.attr? 'format', 'svg') || (target.include? '.svg')) && node.document.safe < SafeMode::SECURE
+      if ((node.attr? 'format', 'svg') || (target.include? '.svg') || (target.start_with? 'data:image/svg+xml')) && node.document.safe < SafeMode::SECURE
         if node.option? 'inline'
           img = (read_svg_contents node, target) || %(<span class="alt">#{node.alt}</span>)
         elsif node.option? 'interactive'
@@ -1314,7 +1314,12 @@ Your browser does not support the video tag.
 
   # NOTE expose read_svg_contents for Bespoke converter
   def read_svg_contents node, target
-    if (svg = node.read_contents target, start: (node.document.attr 'imagesdir'), normalize: true, label: 'SVG', warn_if_empty: true)
+    # A data URI carries the SVG in the target itself (e.g., an embedded diagram produced with the
+    # data-uri attribute set), so decode it directly rather than trying to read it as a file or URI.
+    svg = (target.start_with? 'data:') ?
+        (decode_data_uri target) :
+        (node.read_contents target, start: (node.document.attr 'imagesdir'), normalize: true, label: 'SVG', warn_if_empty: true)
+    if svg
       return if svg.empty?
       svg = svg.sub SvgPreambleRx, '' unless svg.start_with? '<svg'
       old_start_tag = new_start_tag = start_tag_match = nil
@@ -1334,6 +1339,24 @@ Your browser does not support the video tag.
   end
 
   private
+
+  # Internal: Decode the contents of an inline data URI (e.g., an SVG document) so an image whose
+  # target is a data URI can be embedded inline. Supports both Base64 (;base64) and percent-encoded
+  # payloads.
+  #
+  # target - the data URI String (i.e., a target that starts with data:)
+  #
+  # Returns the decoded contents as a String, or nil if the data URI has no payload.
+  def decode_data_uri target
+    return unless (comma = target.index ',')
+    data = target.slice comma + 1, target.length
+    if (target.slice 0, comma).downcase.end_with? ';base64'
+      # NOTE unpack1 'm' is equivalent to Base64.decode64
+      (data.unpack1 'm').force_encoding ::Encoding::UTF_8
+    else
+      Helpers.decode_uri_component data
+    end
+  end
 
   def append_boolean_attribute name, xml
     xml ? %( #{name}="#{name}") : %( #{name})

--- a/lib/asciidoctor/helpers.rb
+++ b/lib/asciidoctor/helpers.rb
@@ -176,6 +176,27 @@ module Helpers
     end
   end
 
+  # Internal: Decode a percent-encoded URI component String.
+  #
+  # str - the URI component String to decode
+  #
+  # Returns the String with all percent-encoded octets decoded (e.g., %20 becomes a space). Unlike
+  # CGI.unescape, a literal plus sign (+) is preserved rather than decoded to a space, which matches
+  # the behavior of the JavaScript decodeURIComponent function.
+  if RUBY_ENGINE == 'opal'
+    def decode_uri_component str
+      %x(return decodeURIComponent(str))
+    end
+  elsif ::CGI.respond_to? :unescapeURIComponent
+    def decode_uri_component str
+      ::CGI.unescapeURIComponent str
+    end
+  else
+    def decode_uri_component str
+      ::CGI.unescape (str.include? '+') ? (str.gsub '+', '%2B') : str
+    end
+  end
+
   # Internal: Apply URI path encoding to spaces in the specified string (i.e., convert spaces to %20).
   #
   # str - the String to encode

--- a/test/blocks_test.rb
+++ b/test/blocks_test.rb
@@ -2528,6 +2528,43 @@ This is just an open block.
       assert_match(/<svg\s[^>]*width="100">/, output, 1)
     end
 
+    test 'converts to inline SVG image when target is a Base64-encoded data URI' do
+      svg = '<svg xmlns="http://www.w3.org/2000/svg"><circle r="1"/></svg>'
+      data_uri = %(data:image/svg+xml;base64,#{[svg].pack 'm0'})
+      input = %(image::#{data_uri}[Circle,100,opts=inline])
+      output = convert_string_to_embedded input, safe: :safe
+      assert_match(/<svg\s[^>]*width="100"[^>]*>/, output, 1)
+      assert_includes output, '<circle r="1"/>'
+      refute_includes output, '<img'
+    end
+
+    test 'converts to inline SVG image when target is a percent-encoded data URI' do
+      svg = '<svg xmlns="http://www.w3.org/2000/svg"><circle r="1"/></svg>'
+      data_uri = %(data:image/svg+xml,#{Asciidoctor::Helpers.encode_uri_component svg})
+      input = %(image::#{data_uri}[Circle,100,opts=inline])
+      output = convert_string_to_embedded input, safe: :safe
+      assert_match(/<svg\s[^>]*width="100"[^>]*>/, output, 1)
+      assert_includes output, '<circle r="1"/>'
+      refute_includes output, '<img'
+    end
+
+    test 'infers SVG format from a data URI media type without an explicit format attribute' do
+      svg = '<svg xmlns="http://www.w3.org/2000/svg"><circle r="1"/></svg>'
+      data_uri = %(data:image/svg+xml;base64,#{[svg].pack 'm0'})
+      doc = document_from_string %(image::#{data_uri}[Circle,opts=inline]), safe: :safe
+      refute doc.blocks[0].attr? 'format'
+      output = doc.convert
+      assert_includes output, '<circle r="1"/>'
+    end
+
+    test 'passes a data URI image target through to the img src unchanged' do
+      data_uri = 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg=='
+      input = %(image::#{data_uri}[Dot])
+      output = convert_string_to_embedded input, safe: :safe, attributes: { 'data-uri' => '', 'allow-uri-read' => '' }
+      assert_css %(img[src="#{data_uri}"]), output, 1
+      assert_empty @logger.messages
+    end
+
     test 'should not throw exception if SVG to inline is empty' do
       input = 'image::empty.svg[nada,opts=inline]'
       output = convert_string_to_embedded input, safe: :safe, attributes: { 'docdir' => testdir, 'imagesdir' => 'fixtures' }

--- a/test/helpers_test.rb
+++ b/test/helpers_test.rb
@@ -16,6 +16,23 @@ context 'Helpers' do
       expect = given
       assert_equal expect, (Asciidoctor::Helpers.encode_uri_component given)
     end
+
+    test 'should URI decode percent-encoded octets' do
+      given = '%20%21%2A%2F%25%26%3F%5C%3D'
+      expect = ' !*/%&?\\='
+      assert_equal expect, (Asciidoctor::Helpers.decode_uri_component given)
+    end
+
+    test 'should not decode a literal plus sign to a space when URI decoding' do
+      given = 'a+b%20c'
+      expect = 'a+b c'
+      assert_equal expect, (Asciidoctor::Helpers.decode_uri_component given)
+    end
+
+    test 'should round trip a string through URI encode and decode' do
+      given = ' !*/%&?\\=+'
+      assert_equal given, (Asciidoctor::Helpers.decode_uri_component Asciidoctor::Helpers.encode_uri_component given)
+    end
   end
 
   context 'URIs and Paths' do


### PR DESCRIPTION
Toolchains that produce embedded diagrams (e.g., when `data-uri` is set, or extensions that emit a data-URI target) end up with the image carried in the target itself. Raster images already worked because they pass straight through to `<img src>`, but an SVG that needs to be embedded inline went through `read_contents`, which only understands local files and remote `http(s)` URIs, so it always degraded to alt text. This rounds out `data:` URI support for image targets.


Add support for a `data:` URI as the target of an image:

1. **Inline SVG embedding** — when the `inline` option is set, the SVG carried in the target is decoded and emitted as inline `<svg>` instead of falling back to the alt text. Both Base64 (`data:image/svg+xml;base64,...`) and percent-encoded (`data:image/svg+xml,...`) payloads are supported.
2. **Format inference** — the SVG format is inferred from the `image/svg+xml` media type, so `format=svg` is no longer required on a `data:` URI target.
3. **Pass-through without a spurious warning** — a non-SVG `data:` URI target (e.g., `data:image/png;base64,...`) is passed through unchanged to the `<img src>`; previously, with `data-uri` and `allow-uri-read` both set, Asciidoctor would attempt to fetch the `data:` URI via OpenURI and log a "could not retrieve image data from URI" warning.


#### Example

```asciidoc
image::data:image/svg+xml;base64,PHN2ZyB4bWxucz0i...[Diagram,opts=inline]
```

renders the `<svg>…</svg>` inline instead of an `<img>` fallback.

#### Implementation details

- **Inline SVG decoding** — `Html5Converter#read_svg_contents` branches on `target.start_with? 'data:'` and decodes the payload via a new private `decode_data_uri` helper instead of calling `read_contents`. `decode_data_uri` decodes Base64 with `unpack1 'm'` (the decode counterpart of the `pack 'm0'` already used by `generate_data_uri`, so no dependency on the `base64` gem) and forces UTF-8 on the result; percent-encoded payloads go through a new `Helpers.decode_uri_component`.
- **`Helpers.decode_uri_component`** — added as the counterpart to `encode_uri_component`, with the same `RUBY_ENGINE == 'opal'` / `CGI.unescapeURIComponent` / fallback structure. The fallback preserves a literal `+` rather than turning it into a space, matching JavaScript's `decodeURIComponent` (and `encodeURIComponent` round-trips through it).
- **Format inference** — the SVG-detection condition in `convert_image` and `convert_inline_image` also matches a target that starts with `data:image/svg+xml`.
- **Pass-through guard** — `AbstractNode#image_uri` returns a `data:` URI target as-is up front, so it is never read as a file nor fetched via OpenURI.

#### Security

Decoding a `data:` URI reads neither the filesystem nor the network — the bytes are already part of the document — so it does not bypass the safe-mode guarantees that `read_contents` / `normalize_system_path` enforce for local files. The tests run under `safe: :safe`.

#### Tests

- `test/blocks_test.rb`:
  - inline SVG from a Base64 data URI and from a percent-encoded data URI (asserts the `<svg>` is embedded with the expected width and no `<img>` fallback);
  - SVG format is inferred from the media type without an explicit `format` attribute;
  - a `data:image/png` target is passed through to `<img src>` unchanged and logs no warning even with `data-uri` + `allow-uri-read`.
- `test/helpers_test.rb`: `decode_uri_component` decodes percent-encoded octets, preserves a literal `+`, and round-trips with `encode_uri_component`.

Resolves #3791 