### PR TITLE
resolves #4870 support link attribute on block image when converting to DocBook

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -33,6 +33,7 @@ Enhancements::
   * Don't add empty line before block content if principal text of dlist item is not specified when converting to man page (#4182)
   * Add support for role on thematic break in HTML converter (#4101)
   * Add support for link=self on image macros (#3656)
+  * Add support for the link attribute on block image macro when converting to DocBook (#4870) (*@youdie006*)
   * Alias Inline#content to Inline#text so Inline node quacks like other nodes (#3220)
   * Add support for skipping TOML front matter (Hugo) when `skip-front-matter` attribute is set (#4300) (*@abhinav*)
   * Add support for Wistia using the video macro

--- a/lib/asciidoctor/converter/docbook5.rb
+++ b/lib/asciidoctor/converter/docbook5.rb
@@ -199,10 +199,14 @@ class Converter::DocBook5Converter < Converter::Base
 
     mediaobject = %(<mediaobject>
 <imageobject>
-<imagedata fileref="#{node.image_uri node.attr 'target'}"#{image_size_attributes node.attributes}#{align_attribute}/>
+<imagedata fileref="#{fileref = node.image_uri node.attr 'target'}"#{image_size_attributes node.attributes}#{align_attribute}/>
 </imageobject>
 <textobject><phrase>#{node.alt}</phrase></textobject>
 </mediaobject>)
+
+    if (node.attr? 'link') && (link_href = node.attr 'link')
+      mediaobject = %(<link xl:href="#{link_href == 'self' ? fileref : link_href}">#{mediaobject}</link>)
+    end
 
     if node.title?
       %(<figure#{common_attributes node.id, node.role, node.reftext}>

--- a/test/blocks_test.rb
+++ b/test/blocks_test.rb
@@ -2806,6 +2806,22 @@ This is just an open block.
       assert_xpath '//imagedata[@align="right"]', output, 1
     end
 
+    test 'can convert block image with link in DocBook backend' do
+      input = 'image::images/tiger.png[Tiger, link="http://en.wikipedia.org/wiki/Tiger"]'
+      output = convert_string_to_embedded input, backend: :docbook
+      assert_match '<link xl:href="http://en.wikipedia.org/wiki/Tiger"><mediaobject>', output
+    end
+
+    test 'can convert block image with link to self in DocBook backend' do
+      input = <<~'EOS'
+      :imagesdir: img
+
+      image::tiger.png[Tiger, link=self]
+      EOS
+      output = convert_string_to_embedded input, backend: :docbook
+      assert_match '<link xl:href="img/tiger.png"><mediaobject>', output
+    end
+
     test 'should set content width and depth in DocBook backend if no scaling' do
       input = 'image::images/sunset.jpg[Sunset,500,332]'
       output = convert_string_to_embedded input, backend: :docbook


### PR DESCRIPTION
Resolves #4870.

### Problem

The DocBook 5 converter honors the image `link` attribute only for *inline* images. `convert_inline_image` wraps the `<inlinemediaobject>` in a `<link xl:href="...">` (added in #4385 / #4779), but `convert_image` (block images) has no equivalent, so:

```
image::tiger.png[Tiger, link="http://example.com/"]
```

produced a bare `<mediaobject>` with no link, while the HTML converter wraps the block image in an anchor. DocBook output therefore lacked parity with HTML, as noted in the issue.

### Fix

Wrap the block image's `<mediaobject>` in `<link xl:href="...">` when the image declares a `link` attribute, directly mirroring the existing inline behavior in `convert_inline_image` (same `link=self` -> `fileref` resolution). The link wraps only the `<mediaobject>`, leaving the figure title/caption outside, matching how the inline case wraps only the media node.

Output for the example above:

```xml
<informalfigure>
<link xl:href="http://example.com/"><mediaobject>
<imageobject>
<imagedata fileref="tiger.png"/>
</imageobject>
<textobject><phrase>Tiger</phrase></textobject>
</mediaobject></link>
</informalfigure>
```

### Tests

Added two tests in `test/blocks_test.rb` (DocBook backend): a block image with an explicit `link`, and one with `link=self` (resolving to the image `fileref`). Red-green verified: both fail on master (bare `<mediaobject>`, no `<link>`) and pass with the fix; the existing block-image DocBook tests still pass. `CHANGELOG.adoc` updated.

I picked the placement (wrapping the `<mediaobject>`) to match the merged inline-image precedent; happy to adjust the structure (for example wrapping the whole `<figure>`, or a different element) if you prefer a different mapping for block images.

---
Disclosure: I used AI assistance (Claude) while preparing this change. I verified the fix, ran the tests, and take responsibility for the contribution.
